### PR TITLE
feat: add method to retrieve all custom properties by type and propertyType

### DIFF
--- a/vec/vec-common/src/main/java/com/foursoft/harness/vec/common/HasCustomProperties.java
+++ b/vec/vec-common/src/main/java/com/foursoft/harness/vec/common/HasCustomProperties.java
@@ -53,4 +53,17 @@ public interface HasCustomProperties<X extends HasPropertyType> {
                 .collect(StreamUtils.findOneOrNone());
     }
 
+    /**
+     * Filters the list of CustomProperties by type and key.
+     *
+     * @param type         derived classifiers
+     * @param propertyType defines the meaning of the value.
+     * @return all properties with the given type and key.
+     */
+    default <T extends X> List<T> getCustomProperties(final Class<T> type, final String propertyType) {
+        return DelegationUtils.getFromListWithTypeAsStream(getCustomProperties(), type)
+                .filter(c -> c.getPropertyType().equals(propertyType))
+                .toList();
+    }
+
 }


### PR DESCRIPTION
## Pull Request

- [X] I have checked for similar PRs.
- [X] I have read the [contributing guidelines](https://github.com/4Soft-de/harness-model/blob/develop/.github/CONTRIBUTING.md).

### Changes

- [X] Code
- [ ] Documentation
- [ ] Other: 

### Description

The HasCustomProperties interface previously only exposed getCustomProperty, which returns a single value for a given type and propertyType. Add a list-returning getCustomProperties(type, propertyType) counterpart so callers can retrieve all matching values.
