### PR TITLE
Allow source/javadoc build without release.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -489,6 +489,21 @@
     </build>
     <profiles>
         <profile>
+            <id>sources</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>release</id>
             <build>
                 <plugins>


### PR DESCRIPTION
## Pull Request

- [X] I have checked for similar PRs.
- [X] I have read the [contributing guidelines](https://github.com/4Soft-de/harness-model/blob/develop/.github/CONTRIBUTING.md).

### Changes

- [X] Code
- [ ] Documentation
- [ ] Other: 

### Description

This pull request adds a new Maven build profile to the `pom.xml` file to improve source and documentation packaging. The new profile makes it easier to generate source and Javadoc artifacts during the build process.

Build enhancements:

* Added a `sources` Maven profile that includes the `maven-source-plugin` and `maven-javadoc-plugin` to facilitate building source and Javadoc jars.