### PR TITLE
Validate that License Headers are present during the CI build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -505,5 +505,40 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>ci-environment</id>
+            <activation>
+                <property>
+                    <name>env.CI</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <!-- Check if all headers are present and up-to-date. -->
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>license-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>check-file-header</id>
+                                <goals>
+                                    <goal>check-file-header</goal>
+                                </goals>
+                                <phase>validate</phase>
+                                <configuration>
+                                    <licenseName>mit</licenseName>
+                                    <roots>
+                                        <root>src/main/java</root>
+                                        <root>src/test/java</root>
+                                    </roots>
+                                    <failOnMissingHeader>true</failOnMissingHeader>
+                                    <failOnNotUptodateHeader>true</failOnNotUptodateHeader>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
## Pull Request

- [x] I have checked for similar PRs.
- [x] I have read the [contributing guidelines](https://github.com/4Soft-de/harness-model/blob/develop/.github/CONTRIBUTING.md).

### Changes

- [ ] Code
- [ ] Documentation
- [x] Other: CI Build Configuration

### Description

In a previous PR it was forgotten to add the License Headers which lead to #303 and #307.

This PR configures the Maven Build to validate the License Headers. This is done only during a CI build since during development, the build should simply add them instead of erroring out.