### PR TITLE
compat: Fixed JPMS problem with org.reflections classpath scanning.

### DIFF
--- a/compatibility/compatibility-core/src/main/java/com/foursoft/harness/compatibility/core/wrapper/WrapperAutoRegistrar.java
+++ b/compatibility/compatibility-core/src/main/java/com/foursoft/harness/compatibility/core/wrapper/WrapperAutoRegistrar.java
@@ -29,12 +29,17 @@ import com.foursoft.harness.compatibility.core.Context;
 import com.foursoft.harness.compatibility.core.WrapperRegistry;
 import com.foursoft.harness.compatibility.core.exception.WrapperException;
 import org.reflections.Reflections;
+import org.reflections.scanners.Scanners;
+import org.reflections.util.ConfigurationBuilder;
+import org.reflections.util.FilterBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
+import java.net.URL;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -64,12 +69,22 @@ public final class WrapperAutoRegistrar {
      * package is also an error and will throw immediately instead of silently overwriting an earlier
      * registration.
      *
-     * @param context     Context whose registry will receive the registrations.
-     * @param basePackage Package prefix to scan (e.g. {@code "com.foo.compat.wrapper"}).
+     * @param context            Context whose registry will receive the registrations.
+     * @param basePackageClasses Classes in packages to scan, type safe way to specify packages.
      */
-    public static void registerAll(final Context context, final String basePackage) {
-        final Set<Class<?>> wrapperClasses =
-                new Reflections(basePackage).getTypesAnnotatedWith(Wraps.class);
+    public static void registerAll(final Context context, final Class<?>... basePackageClasses) {
+        final String[] packages = Arrays.stream(basePackageClasses).map(Class::getPackageName).toArray(String[]::new);
+        final FilterBuilder filterBuilder = new FilterBuilder();
+        for (final String packageName : packages) {
+            filterBuilder.includePackage(packageName);
+        }
+        final URL[] urls = Arrays.stream(basePackageClasses).map(
+                p -> p.getProtectionDomain().getCodeSource().getLocation()).toArray(URL[]::new);
+
+        final Set<Class<?>> wrapperClasses = new Reflections(new ConfigurationBuilder().setUrls(urls)
+                                                                     .filterInputsBy(filterBuilder)
+                                                                     .forPackages(packages).addScanners(
+                        Scanners.TypesAnnotated)).getTypesAnnotatedWith(Wraps.class);
         final WrapperRegistry registry = context.getWrapperRegistry();
         final Set<Class<?>> seenSourceClasses = new HashSet<>();
 
@@ -92,15 +107,15 @@ public final class WrapperAutoRegistrar {
                     throw new WrapperException(
                             "Duplicate @Wraps registration: source class " + sourceClass.getName()
                                     + " is mapped by more than one wrapper in package '"
-                                    + basePackage + "'. Only one wrapper per source class is allowed.");
+                                    + Arrays.toString(packages) + "'. Only one wrapper per source class is allowed.");
                 }
                 registry.register(sourceClass, target -> instantiate(ctor, context, target));
                 registrations++;
             }
         }
 
