### PR TITLE
Remove `jaxb2-basics-annotate` and `jaxb-delegate-plugin` plugins

### DIFF
--- a/kbl/kbl-v24/pom.xml
+++ b/kbl/kbl-v24/pom.xml
@@ -100,8 +100,6 @@
                             </bindingIncludes>
                             <extension>true</extension>
                             <args>
-                                <arg>-Xannotate</arg>
-                                <arg>-Xdelegate</arg>
                                 <arg>-Xext-navs</arg>
                                 <arg>-Xjavadoc</arg>
                                 <arg>-Xinheritance</arg>

--- a/kbl/kbl-v25/pom.xml
+++ b/kbl/kbl-v25/pom.xml
@@ -100,8 +100,6 @@
                             </bindingIncludes>
                             <extension>true</extension>
                             <args>
-                                <arg>-Xannotate</arg>
-                                <arg>-Xdelegate</arg>
                                 <arg>-Xext-navs</arg>
                                 <arg>-Xjavadoc</arg>
                                 <arg>-Xinheritance</arg>

--- a/pom.xml
+++ b/pom.xml
@@ -44,8 +44,6 @@
         <!-- maven-jaxb2-plugin plugins -->
         <jaxb-visitor.version>2.8</jaxb-visitor.version>
         <cxf-xjc-javadoc.version>3.3.1</cxf-xjc-javadoc.version>
-        <jaxb-delegate-plugin.version>2.4.0</jaxb-delegate-plugin.version>
-        <jaxb2-basics-annotate.version>1.1.0</jaxb2-basics-annotate.version>
 
         <!-- Release Plugins -->
         <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
@@ -406,19 +404,9 @@
                                 <version>${jaxb2-basics.version}</version>
                             </plugin>
                             <plugin>
-                                <groupId>org.jvnet.jaxb2_commons</groupId>
-                                <artifactId>jaxb2-basics-annotate</artifactId>
-                                <version>${jaxb2-basics-annotate.version}</version>
-                            </plugin>
-                            <plugin>
                                 <groupId>org.apache.cxf.xjcplugins</groupId>
                                 <artifactId>cxf-xjc-javadoc</artifactId>
                                 <version>${cxf-xjc-javadoc.version}</version>
-                            </plugin>
-                            <plugin>
-                                <groupId>net.codesup.util</groupId>
-                                <artifactId>jaxb-delegate-plugin</artifactId>
-                                <version>${jaxb-delegate-plugin.version}</version>
                             </plugin>
                             <plugin>
                                 <groupId>com.massfords</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -113,11 +113,6 @@
         <dependencies>
             <!-- JAXB -->
             <dependency>
-                <groupId>org.jvnet.jaxb2_commons</groupId>
-                <artifactId>jaxb2-basics</artifactId>
-                <version>${jaxb2_commons.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>jakarta.xml.bind</groupId>
                 <artifactId>jakarta.xml.bind-api</artifactId>
                 <version>${jaxb-api.version}</version>

--- a/vec/vec-v113/pom.xml
+++ b/vec/vec-v113/pom.xml
@@ -99,8 +99,6 @@
                                 <include>vec113/*.xjb</include>
                             </bindingIncludes>
                             <args>
-                                <arg>-Xannotate</arg>
-                                <arg>-Xdelegate</arg>
                                 <arg>-Xext-navs</arg>
                                 <arg>-Xjavadoc</arg>
                                 <arg>-Xinheritance</arg>

--- a/vec/vec-v12x/pom.xml
+++ b/vec/vec-v12x/pom.xml
@@ -99,8 +99,6 @@
                                 <include>vec122/*.xjb</include>
                             </bindingIncludes>
                             <args>
-                                <arg>-Xannotate</arg>
-                                <arg>-Xdelegate</arg>
                                 <arg>-Xext-navs</arg>
                                 <arg>-Xjavadoc</arg>
                                 <arg>-Xinheritance</arg>

--- a/vec/vec-v2x/pom.xml
+++ b/vec/vec-v2x/pom.xml
@@ -99,8 +99,6 @@
                                 <include>vec2/*.xjb</include>
                             </bindingIncludes>
                             <args>
-                                <arg>-Xannotate</arg>
-                                <arg>-Xdelegate</arg>
                                 <arg>-Xext-navs</arg>
                                 <arg>-Xjavadoc</arg>
                                 <arg>-Xinheritance</arg>


### PR DESCRIPTION
## Pull Request

- [x] I have checked for similar PRs.
- [x] I have read the [contributing guidelines](https://github.com/4Soft-de/harness-model/blob/develop/.github/CONTRIBUTING.md).

### Changes

- [ ] Code
- [ ] Documentation
- [x] Other: POM.xml

### Description

Removed `jaxb2-basics-annotate` and `jaxb-delegate-plugin` plugins since they seem to be unneeded. This is done as a preparation for JAXB4.