### PR TITLE
Updated Version constant, overlooked during update to VEC 2.1

### DIFF
--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/Version.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/Version.java
@@ -26,7 +26,7 @@
 package com.foursoft.harness.vec.v2x;
 
 public final class Version {
-    public static final String VERSION = "2.0.2";
+    public static final String VERSION = "2.1.0";
 
     private Version() {
     }


### PR DESCRIPTION
## Pull Request

- [X] I have checked for similar PRs.
- [X] I have read the [contributing guidelines](https://github.com/4Soft-de/harness-model/blob/develop/.github/CONTRIBUTING.md).

### Changes

- [X] Code
- [ ] Documentation
- [ ] Other: 


### Description

Updated Version constant, overlooked during update to VEC 2.1