-        LOGGER.info("Auto-registered {} wrapper(s) for {} source class(es) from package '{}'.",
-                    wrapperClasses.size(), registrations, basePackage);
+        LOGGER.info("Auto-registered {} wrapper(s) for {} source class(es) from packages '{}'.",
+                    wrapperClasses.size(), registrations, packages);
     }
 
     /**

--- a/compatibility/compatibility-core/src/test/java/com/foursoft/harness/compatibility/core/wrapper/WrapperAutoRegistrarTest.java
+++ b/compatibility/compatibility-core/src/test/java/com/foursoft/harness/compatibility/core/wrapper/WrapperAutoRegistrarTest.java
@@ -32,7 +32,7 @@ import com.foursoft.harness.compatibility.core.exception.WrapperException;
 import com.foursoft.harness.compatibility.core.mapping.ClassMapper;
 import com.foursoft.harness.compatibility.core.wrapper.fixture.badctor.BadCtorWrapper;
 import com.foursoft.harness.compatibility.core.wrapper.fixture.duplicate.DuplicateSource;
-import com.foursoft.harness.compatibility.core.wrapper.fixture.emptywraps.EmptyWrapper;
+import com.foursoft.harness.compatibility.core.wrapper.fixture.duplicate.DuplicateWrapperA;
 import com.foursoft.harness.compatibility.core.wrapper.fixture.happy.*;
 import com.foursoft.harness.compatibility.core.wrapper.fixture.nothandler.NotHandlerWrapper;
 import org.junit.jupiter.api.Test;
@@ -44,22 +44,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class WrapperAutoRegistrarTest {
 
-    private static final String HAPPY_PACKAGE =
-            "com.foursoft.harness.compatibility.core.wrapper.fixture.happy";
-    private static final String BAD_CTOR_PACKAGE =
-            "com.foursoft.harness.compatibility.core.wrapper.fixture.badctor";
-    private static final String EMPTY_PACKAGE =
-            "com.foursoft.harness.compatibility.core.wrapper.fixture.emptywraps";
-    private static final String NOT_HANDLER_PACKAGE =
-            "com.foursoft.harness.compatibility.core.wrapper.fixture.nothandler";
-    private static final String DUPLICATE_PACKAGE =
-            "com.foursoft.harness.compatibility.core.wrapper.fixture.duplicate";
-
     @Test
     void registersAllAnnotatedWrappersInPackage() {
         final CompatibilityContext context = newContext();
 
-        WrapperAutoRegistrar.registerAll(context, HAPPY_PACKAGE);
+        WrapperAutoRegistrar.registerAll(context, MultiFixtureWrapper.class);
 
         final InvocationHandler singleHandler = context.getWrapperRegistry().createInvocationHandler(
                 new FixtureSourceA());
@@ -77,27 +66,17 @@ class WrapperAutoRegistrarTest {
     void rejectsWrapperWithoutContextObjectConstructor() {
         final CompatibilityContext context = newContext();
 
-        assertThatThrownBy(() -> WrapperAutoRegistrar.registerAll(context, BAD_CTOR_PACKAGE))
+        assertThatThrownBy(() -> WrapperAutoRegistrar.registerAll(context, BadCtorWrapper.class))
                 .isInstanceOf(WrapperException.class)
                 .hasMessageContaining(BadCtorWrapper.class.getName())
                 .hasMessageContaining("(Context, Object)");
     }
 
     @Test
-    void rejectsWrapperWithEmptyWrapsValue() {
-        final CompatibilityContext context = newContext();
-
-        assertThatThrownBy(() -> WrapperAutoRegistrar.registerAll(context, EMPTY_PACKAGE))
-                .isInstanceOf(WrapperException.class)
-                .hasMessageContaining(EmptyWrapper.class.getName())
-                .hasMessageContaining("at least one source class");
-    }
-
-    @Test
     void rejectsWrapperThatDoesNotImplementInvocationHandler() {
         final CompatibilityContext context = newContext();
 
-        assertThatThrownBy(() -> WrapperAutoRegistrar.registerAll(context, NOT_HANDLER_PACKAGE))
+        assertThatThrownBy(() -> WrapperAutoRegistrar.registerAll(context, NotHandlerWrapper.class))
                 .isInstanceOf(WrapperException.class)
                 .hasMessageContaining(NotHandlerWrapper.class.getName())
                 .hasMessageContaining(InvocationHandler.class.getName());
@@ -107,7 +86,7 @@ class WrapperAutoRegistrarTest {
     void rejectsDuplicateSourceClassRegistration() {
         final CompatibilityContext context = newContext();
 
-        assertThatThrownBy(() -> WrapperAutoRegistrar.registerAll(context, DUPLICATE_PACKAGE))
+        assertThatThrownBy(() -> WrapperAutoRegistrar.registerAll(context, DuplicateWrapperA.class))
                 .isInstanceOf(WrapperException.class)
                 .hasMessageContaining(DuplicateSource.class.getName())
                 .hasMessageContaining("more than one wrapper");

--- a/compatibility/compatibility-vec11to12/src/main/java/com/foursoft/harness/compatibility/vec11to12/Vec11XTo12XCompatibilityWrapper.java
+++ b/compatibility/compatibility-vec11to12/src/main/java/com/foursoft/harness/compatibility/vec11to12/Vec11XTo12XCompatibilityWrapper.java
@@ -30,13 +30,12 @@ import com.foursoft.harness.compatibility.core.CompatibilityContext.Compatibilit
 import com.foursoft.harness.compatibility.core.mapping.ClassMapper;
 import com.foursoft.harness.compatibility.core.wrapper.CompatibilityWrapper;
 import com.foursoft.harness.compatibility.core.wrapper.WrapperAutoRegistrar;
+import com.foursoft.harness.compatibility.vec11to12.wrapper.vec12to11.ContentWrapper;
 
 /**
  * Compatibility Wrapper for VEC 1.1.X to VEC 1.2.X and vice versa.
  */
 public final class Vec11XTo12XCompatibilityWrapper implements CompatibilityWrapper {
-
-    private static final String WRAPPER_PACKAGE = "com.foursoft.harness.compatibility.vec11to12.wrapper";
 
     private final CompatibilityContext compatibilityContext;
 
@@ -51,7 +50,8 @@ public final class Vec11XTo12XCompatibilityWrapper implements CompatibilityWrapp
                         .withUnsupportedMethodCheck(classMapper.checkUnsupportedMethods())
                         .build();
 
-        WrapperAutoRegistrar.registerAll(context, WRAPPER_PACKAGE);
+        WrapperAutoRegistrar.registerAll(context, ContentWrapper.class,
+                                         com.foursoft.harness.compatibility.vec11to12.wrapper.vec11to12.ContentWrapper.class);
 
         compatibilityContext = context;
     }

