### PR TITLE
vec: Added marker interface for "StructuredPrimitive" in VEC 2.X

### DIFF
--- a/scripts/generate-structured-primitive-xjb-from-model.xsl
+++ b/scripts/generate-structured-primitive-xjb-from-model.xsl
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:uml="http://www.omg.org/spec/UML/20131001"
+    xmlns:xmi="http://www.omg.org/spec/XMI/20131001"
+    xmlns:Stereotypes="http://www.magicdraw.com/schemas/Stereotypes.xmi"
+    xmlns:MagicDraw_Profile="http://www.omg.org/spec/UML/20131001/MagicDrawProfile"
+    xmlns:jxb="https://jakarta.ee/xml/ns/jaxb"
+    xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:nav="http://www.4soft.de/xjc-plugins/navigations"
+    xmlns:inheritance="urn:jvnet.org:basicjaxb:xjc:inheritance"
+    exclude-result-prefixes="uml xmi Stereotypes MagicDraw_Profile"
+    version="3.0">
+    
+    <xsl:key name="idlookup" match="*" use="@xmi:id"/>
+    
+    <xsl:output method="xml" indent="yes"/>
+    <xsl:strip-space elements="*"/>
+    
+    <xsl:param name="VEC_VERSION" required="yes"/>
+    
+    <xsl:template match="/">
+        <jxb:bindings node="/xs:schema" schemaLocation="{concat('vec_',$VEC_VERSION,'.xsd')}" version="3.0" extensionBindingPrefixes="xjc">
+            <xsl:apply-templates select="key('idlookup',//Stereotypes:StructuredPrimitive/@base_Class)"></xsl:apply-templates>        
+        </jxb:bindings>
+    </xsl:template>
+    
+    <xsl:template match="packagedElement">
+        <jxb:bindings multiple="true" node="//xs:complexType[@name='{@name}']">
+            <inheritance:implements>com.foursoft.harness.vec.common.StructuredPrimitive</inheritance:implements>
+        </jxb:bindings>        
+    </xsl:template>
+    
+</xsl:stylesheet>

--- a/vec/vec-common/src/main/java/com/foursoft/harness/vec/common/StructuredPrimitive.java
+++ b/vec/vec-common/src/main/java/com/foursoft/harness/vec/common/StructuredPrimitive.java
@@ -1,0 +1,46 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC Common
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.common;
+
+/**
+ * Marker-Interface for VEC model classes that stereotyped as <code>StructuredPrimitive</code>. This means:
+ *
+ * <code><StructuredPrimitives/code> are semantically like primitive types in that:
+ *
+ * <ul>
+ *     <li>They are used as attribute types in other model elements.</li>
+ *     <li>They are not independently identifiable.</li>
+ *     <li>They shall not be referenced from other parts of the model.</li>
+ *     <li>They shall not be an ExtendableElement.</li>
+ * </ul>
+ *
+ * @see
+ * <a href="https://ecad-wiki.prostep.org/specifications/vec/v220/basic-datatypes/structured-primitives/">Structured Primitives Model Documentation</a>
+ * @since VEC V2.2.0
+ *
+ */
+public interface StructuredPrimitive {
+}

--- a/vec/vec-v2x/src/main/resources/vec2/README.md
+++ b/vec/vec-v2x/src/main/resources/vec2/README.md
@@ -10,6 +10,8 @@ follow these steps:
   `src/main/java/com/foursoft/harness/vec/v2x/validation/SchemaFactory.java`.
 - Run the `scripts/relocate-doc-in-xsd.xsl` on the XSDs, to make the embedded docs XJC compatible.
 - Run the `scripts/generate-xjb-from-schema.xsl` on the XSDs to generate the `vec_2.x.x.xjb` file.
