### PR TITLE
Fixed wrong condition for default values.

### DIFF
--- a/compatibility/compatibility-core/src/main/java/com/foursoft/harness/compatibility/core/wrapper/ReflectionBasedWrapper.java
+++ b/compatibility/compatibility-core/src/main/java/com/foursoft/harness/compatibility/core/wrapper/ReflectionBasedWrapper.java
@@ -94,7 +94,7 @@ public class ReflectionBasedWrapper implements InvocationHandler, CompatibilityW
     public final Object invoke(final Object obj, final Method method, final Object[] allArguments) throws Throwable {
         final Object returnValue = innerInvoke(obj, method, allArguments);
         // In case the return value is a List. This should prevent NPEs when trying to loop over the list.
-        if (returnValue == null && method.getReturnType().isAssignableFrom(List.class)) {
+        if (returnValue == null && List.class.isAssignableFrom(method.getReturnType())) {
             return new ArrayList<>();
         }
         return returnValue;

--- a/compatibility/compatibility-core/src/test/java/com/foursoft/harness/compatibility/core/wrapper/ReflectionBasedWrapperNullCoercionTest.java
+++ b/compatibility/compatibility-core/src/test/java/com/foursoft/harness/compatibility/core/wrapper/ReflectionBasedWrapperNullCoercionTest.java
@@ -1,0 +1,101 @@
+/*-
+ * ========================LICENSE_START=================================
+ * Compatibility Core
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.compatibility.core.wrapper;
+
+import com.foursoft.harness.compatibility.core.CompatibilityContext;
+import com.foursoft.harness.compatibility.core.CompatibilityContext.CompatibilityContextBuilder;
+import com.foursoft.harness.compatibility.core.mapping.ClassMapper;
+import com.foursoft.harness.compatibility.core.wrapper.fixture.additions.AdditionsBean;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies the null-to-empty-list coercion in {@link ReflectionBasedWrapper#invoke}.
+ * <p>
+ * The condition {@code List.class.isAssignableFrom(method.getReturnType())} must only
+ * fire for actual List return types, not for supertypes of List such as {@code Object}
+ * or {@code Collection} (regression: the operands were previously reversed).
+ */
+class ReflectionBasedWrapperNullCoercionTest {
+
+    private static final String FIXTURE_PACKAGE =
+            "com.foursoft.harness.compatibility.core.wrapper.fixture.additions";
+
+    @Test
+    void nullReturn_onListMethod_isCoercedToEmptyList() throws Exception {
+        final Object proxy = proxyFor(new AdditionsBean());
+
+        final Object result = method(proxy, "getNullList").invoke(proxy);
+
+        assertThat(result).isNotNull().isInstanceOf(List.class);
+        assertThat((List<?>) result).isEmpty();
+    }
+
+    @Test
+    void nullReturn_onObjectMethod_remainsNull() throws Exception {
+        // Regression: with the reversed isAssignableFrom, Object-typed methods that returned
+        // null were incorrectly coerced to new ArrayList<>() because Object.isAssignableFrom(List)
+        // is true (List IS-A Object). The corrected check is List.isAssignableFrom(returnType).
+        final Object proxy = proxyFor(new AdditionsBean());
+
+        final Object result = method(proxy, "getNullObject").invoke(proxy);
+
+        assertThat(result).isNull();
+    }
+
+    private Object proxyFor(final Object source) {
+        final CompatibilityContext ctx = new CompatibilityContextBuilder()
+                .withClassMapper(new SimpleClassMapper())
+                .build();
+        return ctx.getWrapperProxyFactory().createProxy(source);
+    }
+
+    private static Method method(final Object proxy, final String name, final Class<?>... params)
+            throws NoSuchMethodException {
+        return proxy.getClass().getMethod(name, params);
+    }
+
+    private static final class SimpleClassMapper implements ClassMapper {
+        @Override
+        public Class<?> map(final Class<?> clazz) {
+            return clazz;
+        }
+
+        @Override
+        public String getSourcePackageName() {
+            return FIXTURE_PACKAGE;
+        }
+
+        @Override
+        public String getTargetPackageName() {
+            return FIXTURE_PACKAGE;
+        }
+    }
+}

--- a/compatibility/compatibility-core/src/test/java/com/foursoft/harness/compatibility/core/wrapper/fixture/additions/AdditionsBean.java
+++ b/compatibility/compatibility-core/src/test/java/com/foursoft/harness/compatibility/core/wrapper/fixture/additions/AdditionsBean.java
@@ -46,4 +46,12 @@ public class AdditionsBean extends ParentAdditionsBean {
     public Set<String> getBazSet() {
         return Collections.singleton("bazOriginal");
     }
+
+    public List<String> getNullList() {
+        return null;
+    }
+
+    public Object getNullObject() {
+        return null;
+    }
 }


### PR DESCRIPTION
## Pull Request

- [X] I have checked for similar PRs.
- [X] I have read the [contributing guidelines](https://github.com/4Soft-de/harness-model/blob/develop/.github/CONTRIBUTING.md).

### Changes

- [X] Code
- [ ] Documentation
- [ ] Other: 

### Description

This pull request fixes a bug in the `ReflectionBasedWrapper` related to how null return values are coerced to empty lists, and adds comprehensive tests to prevent regressions. The main issue was that the logic for determining when to coerce a null to an empty list was reversed, causing methods returning `Object` (or other supertypes of `List`) to incorrectly return an empty list instead of `null`. The PR also introduces new test cases and supporting fixture methods.

### Bug fix: Null-to-empty-list coercion

* Corrected the logic in `ReflectionBasedWrapper#invoke` so that null return values are only coerced to empty lists when the method's return type is actually a `List` (and not a supertype like `Object` or `Collection`). This prevents incorrect coercion and potential bugs when handling methods with broader return types.

### Testing improvements

* Added `ReflectionBasedWrapperNullCoercionTest` to verify the correct behavior of null-to-empty-list coercion, including regression tests to ensure that only methods returning `List` are coerced and not those returning `Object`.
* Added new methods `getNullList` and `getNullObject` to the `AdditionsBean` fixture to support the new test cases.