### PR TITLE
fix: Compatibility lib stumbles on overloaded JavaBean getters.

### DIFF
--- a/compatibility/compatibility-core/src/main/java/com/foursoft/harness/compatibility/core/wrapper/ReflectionBasedWrapper.java
+++ b/compatibility/compatibility-core/src/main/java/com/foursoft/harness/compatibility/core/wrapper/ReflectionBasedWrapper.java
@@ -247,7 +247,7 @@ public class ReflectionBasedWrapper implements InvocationHandler, CompatibilityW
         try {
             targetMethodResult = targetMethod.invoke(target, objects);
         } catch (final IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
-            final String args = Arrays.stream(objects)
+            final String args = objects == null ? "[]" : Arrays.stream(objects)
                     .map(Object::toString)
                     .collect(Collectors.joining(", "));
             final String errorMsg = String.format("Cannot invoke method %s on class %s with args '%s'.",

--- a/vec/vec-common/src/main/java/com/foursoft/harness/vec/common/HasCustomProperties.java
+++ b/vec/vec-common/src/main/java/com/foursoft/harness/vec/common/HasCustomProperties.java
@@ -60,7 +60,7 @@ public interface HasCustomProperties<X extends HasPropertyType> {
      * @param propertyType defines the meaning of the value.
      * @return all properties with the given type and key.
      */
-    default <T extends X> List<T> getCustomProperties(final Class<T> type, final String propertyType) {
+    default <T extends X> List<T> getCustomPropertiesWithType(final Class<T> type, final String propertyType) {
         return DelegationUtils.getFromListWithTypeAsStream(getCustomProperties(), type)
                 .filter(c -> c.getPropertyType().equals(propertyType))
                 .toList();


### PR DESCRIPTION
## Pull Request

- [X] I have checked for similar PRs.
- [X] I have read the [contributing guidelines](https://github.com/4Soft-de/harness-model/blob/develop/.github/CONTRIBUTING.md).

### Changes

- [X] Code
- [ ] Documentation
- [ ] Other: 

### Description

Added new method to `HasCustomProperties` with the last commit. This lead to problems with the compat-lib