+- Run the `scripts/generate-structured-primitive-xjb-from-model.xsl` on the UML XMI file (downloadable from the
+  ECAD-WIKI) to generate `vec_2.x.x-structured-primitives.xjb`
 - Adapt the `schemaLocation="vec_2.2.0.xsd"` attribute in the XJB files located in this directory.
 - Also add the files (including model and ontologies) to `vec-rdf/vec-rdf-common/src/main/resources/vec`
 - Fix the `com.foursoft.harness.vec.v2x.Version.VERSION` constant.

--- a/vec/vec-v2x/src/main/resources/vec2/vec_2.2.0-structured-primitives.xjb
+++ b/vec/vec-v2x/src/main/resources/vec2/vec_2.2.0-structured-primitives.xjb
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jxb:bindings xmlns:inheritance="urn:jvnet.org:basicjaxb:xjc:inheritance"
+        xmlns:jxb="https://jakarta.ee/xml/ns/jaxb"
+        xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
+        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        node="/xs:schema"
+        schemaLocation="vec_2.2.0.xsd"
+        version="3.0"
+        extensionBindingPrefixes="xjc">
+    <jxb:bindings multiple="true" node="//xs:complexType[@name='AliasIdentification']">
+        <inheritance:implements>com.foursoft.harness.vec.common.StructuredPrimitive</inheritance:implements>
+    </jxb:bindings>
+    <jxb:bindings multiple="true" node="//xs:complexType[@name='LocalizedString']">
+        <inheritance:implements>com.foursoft.harness.vec.common.StructuredPrimitive</inheritance:implements>
+    </jxb:bindings>
+    <jxb:bindings multiple="true"
+            node="//xs:complexType[@name='AbstractLocalizedString']">
+        <inheritance:implements>com.foursoft.harness.vec.common.StructuredPrimitive</inheritance:implements>
+    </jxb:bindings>
+    <jxb:bindings multiple="true" node="//xs:complexType[@name='LocalizedTypedString']">
+        <inheritance:implements>com.foursoft.harness.vec.common.StructuredPrimitive</inheritance:implements>
+    </jxb:bindings>
+    <jxb:bindings multiple="true" node="//xs:complexType[@name='DocumentClassification']">
+        <inheritance:implements>com.foursoft.harness.vec.common.StructuredPrimitive</inheritance:implements>
+    </jxb:bindings>
+    <jxb:bindings multiple="true" node="//xs:complexType[@name='CustomProperty']">
+        <inheritance:implements>com.foursoft.harness.vec.common.StructuredPrimitive</inheritance:implements>
+    </jxb:bindings>
+    <jxb:bindings multiple="true" node="//xs:complexType[@name='NumericalValueProperty']">
+        <inheritance:implements>com.foursoft.harness.vec.common.StructuredPrimitive</inheritance:implements>
+    </jxb:bindings>
+    <jxb:bindings multiple="true" node="//xs:complexType[@name='SimpleValueProperty']">
+        <inheritance:implements>com.foursoft.harness.vec.common.StructuredPrimitive</inheritance:implements>
+    </jxb:bindings>
+    <jxb:bindings multiple="true" node="//xs:complexType[@name='ValueRangeProperty']">
+        <inheritance:implements>com.foursoft.harness.vec.common.StructuredPrimitive</inheritance:implements>
+    </jxb:bindings>
+    <jxb:bindings multiple="true"
+            node="//xs:complexType[@name='LocalizedStringProperty']">
+        <inheritance:implements>com.foursoft.harness.vec.common.StructuredPrimitive</inheritance:implements>
+    </jxb:bindings>
+    <jxb:bindings multiple="true" node="//xs:complexType[@name='BooleanValueProperty']">
+        <inheritance:implements>com.foursoft.harness.vec.common.StructuredPrimitive</inheritance:implements>
+    </jxb:bindings>
+    <jxb:bindings multiple="true" node="//xs:complexType[@name='DateValueProperty']">
+        <inheritance:implements>com.foursoft.harness.vec.common.StructuredPrimitive</inheritance:implements>
+    </jxb:bindings>
+    <jxb:bindings multiple="true" node="//xs:complexType[@name='DoubleValueProperty']">
+        <inheritance:implements>com.foursoft.harness.vec.common.StructuredPrimitive</inheritance:implements>
+    </jxb:bindings>
+    <jxb:bindings multiple="true" node="//xs:complexType[@name='IntegerValueProperty']">
+        <inheritance:implements>com.foursoft.harness.vec.common.StructuredPrimitive</inheritance:implements>
+    </jxb:bindings>
+    <jxb:bindings multiple="true" node="//xs:complexType[@name='ComplexProperty']">
+        <inheritance:implements>com.foursoft.harness.vec.common.StructuredPrimitive</inheritance:implements>
+    </jxb:bindings>
+    <jxb:bindings multiple="true"
+            node="//xs:complexType[@name='MultiDimensionalValueProperty']">
+        <inheritance:implements>com.foursoft.harness.vec.common.StructuredPrimitive</inheritance:implements>
+    </jxb:bindings>
+    <jxb:bindings multiple="true" node="//xs:complexType[@name='SlotLayout']">
+        <inheritance:implements>com.foursoft.harness.vec.common.StructuredPrimitive</inheritance:implements>
+    </jxb:bindings>
+    <jxb:bindings multiple="true"
+            node="//xs:complexType[@name='TerminalCurrentInformation']">
+        <inheritance:implements>com.foursoft.harness.vec.common.StructuredPrimitive</inheritance:implements>
+    </jxb:bindings>
+    <jxb:bindings multiple="true" node="//xs:complexType[@name='WireType']">
+        <inheritance:implements>com.foursoft.harness.vec.common.StructuredPrimitive</inheritance:implements>
+    </jxb:bindings>
+    <jxb:bindings multiple="true"
+            node="//xs:complexType[@name='TerminalDistanceInformation']">
+        <inheritance:implements>com.foursoft.harness.vec.common.StructuredPrimitive</inheritance:implements>
+    </jxb:bindings>
+    <jxb:bindings multiple="true"
+            node="//xs:complexType[@name='ReferenceSurfaceDefinition']">
+        <inheritance:implements>com.foursoft.harness.vec.common.StructuredPrimitive</inheritance:implements>
+    </jxb:bindings>
+    <jxb:bindings multiple="true" node="//xs:complexType[@name='FuseCharacteristic']">
+        <inheritance:implements>com.foursoft.harness.vec.common.StructuredPrimitive</inheritance:implements>
+    </jxb:bindings>
+    <jxb:bindings multiple="true" node="//xs:complexType[@name='NURBSControlPoint']">
+        <inheritance:implements>com.foursoft.harness.vec.common.StructuredPrimitive</inheritance:implements>
+    </jxb:bindings>
+    <jxb:bindings multiple="true" node="//xs:complexType[@name='Color']">
+        <inheritance:implements>com.foursoft.harness.vec.common.StructuredPrimitive</inheritance:implements>
+    </jxb:bindings>
+    <jxb:bindings multiple="true" node="//xs:complexType[@name='MassInformation']">
+        <inheritance:implements>com.foursoft.harness.vec.common.StructuredPrimitive</inheritance:implements>
+    </jxb:bindings>
+    <jxb:bindings multiple="true" node="//xs:complexType[@name='Material']">
+        <inheritance:implements>com.foursoft.harness.vec.common.StructuredPrimitive</inheritance:implements>
+    </jxb:bindings>
+    <jxb:bindings multiple="true" node="//xs:complexType[@name='NumericalValue']">
+        <inheritance:implements>com.foursoft.harness.vec.common.StructuredPrimitive</inheritance:implements>
+    </jxb:bindings>
+    <jxb:bindings multiple="true" node="//xs:complexType[@name='RobustnessProperties']">
+        <inheritance:implements>com.foursoft.harness.vec.common.StructuredPrimitive</inheritance:implements>
+    </jxb:bindings>
+    <jxb:bindings multiple="true" node="//xs:complexType[@name='Size']">
+        <inheritance:implements>com.foursoft.harness.vec.common.StructuredPrimitive</inheritance:implements>
+    </jxb:bindings>
+    <jxb:bindings multiple="true" node="//xs:complexType[@name='SoundDampingClass']">
+        <inheritance:implements>com.foursoft.harness.vec.common.StructuredPrimitive</inheritance:implements>
+    </jxb:bindings>
+    <jxb:bindings multiple="true" node="//xs:complexType[@name='TemperatureInformation']">
+        <inheritance:implements>com.foursoft.harness.vec.common.StructuredPrimitive</inheritance:implements>
+    </jxb:bindings>
+    <jxb:bindings multiple="true" node="//xs:complexType[@name='Tolerance']">
+        <inheritance:implements>com.foursoft.harness.vec.common.StructuredPrimitive</inheritance:implements>
+    </jxb:bindings>
+    <jxb:bindings multiple="true" node="//xs:complexType[@name='ValueRange']">
+        <inheritance:implements>com.foursoft.harness.vec.common.StructuredPrimitive</inheritance:implements>
+    </jxb:bindings>
+    <jxb:bindings multiple="true" node="//xs:complexType[@name='ValueWithUnit']">
+        <inheritance:implements>com.foursoft.harness.vec.common.StructuredPrimitive</inheritance:implements>
+    </jxb:bindings>
+    <jxb:bindings multiple="true" node="//xs:complexType[@name='MaterialComposition']">
+        <inheritance:implements>com.foursoft.harness.vec.common.StructuredPrimitive</inheritance:implements>
+    </jxb:bindings>
+    <jxb:bindings multiple="true" node="//xs:complexType[@name='MultiDimensionalValue']">
+        <inheritance:implements>com.foursoft.harness.vec.common.StructuredPrimitive</inheritance:implements>
+    </jxb:bindings>
+    <jxb:bindings multiple="true" node="//xs:complexType[@name='DataPoint']">
+        <inheritance:implements>com.foursoft.harness.vec.common.StructuredPrimitive</inheritance:implements>
+    </jxb:bindings>
+    <jxb:bindings multiple="true" node="//xs:complexType[@name='DataPointValue']">
+        <inheritance:implements>com.foursoft.harness.vec.common.StructuredPrimitive</inheritance:implements>
+    </jxb:bindings>
+</jxb:bindings>


