### PR TITLE
compat: less boilerplate for pure API additions in wrapper proxies.

### DIFF
--- a/compatibility/compatibility-core/src/main/java/com/foursoft/harness/compatibility/core/wrapper/ReflectionBasedWrapper.java
+++ b/compatibility/compatibility-core/src/main/java/com/foursoft/harness/compatibility/core/wrapper/ReflectionBasedWrapper.java
@@ -109,7 +109,7 @@ public class ReflectionBasedWrapper implements InvocationHandler, CompatibilityW
      * @param propertyName Property name in camelCase (e.g. {@code "myProperty"}).
      */
     protected void registerValueProperty(final String propertyName) {
-        final String capitalised = Character.toUpperCase(propertyName.charAt(0)) + propertyName.substring(1);
+        final String capitalised = capitalize(propertyName);
         registerValueProperty("get" + capitalised, "set" + capitalised);
     }
 
@@ -131,8 +131,7 @@ public class ReflectionBasedWrapper implements InvocationHandler, CompatibilityW
      * @param propertyName Property name in camelCase (e.g. {@code "myList"}).
      */
     protected void registerListProperty(final String propertyName) {
-        final String capitalised = Character.toUpperCase(propertyName.charAt(0)) + propertyName.substring(1);
-        listPropertyGetters.add("get" + capitalised);
+        listPropertyGetters.add("get" + capitalize(propertyName));
     }
 
     /**
@@ -142,8 +141,7 @@ public class ReflectionBasedWrapper implements InvocationHandler, CompatibilityW
      * @param propertyName Property name in camelCase (e.g. {@code "refEEComponentRole"}).
      */
     protected void registerBackRefProperty(final String propertyName) {
-        final String capitalised = Character.toUpperCase(propertyName.charAt(0)) + propertyName.substring(1);
-        backRefPropertyGetters.add("get" + capitalised);
+        backRefPropertyGetters.add("get" + capitalize(propertyName));
     }
 
     protected Object wrapObject(final Object obj, final Method method, final Object[] allArguments) throws Throwable {
@@ -332,6 +330,13 @@ public class ReflectionBasedWrapper implements InvocationHandler, CompatibilityW
         }
 
         return interestingObjects;
+    }
+
+    private static String capitalize(final String s) {
+        if (s == null || s.isEmpty()) {
+            return s;
+        }
+        return Character.toUpperCase(s.charAt(0)) + s.substring(1);
     }
 
     private boolean isClassOfInterest(final Class<?> o) {

--- a/compatibility/compatibility-core/src/main/java/com/foursoft/harness/compatibility/core/wrapper/ReflectionBasedWrapper.java
+++ b/compatibility/compatibility-core/src/main/java/com/foursoft/harness/compatibility/core/wrapper/ReflectionBasedWrapper.java
@@ -51,6 +51,14 @@ public class ReflectionBasedWrapper implements InvocationHandler, CompatibilityW
 
     private final Map<Object, Object> collectionsByMethod = new HashMap<>();
 
+    private final Map<String, Object> valuePropertyValues = new HashMap<>();
+    private final Set<String> valuePropertyGetters = new HashSet<>();
+    private final Map<String, String> setterToGetter = new HashMap<>();
+    private final Set<String> listPropertyGetters = new HashSet<>();
+    private final Map<String, List<Object>> listPropertyStore = new HashMap<>();
+    private final Set<String> backRefPropertyGetters = new HashSet<>();
+    private final Map<String, Set<Object>> backRefPropertyStore = new HashMap<>();
+
     private final WrapperHelper wrapperHelper;
     private final Context context;
     private final Object target;
@@ -93,7 +101,69 @@ public class ReflectionBasedWrapper implements InvocationHandler, CompatibilityW
         return target;
     }
 
