### PR TITLE
Some optimizations in Scripting APIs Identification generation

### DIFF
--- a/vec/vec-scripting/src/main/java/com/foursoft/harness/vec/scripting/VecSession.java
+++ b/vec/vec-scripting/src/main/java/com/foursoft/harness/vec/scripting/VecSession.java
@@ -77,6 +77,7 @@ public class VecSession {
     private VecSIUnit ohm;
     private VecSIUnit ampere;
     private VecSIUnit volts;
+    private VecSIUnit gram;
 
     public VecSession() {
         xmlMeta.setComments(comments);
@@ -307,14 +308,19 @@ public class VecSession {
         return this.ampere;
     }
 
+    public VecSIUnit gram() {
+        if (this.gram == null) {
+            this.gram = SiUnitFactory.gram();
+            this.vecContentRoot.getUnits().add(gram);
+        }
+        return gram;
+    }
+
     public VecUnit gramPerMeter() {
         if (this.gramPerMeter == null) {
-            final VecSIUnit gram = SiUnitFactory.gram();
             this.gramPerMeter = new VecCompositeUnit();
-            this.gramPerMeter.getFactors().add(gram);
+            this.gramPerMeter.getFactors().add(this.gram());
             this.gramPerMeter.getFactors().add(perMetre());
-
-            this.vecContentRoot.getUnits().add(gram);
             this.vecContentRoot.getUnits().add(this.gramPerMeter);
         }
         return this.gramPerMeter;

--- a/vec/vec-scripting/src/main/java/com/foursoft/harness/vec/scripting/VecSession.java
+++ b/vec/vec-scripting/src/main/java/com/foursoft/harness/vec/scripting/VecSession.java
@@ -103,7 +103,7 @@ public class VecSession {
 
     public void part(final String partNumber, final VecPrimaryPartType primaryPartType,
                      final Customizer<PartVersionBuilder> customizer) {
-        final PartVersionBuilder builder = new PartVersionBuilder(this, partNumber, primaryPartType);
+        final PartVersionBuilder builder = new PartVersionBuilder(this, partNumber, "1", primaryPartType);
 
         customizer.customize(builder);
 
@@ -115,7 +115,15 @@ public class VecSession {
     public void component(final String partNumber, final String documentNumber,
                           final VecPrimaryPartType primaryPartType,
                           final Customizer<ComponentMasterDataBuilder> customizer) {
-        final ComponentMasterDataBuilder builder = new ComponentMasterDataBuilder(this, partNumber, documentNumber,
+        this.component(partNumber, "1", documentNumber, "1", primaryPartType, customizer);
+    }
+
+    public void component(final String partNumber, final String partVersion, final String documentNumber,
+                          final String documentVersion,
+                          final VecPrimaryPartType primaryPartType,
+                          final Customizer<ComponentMasterDataBuilder> customizer) {
+        final ComponentMasterDataBuilder builder = new ComponentMasterDataBuilder(this, partNumber, partVersion,
+                                                                                  documentNumber, documentVersion,
                                                                                   primaryPartType);
         customizer.customize(builder);
 

--- a/vec/vec-scripting/src/main/java/com/foursoft/harness/vec/scripting/components/ComponentMasterDataBuilder.java
+++ b/vec/vec-scripting/src/main/java/com/foursoft/harness/vec/scripting/components/ComponentMasterDataBuilder.java
@@ -58,12 +58,13 @@ public class ComponentMasterDataBuilder implements Builder<ComponentMasterDataBu
     private ConnectionSpecificationQueries internalSchematicQuery;
 
     public ComponentMasterDataBuilder(final VecSession session,
-                                      final String partNumber, final String documentNumber,
+                                      final String partNumber, final String partVersion, final String documentNumber,
+                                      final String documentVersion,
                                       final VecPrimaryPartType primaryPartType) {
         this.session = session;
         this.partNumber = partNumber;
-        this.part = new PartVersionBuilder(session, partNumber, primaryPartType).build();
-        this.partMasterDocument = initializeDocument(documentNumber);
+        this.part = new PartVersionBuilder(session, partNumber, partVersion, primaryPartType).build();
+        this.partMasterDocument = initializeDocument(documentNumber, documentVersion);
     }
 
     @Override
@@ -74,8 +75,9 @@ public class ComponentMasterDataBuilder implements Builder<ComponentMasterDataBu
         return new PartDocumentsPair(part, documents);
     }
 
-    private DocumentVersionBuilder initializeDocument(final String documentNumber) {
-        return new DocumentVersionBuilder(session, documentNumber, "1").documentType(DocumentType.PART_MASTER)
+    private DocumentVersionBuilder initializeDocument(final String documentNumber, final String documentVersion) {
+        return new DocumentVersionBuilder(session, documentNumber, documentVersion).documentType(
+                        DocumentType.PART_MASTER)
                 .addReferencedPart(
                         this.part);
     }

--- a/vec/vec-scripting/src/main/java/com/foursoft/harness/vec/scripting/components/ConnectorSpecificationBuilder.java
+++ b/vec/vec-scripting/src/main/java/com/foursoft/harness/vec/scripting/components/ConnectorSpecificationBuilder.java
@@ -46,6 +46,11 @@ public class ConnectorSpecificationBuilder
         connectorHousingSpecification = initializeSpecification(VecConnectorHousingSpecification.class, partNumber);
     }
 
+    public ConnectorSpecificationBuilder withIdentification(final String identification) {
+        connectorHousingSpecification.setIdentification(identification);
+        return this;
+    }
+
     public ConnectorSpecificationBuilder withCoding(final String coding) {
         final VecCoding codingObject = new VecCoding();
         codingObject.setCoding(coding);
@@ -69,7 +74,8 @@ public class ConnectorSpecificationBuilder
         return this;
     }
 
-    @Override public VecConnectorHousingSpecification build() {
+    @Override
+    public VecConnectorHousingSpecification build() {
         return connectorHousingSpecification;
     }
 

--- a/vec/vec-scripting/src/main/java/com/foursoft/harness/vec/scripting/core/PartVersionBuilder.java
+++ b/vec/vec-scripting/src/main/java/com/foursoft/harness/vec/scripting/core/PartVersionBuilder.java
@@ -36,12 +36,13 @@ public class PartVersionBuilder implements Builder<VecPartVersion> {
     private final VecPartVersion part;
     private final VecSession session;
 
-    public PartVersionBuilder(final VecSession session, final String partNumber, final VecPrimaryPartType primaryPartType) {
+    public PartVersionBuilder(final VecSession session, final String partNumber, final String partVersion,
+                              final VecPrimaryPartType primaryPartType) {
         this.session = session;
         part = new VecPartVersion();
 
         part.setCompanyName(this.session.getDefaultValues().getCompanyName());
-        part.setPartVersion("1");
+        part.setPartVersion(partVersion);
         part.setPartNumber(partNumber);
         part.setPrimaryPartType(primaryPartType);
     }
@@ -51,7 +52,8 @@ public class PartVersionBuilder implements Builder<VecPartVersion> {
         return this;
     }
 
-    @Override public VecPartVersion build() {
+    @Override
+    public VecPartVersion build() {
         return part;
     }
 }

--- a/vec/vec-scripting/src/main/java/com/foursoft/harness/vec/scripting/harness/VariantBuilder.java
+++ b/vec/vec-scripting/src/main/java/com/foursoft/harness/vec/scripting/harness/VariantBuilder.java
@@ -40,19 +40,17 @@ public class VariantBuilder implements Builder<VariantBuilder.VariantResult> {
     private final Function<String[], List<VecPartOccurrence>> occurrencesLookup;
     private VecVariantConfiguration variantConfiguration;
 
-    ;
-
     private final VecPartVersion partVersion;
     private final VecPartStructureSpecification partStructureSpecification;
     private final VecPartOccurrence moduleOccurrence;
     private VecPartWithSubComponentsRole partWithSubComponentsRole;
 
-    public VariantBuilder(VecSession session,
-                          String partNumber,
-                          Function<String[], List<VecPartOccurrence>> occurrencesLookup
+    public VariantBuilder(final VecSession session,
+                          final String partNumber,
+                          final Function<String[], List<VecPartOccurrence>> occurrencesLookup
     ) {
         this.occurrencesLookup = occurrencesLookup;
-        this.partVersion = new PartVersionBuilder(session, partNumber, VecPrimaryPartType.PART_STRUCTURE).build();
+        this.partVersion = new PartVersionBuilder(session, partNumber, "1", VecPrimaryPartType.PART_STRUCTURE).build();
 
         this.partStructureSpecification = initializePartStructure(this.partVersion);
         this.moduleOccurrence = initializeModuleOccurrence(partNumber);
@@ -63,13 +61,13 @@ public class VariantBuilder implements Builder<VariantBuilder.VariantResult> {
         return new VariantResult(partVersion, moduleOccurrence, partStructureSpecification, variantConfiguration);
     }
 
-    public VariantBuilder withAbbreviation(String text) {
+    public VariantBuilder withAbbreviation(final String text) {
         this.partVersion.getAbbreviations().add(de(text));
         return this;
     }
 
-    public VariantBuilder withOccurrences(String... occurrences) {
-        List<VecPartOccurrence> result = this.occurrencesLookup.apply(occurrences);
+    public VariantBuilder withOccurrences(final String... occurrences) {
+        final List<VecPartOccurrence> result = this.occurrencesLookup.apply(occurrences);
         this.partStructureSpecification.getInBillOfMaterial().addAll(result);
         this.partWithSubComponentsRole.getSubComponent().addAll(result);
         return this;
@@ -80,7 +78,7 @@ public class VariantBuilder implements Builder<VariantBuilder.VariantResult> {
         variantConfiguration.setIdentification("Config@" + this.partVersion.getPartNumber());
         variantConfiguration.setLogisticControlString(configuration);
 
-        VecConfigurationConstraint constraint = new VecConfigurationConstraint();
+        final VecConfigurationConstraint constraint = new VecConfigurationConstraint();
         constraint.setIdentification("Config@" + this.partVersion.getPartNumber());
         constraint.setConfigInfo(variantConfiguration);
 
@@ -89,8 +87,8 @@ public class VariantBuilder implements Builder<VariantBuilder.VariantResult> {
         return this;
     }
 
-    private VecPartOccurrence initializeModuleOccurrence(String partNumber) {
-        VecPartOccurrence result = new VecPartOccurrence();
+    private VecPartOccurrence initializeModuleOccurrence(final String partNumber) {
+        final VecPartOccurrence result = new VecPartOccurrence();
         result.setIdentification(partNumber);
         result.setPart(partVersion);
 
@@ -103,7 +101,7 @@ public class VariantBuilder implements Builder<VariantBuilder.VariantResult> {
         return result;
     }
 
-    private VecPartStructureSpecification initializePartStructure(VecPartVersion partVersion) {
+    private VecPartStructureSpecification initializePartStructure(final VecPartVersion partVersion) {
         final VecPartStructureSpecification ps = new VecPartStructureSpecification();
         ps.setIdentification("STRUCTURE_" + partVersion.getPartNumber());
         ps.getDescribedPart().add(partVersion);


### PR DESCRIPTION
## Pull Request

- [X] I have checked for similar PRs.
- [X] I have read the [contributing guidelines](https://github.com/4Soft-de/harness-model/blob/develop/.github/CONTRIBUTING.md).

### Changes

- [X] Code
- [ ] Documentation
- [ ] Other: 

### Description

This pull request introduces several enhancements and refactorings to the VEC scripting API, focusing on improved handling of part and document versions, unit management, and builder extensibility. The main changes ensure better version control for parts and documents, add convenience methods for SI units, and improve code clarity and extensibility in builder classes.

**Versioning Improvements:**
- The constructors and methods across `VecSession`, `PartVersionBuilder`, and `ComponentMasterDataBuilder` have been updated to explicitly handle part and document versions, allowing for more flexible and accurate version management. [[1]](diffhunk://#diff-7f177a119951b23267bba1c17249cec633d27b64a2c6f3f7569445cb47ff53e6L106-R107) [[2]](diffhunk://#diff-fade73e4f65f0ce3856687bb9ff5b001ebe999617b25ee762720efd7f75baa8aL61-R67) [[3]](diffhunk://#diff-ce7a09a7b08ff327a4b60e255e064b6946c795777539454940109743e37393e1L39-R45)

**SI Unit Management:**
- Added a cached `gram` SI unit to `VecSession`, with a new `gram()` method to ensure consistent and efficient unit creation and registration. The `gramPerMeter()` method now uses this cached unit. [[1]](diffhunk://#diff-7f177a119951b23267bba1c17249cec633d27b64a2c6f3f7569445cb47ff53e6R80) [[2]](diffhunk://#diff-7f177a119951b23267bba1c17249cec633d27b64a2c6f3f7569445cb47ff53e6R311-L309)

**Builder API Enhancements:**
- The `ConnectorSpecificationBuilder` now includes a `withIdentification` method for setting connector identification, improving the builder's fluency.
- Minor formatting and method signature improvements were made to various builder classes for consistency and clarity, such as parameter finalization and method reformatting. [[1]](diffhunk://#diff-b196eb5979c46a10d8dbe40d75c02f72ddfd01289efb2bdb39650b11c80657a4L72-R78) [[2]](diffhunk://#diff-ce7a09a7b08ff327a4b60e255e064b6946c795777539454940109743e37393e1L54-R56) [[3]](diffhunk://#diff-a466a12bb5b825c23fce81283134e58565a62dc9c6b504eaa6bd64ac7caa9a28L66-R70) [[4]](diffhunk://#diff-a466a12bb5b825c23fce81283134e58565a62dc9c6b504eaa6bd64ac7caa9a28L83-R81) [[5]](diffhunk://#diff-a466a12bb5b825c23fce81283134e58565a62dc9c6b504eaa6bd64ac7caa9a28L92-R91) [[6]](diffhunk://#diff-a466a12bb5b825c23fce81283134e58565a62dc9c6b504eaa6bd64ac7caa9a28L106-R104)

**Detailed Changes:**

*Versioning and Builder Refactoring*
- `VecSession`, `PartVersionBuilder`, and `ComponentMasterDataBuilder` now require explicit part and document version parameters, improving version tracking and flexibility throughout the API. [[1]](diffhunk://#diff-7f177a119951b23267bba1c17249cec633d27b64a2c6f3f7569445cb47ff53e6L106-R107) [[2]](diffhunk://#diff-fade73e4f65f0ce3856687bb9ff5b001ebe999617b25ee762720efd7f75baa8aL61-R67) [[3]](diffhunk://#diff-ce7a09a7b08ff327a4b60e255e064b6946c795777539454940109743e37393e1L39-R45)
- `VariantBuilder` and related methods updated to use the new versioned `PartVersionBuilder` constructor, ensuring variant parts are versioned correctly.

*SI Unit Handling*
- Introduced a cached `gram` SI unit in `VecSession`, with a new `gram()` accessor and updated `gramPerMeter()` to use this cached instance, preventing duplicate unit creation and ensuring units are registered only once. [[1]](diffhunk://#diff-7f177a119951b23267bba1c17249cec633d27b64a2c6f3f7569445cb47ff53e6R80) [[2]](diffhunk://#diff-7f177a119951b23267bba1c17249cec633d27b64a2c6f3f7569445cb47ff53e6R311-L309)

*Builder API Improvements*
- Added `withIdentification` to `ConnectorSpecificationBuilder` for setting identification directly on the connector housing specification.
- Improved method signatures and formatting across builder classes for better code readability and maintainability. [[1]](diffhunk://#diff-b196eb5979c46a10d8dbe40d75c02f72ddfd01289efb2bdb39650b11c80657a4L72-R78) [[2]](diffhunk://#diff-ce7a09a7b08ff327a4b60e255e064b6946c795777539454940109743e37393e1L54-R56) [[3]](diffhunk://#diff-a466a12bb5b825c23fce81283134e58565a62dc9c6b504eaa6bd64ac7caa9a28L66-R70) [[4]](diffhunk://#diff-a466a12bb5b825c23fce81283134e58565a62dc9c6b504eaa6bd64ac7caa9a28L83-R81) [[5]](diffhunk://#diff-a466a12bb5b825c23fce81283134e58565a62dc9c6b504eaa6bd64ac7caa9a28L92-R91) [[6]](diffhunk://#diff-a466a12bb5b825c23fce81283134e58565a62dc9c6b504eaa6bd64ac7caa9a28L106-R104)