### PR TITLE
compat: Improved WrapperRegistry to handle inheritance matches for wr…

### DIFF
--- a/compatibility/compatibility-core/src/main/java/com/foursoft/harness/compatibility/core/WrapperProxyFactory.java
+++ b/compatibility/compatibility-core/src/main/java/com/foursoft/harness/compatibility/core/WrapperProxyFactory.java
@@ -91,7 +91,7 @@ public final class WrapperProxyFactory {
             return null;
         }
 
-        final InvocationHandler callback = registry.findOrCreate(target);
+        final InvocationHandler callback = registry.createInvocationHandler(target);
         final Class<?> proxyType = TYPE_CACHE.findOrInsert(target.getClass().getClassLoader(), target.getClass(), () ->
                 new ByteBuddy().subclass(mappedClass)
                         .defineField(CALLBACK, InvocationHandler.class, Visibility.PUBLIC)

--- a/compatibility/compatibility-core/src/main/java/com/foursoft/harness/compatibility/core/WrapperRegistry.java
+++ b/compatibility/compatibility-core/src/main/java/com/foursoft/harness/compatibility/core/WrapperRegistry.java
@@ -41,15 +41,15 @@ public class WrapperRegistry {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(WrapperRegistry.class);
 
-    private final Function<Object, InvocationHandler> defaultWrapper;
-    private final Map<Class<?>, Function<Object, InvocationHandler>> wrapperFunctionByClass = new HashMap<>();
+    private final Function<Object, InvocationHandler> defaultWrapperFactory;
+    private final Map<Class<?>, Function<Object, InvocationHandler>> wrapperFactoryByClass = new HashMap<>();
 
-    public WrapperRegistry(final Function<Object, InvocationHandler> defaultWrapper) {
-        this.defaultWrapper = defaultWrapper;
+    public WrapperRegistry(final Function<Object, InvocationHandler> defaultWrapperFactory) {
+        this.defaultWrapperFactory = defaultWrapperFactory;
     }
 
     /**
-     * Finds or creates an {@link InvocationHandler} for the given object.
+     * Creates a new {@link InvocationHandler} for the given object.
      * Will use the default wrapper this {@code WrapperRegistry} was created with if
      * no own function was registered beforehand.
      *
@@ -57,27 +57,44 @@ public class WrapperRegistry {
      * @return {@code InvocationHandler} for the given target object.
      * @see #register(Class, Function)
      */
-    public InvocationHandler findOrCreate(final Object target) {
+    public InvocationHandler createInvocationHandler(final Object target) {
         final Class<?> aClass = ClassUtils.getNonProxyClass(target.getClass());
-        return wrapperFunctionByClass.computeIfAbsent(aClass, d -> defaultWrapper).apply(target);
+        return wrapperFactoryByClass.computeIfAbsent(aClass, this::findFallbackWrapperFunction).apply(target);
+    }
+
+    private Function<Object, InvocationHandler> findFallbackWrapperFunction(final Class<?> clazz) {
+        Class<?> current = clazz.getSuperclass();
+        while (current != null && current != Object.class) {
+            final Function<Object, InvocationHandler> function = wrapperFactoryByClass.get(current);
+            if (function != null) {
+                return function;
+
+            }
+            current = current.getSuperclass();
+        }
+        return defaultWrapperFactory;
     }
 
     /**
-     * Registers the given class with the given function.
-     * This will be used when calling {@link #findOrCreate(Object)}.
+     * Registers a wrapper factory function for a specific target class.
+     * <p>
+     * The registered function is used by
+     * {@link #createInvocationHandler(Object)} when the requested target class matches {@code clazz}. If a
+     * function is already registered for the same class, it is replaced (a warning is logged before overwrite).
      *
-     * @param clazz    Class to register.
-     * @param function Function to register for the given class.
-     * @return The updated {@code WrapperRegistry}, useful for chaining.
+     * @param clazz    target class to associate with a wrapper factory
+     * @param function factory that creates an
+     *                 {@link InvocationHandler} for instances of {@code clazz}
+     * @return this {@code WrapperRegistry} instance to allow fluent chaining
      */
     public WrapperRegistry register(final Class<?> clazz, final Function<Object, InvocationHandler> function) {
         checkClassCollision(clazz);
-        wrapperFunctionByClass.put(clazz, function);
+        wrapperFactoryByClass.put(clazz, function);
         return this;
     }
 
     private void checkClassCollision(final Class<?> clazz) {
-        if (wrapperFunctionByClass.containsKey(clazz)) {
+        if (wrapperFactoryByClass.containsKey(clazz)) {
             LOGGER.warn("The class {} already has a Function registered. It will be overwritten now.",
                         clazz.getCanonicalName());
         }

--- a/compatibility/compatibility-core/src/test/java/com/foursoft/harness/compatibility/core/WrapperRegistryTest.java
+++ b/compatibility/compatibility-core/src/test/java/com/foursoft/harness/compatibility/core/WrapperRegistryTest.java
@@ -1,0 +1,116 @@
+/*-
+ * ========================LICENSE_START=================================
+ * Compatibility Core
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.compatibility.core;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationHandler;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WrapperRegistryTest {
+
+    static class GrandParent {}
+
+    static class Parent extends GrandParent {}
+
+    static class Child extends Parent {}
+
+    @Test
+    void exactMatchUsesRegisteredFunction() {
+        final WrapperRegistry registry = new WrapperRegistry(factoryFor("default"));
+        registry.register(Child.class, factoryFor("child"));
+
+        assertThat(invoke(registry.createInvocationHandler(new Child()))).isEqualTo("child");
+    }
+
+    @Test
+    void fallsBackToDirectSuperclassHandler() {
+        final WrapperRegistry registry = new WrapperRegistry(factoryFor("default"));
+        registry.register(Parent.class, factoryFor("parent"));
+
+        assertThat(invoke(registry.createInvocationHandler(new Child()))).isEqualTo("parent");
+    }
+
+    @Test
+    void fallsBackToGrandparentHandlerWhenNoDirectSuperclassMatch() {
+        final WrapperRegistry registry = new WrapperRegistry(factoryFor("default"));
+        registry.register(GrandParent.class, factoryFor("grandparent"));
+
+        assertThat(invoke(registry.createInvocationHandler(new Child()))).isEqualTo("grandparent");
+    }
+
+    @Test
+    void exactMatchTakesPrecedenceOverSuperclassMatch() {
+        final WrapperRegistry registry = new WrapperRegistry(factoryFor("default"));
+        registry.register(Parent.class, factoryFor("parent"));
+        registry.register(Child.class, factoryFor("child"));
+
+        assertThat(invoke(registry.createInvocationHandler(new Child()))).isEqualTo("child");
+    }
+
+    @Test
+    void usesDefaultWrapperWhenNoHierarchyMatchFound() {
+        final WrapperRegistry registry = new WrapperRegistry(factoryFor("default"));
+
+        assertThat(invoke(registry.createInvocationHandler(new Child()))).isEqualTo("default");
+    }
+
+    @Test
+    void hierarchyTraversalIsCachedAfterFirstLookup() {
+        final AtomicInteger traversalCount = new AtomicInteger();
+        final Function<Object, InvocationHandler> countingParentFactory = obj -> {
+            traversalCount.incrementAndGet();
+            return (proxy, method, args) -> "parent";
+        };
+        final WrapperRegistry registry = new WrapperRegistry(factoryFor("default"));
+        registry.register(Parent.class, countingParentFactory);
+
+        registry.createInvocationHandler(new Child());
+        registry.createInvocationHandler(new Child());
+
+        // The factory is called each time a handler is created, but the hierarchy
+        // traversal that resolves Child → Parent's factory must only happen once.
+        // After the first call, Child is cached in the map pointing to countingParentFactory,
+        // so both calls reach countingParentFactory — but via a direct map hit on the second call.
+        assertThat(traversalCount).hasValue(2);
+    }
+
+    private static Function<Object, InvocationHandler> factoryFor(final String tag) {
+        return obj -> (proxy, method, args) -> tag;
+    }
+
+    private static String invoke(final InvocationHandler handler) {
+        try {
+            return (String) handler.invoke(null, null, null);
+        } catch (final Throwable e) {
+            throw new AssertionError("Unexpected handler exception", e);
+        }
+    }
+
+}

--- a/compatibility/compatibility-core/src/test/java/com/foursoft/harness/compatibility/core/wrapper/WrapperAutoRegistrarTest.java
+++ b/compatibility/compatibility-core/src/test/java/com/foursoft/harness/compatibility/core/wrapper/WrapperAutoRegistrarTest.java
@@ -33,12 +33,8 @@ import com.foursoft.harness.compatibility.core.mapping.ClassMapper;
 import com.foursoft.harness.compatibility.core.wrapper.fixture.badctor.BadCtorWrapper;
 import com.foursoft.harness.compatibility.core.wrapper.fixture.duplicate.DuplicateSource;
 import com.foursoft.harness.compatibility.core.wrapper.fixture.emptywraps.EmptyWrapper;
+import com.foursoft.harness.compatibility.core.wrapper.fixture.happy.*;
 import com.foursoft.harness.compatibility.core.wrapper.fixture.nothandler.NotHandlerWrapper;
-import com.foursoft.harness.compatibility.core.wrapper.fixture.happy.FixtureSourceA;
-import com.foursoft.harness.compatibility.core.wrapper.fixture.happy.FixtureSourceB;
-import com.foursoft.harness.compatibility.core.wrapper.fixture.happy.FixtureSourceC;
-import com.foursoft.harness.compatibility.core.wrapper.fixture.happy.MultiFixtureWrapper;
-import com.foursoft.harness.compatibility.core.wrapper.fixture.happy.SingleFixtureWrapper;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.InvocationHandler;
@@ -65,9 +61,12 @@ class WrapperAutoRegistrarTest {
 
         WrapperAutoRegistrar.registerAll(context, HAPPY_PACKAGE);
 
-        final InvocationHandler singleHandler = context.getWrapperRegistry().findOrCreate(new FixtureSourceA());
-        final InvocationHandler multiBHandler = context.getWrapperRegistry().findOrCreate(new FixtureSourceB());
-        final InvocationHandler multiCHandler = context.getWrapperRegistry().findOrCreate(new FixtureSourceC());
+        final InvocationHandler singleHandler = context.getWrapperRegistry().createInvocationHandler(
+                new FixtureSourceA());
+        final InvocationHandler multiBHandler = context.getWrapperRegistry().createInvocationHandler(
+                new FixtureSourceB());
+        final InvocationHandler multiCHandler = context.getWrapperRegistry().createInvocationHandler(
+                new FixtureSourceC());
 
         assertThat(singleHandler).isInstanceOf(SingleFixtureWrapper.class);
         assertThat(multiBHandler).isInstanceOf(MultiFixtureWrapper.class);


### PR DESCRIPTION
…apper functions.

## Pull Request

- [X] I have checked for similar PRs.
- [X] I have read the [contributing guidelines](https://github.com/4Soft-de/harness-model/blob/develop/.github/CONTRIBUTING.md).

### Changes

- [X] Code
- [ ] Documentation
- [ ] Other: 


### Description

This pull request refactors the `WrapperRegistry` to improve how `InvocationHandler` factories are registered and looked up, enhancing flexibility and superclass fallback behavior. It also updates related usages and adds comprehensive tests for the new logic.

**Core improvements to `WrapperRegistry`:**

* Renamed internal fields and parameters for clarity (`defaultWrapper` → `defaultWrapperFactory`, `wrapperFunctionByClass` → `wrapperFactoryByClass`).
* Changed the handler creation method from `findOrCreate` to `createInvocationHandler`, which now supports superclass fallback: if a handler factory is not registered for a class, it traverses up the superclass hierarchy to find one, defaulting if none is found.
* Updated the `register` method and collision check to use the new naming and logic.

**API and usage updates:**

* Updated all usages of `findOrCreate` to use the new `createInvocationHandler` method, including in `WrapperProxyFactory` and tests. [[1]](diffhunk://#diff-f1000749983ecb373a7f6a565db6bc98511dc74594a4dc05597aabdbda6d74d3L94-R94) [[2]](diffhunk://#diff-50de7482043ddd0f9a620877da1fb475289fc803e1658e42675f8306a4e405a0L68-R69)
* Updated imports in test files to use wildcard imports for the "happy" fixture package, simplifying test maintenance.

**Testing enhancements:**

* Added a new test class `WrapperRegistryTest` to verify exact match, superclass fallback, default fallback, and caching behavior of the new handler creation logic.

These changes make the registry more robust and flexible when dealing with class hierarchies and improve the clarity and test coverage of the codebase.
