### PR TITLE
  Update Java baseline to JDK 21

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -33,11 +33,11 @@ jobs:
           # Disabling shallow clone is recommended for improving relevancy of reporting
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v5.5.0
         with:
-          distribution: 'adopt'
-          java-version: '17'
+          distribution: 'temurin'
+          java-version: '21'
           check-latest: true
           cache: 'maven'
       - name: Cache SonarCloud packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,11 +31,11 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v5.5.0
         with:
-          distribution: 'adopt'
-          java-version: '17'
+          distribution: 'temurin'
+          java-version: '21'
           check-latest: true
           cache: 'maven'
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }} # Value of the GPG private key to import

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Java CI with Maven](https://github.com/4Soft-de/harness-model/workflows/Java%20CI%20with%20Maven/badge.svg?branch=develop)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=4Soft-de_harness-model&metric=alert_status)](https://sonarcloud.io/dashboard?id=4Soft-de_harness-model)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-![Java17](https://img.shields.io/badge/java-17-blue)
+![Java21](https://img.shields.io/badge/java-21-blue)
 
 ## Repository Contents
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>17</java.version>
+        <java.version>21</java.version>
 
         <!-- Dependencies -->
         <jakarta.version>4.0.8</jakarta.version>


### PR DESCRIPTION
## Pull Request

- [X] I have checked for similar PRs.
- [X] I have read the [contributing guidelines](https://github.com/4Soft-de/harness-model/blob/develop/.github/CONTRIBUTING.md).

### Changes

- [X] Code
- [X] Documentation
- [ ] Other: 


### Description

Update Java baseline to JDK 21

Raises the project's minimum supported Java version from 17 to 21.

Changes

- pom.xml — java.version property 17 → 21. This single property drives maven-compiler-plugin's source/target for every module, so it's the sole language-level control.
- .github/workflows/maven.yml & .github/workflows/release.yml — CI and release now set up JDK 21. Also switched distribution from the deprecated adopt id to its successor temurin.
- README.md — Java version badge updated to 21.

Verification

- ./mvnw clean compile builds all modules cleanly against the Java 21 target.

⚠️ Version bump note

This is a consumer-facing breaking change: artifacts built from this branch will no longer run on JDK 17. Under semver, the next release should be a major version bump (→ 6.0.0) rather than continuing the 5.x line. The parent POM is currently at 5.6.1-SNAPSHOT; the release version should be set accordingly at release time.