### PR DESCRIPTION
## Pull Request

- [X] I have checked for similar PRs.
- [X] I have read the [contributing guidelines](https://github.com/4Soft-de/harness-model/blob/develop/.github/CONTRIBUTING.md).

### Changes

- [X] Code
- [ ] Documentation
- [ ] Other: 

### Description

This pull request introduces support for "StructuredPrimitive" types in the VEC model by adding a marker interface and updating the JAXB (XJB) binding process to ensure relevant model classes implement this interface. It also documents the new generation step in the build process and provides an initial generated binding file for VEC 2.2.0.

**StructuredPrimitive interface and binding integration:**

* Added the new `StructuredPrimitive` marker interface in `com.foursoft.harness.vec.common`, with documentation explaining its purpose and usage in the VEC model.
* Created a new XSLT script (`scripts/generate-structured-primitive-xjb-from-model.xsl`) to generate JAXB bindings that ensure all UML classes stereotyped as `StructuredPrimitive` implement the new interface.

**Build and documentation updates:**

* Updated the `README.md` in `vec2` resources to include instructions for running the new XSLT script as part of the model processing workflow.

**Generated bindings:**

* Added the generated `vec_2.2.0-structured-primitives.xjb` file, which binds a comprehensive list of complex types to implement the new `StructuredPrimitive` interface for VEC 2.2.0.