+    /**
+     * Registers a value property (getter + setter) that is handled in-memory by this wrapper.
+     * Getter and setter names are inferred by capitalising the property name and prepending
+     * {@code get} / {@code set} (standard JavaBean convention).
+     *
+     * @param propertyName Property name in camelCase (e.g. {@code "myProperty"}).
+     */
+    protected void registerValueProperty(final String propertyName) {
+        final String capitalised = Character.toUpperCase(propertyName.charAt(0)) + propertyName.substring(1);
+        registerValueProperty("get" + capitalised, "set" + capitalised);
+    }
+
+    /**
+     * Registers a value property with explicit getter and setter method names.
+     *
+     * @param getterName Name of the getter method.
+     * @param setterName Name of the setter method.
+     */
+    protected void registerValueProperty(final String getterName, final String setterName) {
+        valuePropertyGetters.add(getterName);
+        setterToGetter.put(setterName, getterName);
+    }
+
+    /**
+     * Registers a list property whose getter returns a stable, lazily-created empty list.
+     * The getter name is inferred by capitalising the property name and prepending {@code get}.
+     *
+     * @param propertyName Property name in camelCase (e.g. {@code "myList"}).
+     */
+    protected void registerListProperty(final String propertyName) {
+        final String capitalised = Character.toUpperCase(propertyName.charAt(0)) + propertyName.substring(1);
+        listPropertyGetters.add("get" + capitalised);
+    }
+
+    /**
+     * Registers a back-reference property whose getter returns a stable, lazily-created empty set.
+     * The getter name is inferred by capitalising the property name and prepending {@code get}.
+     *
+     * @param propertyName Property name in camelCase (e.g. {@code "refEEComponentRole"}).
+     */
+    protected void registerBackRefProperty(final String propertyName) {
+        final String capitalised = Character.toUpperCase(propertyName.charAt(0)) + propertyName.substring(1);
+        backRefPropertyGetters.add("get" + capitalised);
+    }
+
     protected Object wrapObject(final Object obj, final Method method, final Object[] allArguments) throws Throwable {
+        final String methodName = method.getName();
+
+        if (valuePropertyGetters.contains(methodName)) {
+            return valuePropertyValues.get(methodName);
+        }
+        if (setterToGetter.containsKey(methodName)) {
+            valuePropertyValues.put(setterToGetter.get(methodName),
+                                    allArguments != null && allArguments.length > 0 ? allArguments[0] : null);
+            return null;
+        }
+        if (listPropertyGetters.contains(methodName)) {
+            return listPropertyStore.computeIfAbsent(methodName, k -> new ArrayList<>());
+        }
+        if (backRefPropertyGetters.contains(methodName)) {
+            return backRefPropertyStore.computeIfAbsent(methodName, k -> new HashSet<>());
+        }
+
         return defaultInvoke(method, allArguments);
     }
 