--- a/compatibility/compatibility-vec12to20/src/main/java/com/foursoft/harness/compatibility/vec12to20/Vec12XTo20XCompatibilityWrapper.java
+++ b/compatibility/compatibility-vec12to20/src/main/java/com/foursoft/harness/compatibility/vec12to20/Vec12XTo20XCompatibilityWrapper.java
@@ -31,13 +31,12 @@ import com.foursoft.harness.compatibility.core.mapping.ClassMapper;
 import com.foursoft.harness.compatibility.core.wrapper.CompatibilityWrapper;
 import com.foursoft.harness.compatibility.core.wrapper.WrapperAutoRegistrar;
 import com.foursoft.harness.compatibility.vec12to20.wrapper.vec12to20.DefaultWrapper;
+import com.foursoft.harness.compatibility.vec12to20.wrapper.vec20to12.ContentWrapper;
 
 /**
  * Compatibility Wrapper for VEC 1.2.X to VEC 2.X.X and vice versa.
  */
 public final class Vec12XTo20XCompatibilityWrapper implements CompatibilityWrapper {
-
-    private static final String WRAPPER_PACKAGE = "com.foursoft.harness.compatibility.vec12to20.wrapper";
 
     private final CompatibilityContext compatibilityContext;
 
@@ -53,7 +52,7 @@ public final class Vec12XTo20XCompatibilityWrapper implements CompatibilityWrapp
                         .withUnsupportedMethodCheck(classMapper.checkUnsupportedMethods())
                         .build();
 
-        WrapperAutoRegistrar.registerAll(context, WRAPPER_PACKAGE);
+        WrapperAutoRegistrar.registerAll(context, DefaultWrapper.class, ContentWrapper.class);
 
         compatibilityContext = context;
     }


### PR DESCRIPTION
## Pull Request

- [X] I have checked for similar PRs.
- [X] I have read the [contributing guidelines](https://github.com/4Soft-de/harness-model/blob/develop/.github/CONTRIBUTING.md).

### Changes

- [X] Code
- [ ] Documentation
- [ ] Other: 

### Description

This pull request refactors the way wrapper classes are auto-registered throughout the compatibility modules. Instead of specifying package names as strings, registration now uses class references for type safety and reliability. The changes update both the core registration logic and all affected usages and tests.

**Core API and Implementation Improvements:**

* The `WrapperAutoRegistrar.registerAll` method now accepts one or more class references (e.g., `SomeWrapper.class`) instead of a package name string, improving type safety and reducing errors from typos or refactoring.
* The internal scanning logic in `WrapperAutoRegistrar` is updated to use the packages and locations of the provided classes, ensuring accurate and efficient annotation scanning. [[1]](diffhunk://#diff-5a31829abe800cfe08eba2c7287dffb6a28cf97b4b071ab68789b75a0920400fL68-R87) [[2]](diffhunk://#diff-5a31829abe800cfe08eba2c7287dffb6a28cf97b4b071ab68789b75a0920400fR32-R42)
* Logging and error messages are updated to reflect the new multi-package, class-based approach.

**Test Updates:**

* All tests in `WrapperAutoRegistrarTest` are updated to use class references instead of package name strings, aligning with the new API and improving test robustness. [[1]](diffhunk://#diff-50de7482043ddd0f9a620877da1fb475289fc803e1658e42675f8306a4e405a0L47-R51) [[2]](diffhunk://#diff-50de7482043ddd0f9a620877da1fb475289fc803e1658e42675f8306a4e405a0L80-R79) [[3]](diffhunk://#diff-50de7482043ddd0f9a620877da1fb475289fc803e1658e42675f8306a4e405a0L110-R89)

**Integration Updates:**

* The VEC compatibility wrapper modules (`Vec11XTo12XCompatibilityWrapper` and `Vec12XTo20XCompatibilityWrapper`) now register wrappers using class references, ensuring correctness and easier maintenance. [[1]](diffhunk://#diff-e99841bba638bf61a14b39f43cff8f6b1e87db51cd236131c015b98365aeadaeL54-R54) [[2]](diffhunk://#diff-5612cffc1617028380e1a513d8a9195a6a1d82d4fc27e81e0ded8e9deb926f01L56-R55) [[3]](diffhunk://#diff-e99841bba638bf61a14b39f43cff8f6b1e87db51cd236131c015b98365aeadaeR33-L40) [[4]](diffhunk://#diff-5612cffc1617028380e1a513d8a9195a6a1d82d4fc27e81e0ded8e9deb926f01R34-L41)