--- a/compatibility/compatibility-vec11to12/src/main/java/com/foursoft/harness/compatibility/vec11to12/wrapper/vec11to12/specification/CavityPartSpecificationWrapper.java
+++ b/compatibility/compatibility-vec11to12/src/main/java/com/foursoft/harness/compatibility/vec11to12/wrapper/vec11to12/specification/CavityPartSpecificationWrapper.java
@@ -47,7 +47,6 @@ import java.util.List;
 @Wraps(com.foursoft.harness.vec.v113.VecCavityPartSpecification.class)
 public class CavityPartSpecificationWrapper extends ReflectionBasedWrapper {
 
-    private List<String> compatibleCavityGeometries;
     private List<VecSize> vecSize;
 
     /**
@@ -58,6 +57,7 @@ public class CavityPartSpecificationWrapper extends ReflectionBasedWrapper {
      */
     public CavityPartSpecificationWrapper(final CompatibilityContext context, final Object target) {
         super(context, target);
+        registerListProperty("compatibleCavityGeometries");
     }
 
     public List<VecSize> createVecSize(final VecValueRange range, final Context context) {
@@ -76,13 +76,6 @@ public class CavityPartSpecificationWrapper extends ReflectionBasedWrapper {
                 vecSize = getVecSizes();
             }
             return vecSize;
-        }
-
-        if ("getCompatibleCavityGeometries".equals(methodName)) {
-            if (compatibleCavityGeometries == null) {
-                compatibleCavityGeometries = new ArrayList<>();
-            }
-            return compatibleCavityGeometries;
         }
 
         return super.wrapObject(obj, method, allArguments);

--- a/compatibility/compatibility-vec12to20/src/test/java/com/foursoft/harness/compatibility/vec12to20/wrapper/vec12to20/DefaultWrapperTest.java
+++ b/compatibility/compatibility-vec12to20/src/test/java/com/foursoft/harness/compatibility/vec12to20/wrapper/vec12to20/DefaultWrapperTest.java
@@ -10,10 +10,10 @@
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -25,19 +25,33 @@
  */
 package com.foursoft.harness.compatibility.vec12to20.wrapper.vec12to20;
 
-import com.foursoft.harness.compatibility.core.Context;
-import com.foursoft.harness.compatibility.core.wrapper.ReflectionBasedWrapper;
+import com.foursoft.harness.compatibility.vec12to20.wrapper.AbstractBaseWrapperTest;
+import com.foursoft.harness.vec.v2x.VecColor;
+import org.junit.jupiter.api.Test;
 
-public class DefaultWrapper extends ReflectionBasedWrapper {
+import static org.assertj.core.api.Assertions.assertThat;
 
-    /**
-     * Creates a wrapper for the given {@link Context} and target object.
-     *
-     * @param context Context for the wrapper.
-     * @param target  Target object to adjust.
-     */
-    public DefaultWrapper(final Context context, final Object target) {
-        super(context, target);
-        registerValueProperty("immutableGlobalIri");
+class DefaultWrapperTest extends AbstractBaseWrapperTest {
+
+    @Test
+    void immutableGlobalIri_should_be_null_initially() {
+        final VecColor proxy = createProxy();
+
+        assertThat(proxy.getImmutableGlobalIri()).isNull();
     }
+
+    @Test
+    void immutableGlobalIri_should_roundtrip_through_setter_and_getter() {
+        final VecColor proxy = createProxy();
+
+        proxy.setImmutableGlobalIri("urn:example:color:red");
+
+        assertThat(proxy.getImmutableGlobalIri()).isEqualTo("urn:example:color:red");
+    }
+
+    private VecColor createProxy() {
+        return get12To20Context().getWrapperProxyFactory()
+                .createProxy(new com.foursoft.harness.vec.v12x.VecColor());
+    }
+
 }


### PR DESCRIPTION
## Pull Request

- [X] I have checked for similar PRs.
- [X] I have read the [contributing guidelines](https://github.com/4Soft-de/harness-model/blob/develop/.github/CONTRIBUTING.md).

### Changes

- [X] Code
- [ ] Documentation
- [ ] Other: 

### Description

This pull request refactors the property handling logic in wrapper classes to provide a more generic, reusable, and memory-backed approach for managing simple value, list, and back-reference properties. The main improvements are the introduction of registration methods for different property types in `ReflectionBasedWrapper`, and the simplification of child wrapper classes by removing custom property management code. Additionally, new tests are added to verify the new property handling.

Core enhancements to property handling:

* Added generic in-memory property management to `ReflectionBasedWrapper`, including methods to register value properties (with getter/setter), list properties, and back-reference properties, along with supporting data structures and logic in `wrapObject`. This allows subclasses to easily define properties without custom code. [[1]](diffhunk://#diff-31f9c8833f6335291b84d5462b8646edde959978c00b1f07ea30128f3dfcdfdcR54-R61) [[2]](diffhunk://#diff-31f9c8833f6335291b84d5462b8646edde959978c00b1f07ea30128f3dfcdfdcR104-R166)

Refactoring of wrapper subclasses:

* Refactored `CavityPartSpecificationWrapper` to use the new `registerListProperty` method for `compatibleCavityGeometries`, removing the manual property field and custom getter logic. [[1]](diffhunk://#diff-2e4ddaf109c9c3e2c99c61a0fd10eddad66bf11daae1cdd88bcafb104b1933c1L50) [[2]](diffhunk://#diff-2e4ddaf109c9c3e2c99c61a0fd10eddad66bf11daae1cdd88bcafb104b1933c1R60) [[3]](diffhunk://#diff-2e4ddaf109c9c3e2c99c61a0fd10eddad66bf11daae1cdd88bcafb104b1933c1L81-L87)
* Refactored `DefaultWrapper` to use `registerValueProperty` for `immutableGlobalIri`, removing the explicit field and overridden `wrapObject` method. [[1]](diffhunk://#diff-b04d429be666a6b547a1d14411b4ec68ab5ec4e3792c1dad853336daf2065c9eL31-L36) [[2]](diffhunk://#diff-b04d429be666a6b547a1d14411b4ec68ab5ec4e3792c1dad853336daf2065c9eL45-R41)

Testing improvements:

* Added a new test class `DefaultWrapperTest` to ensure correct behavior of the in-memory value property for `immutableGlobalIri`, including initial state and getter/setter roundtrip.