### PR TITLE
feat: add typed navigation API in new traversal package

### DIFF
--- a/compatibility/compatibility-vec11to12/src/main/java/com/foursoft/harness/compatibility/vec11to12/wrapper/vec11to12/specification/wireprotection/StripeSpecificationWrapper.java
+++ b/compatibility/compatibility-vec11to12/src/main/java/com/foursoft/harness/compatibility/vec11to12/wrapper/vec11to12/specification/wireprotection/StripeSpecificationWrapper.java
@@ -28,10 +28,13 @@ package com.foursoft.harness.compatibility.vec11to12.wrapper.vec11to12.specifica
 import com.foursoft.harness.compatibility.core.CompatibilityContext;
 import com.foursoft.harness.compatibility.core.wrapper.Wraps;
 import com.foursoft.harness.compatibility.vec11to12.wrapper.vec11to12.DefaultWrapper;
+import com.foursoft.harness.vec.common.HasCustomProperties;
+import com.foursoft.harness.vec.common.traversal.Navigations;
+import com.foursoft.harness.vec.common.traversal.SingleNavigation;
 import com.foursoft.harness.vec.v12x.VecCustomProperty;
 import com.foursoft.harness.vec.v12x.VecNumericalValue;
 import com.foursoft.harness.vec.v12x.VecNumericalValueProperty;
-import com.foursoft.harness.vec.v12x.navigations.CustomPropertyNavs;
+import com.foursoft.harness.vec.v12x.traversal.CustomProperties;
 
 import java.lang.reflect.Method;
 import java.util.List;
@@ -45,6 +48,13 @@ public class StripeSpecificationWrapper extends DefaultWrapper {
 
     private static final String GET_CUSTOM_PROPERTIES_METHOD_NAME = "getCustomProperties";
     private static final String THICKNESS_CUSTOM_PROPERTY = "Thickness";
+
+    private static final SingleNavigation<HasCustomProperties<VecCustomProperty>, VecNumericalValue> THICKNESS =
+            CustomProperties.toCustomProperties()
+                    .filter(property -> THICKNESS_CUSTOM_PROPERTY.equalsIgnoreCase(property.getPropertyType()))
+                    .ofType(VecNumericalValueProperty.class)
+                    .atMostOne()
+                    .then(Navigations.nullable(VecNumericalValueProperty::getValue));
 
     private VecNumericalValue thickness;
 
@@ -87,13 +97,9 @@ public class StripeSpecificationWrapper extends DefaultWrapper {
 
     private VecNumericalValue getThickness() {
         if (thickness == null) {
-            final List<VecCustomProperty> vecCustomProperties =
+            final List<VecCustomProperty> customProperties =
                     wrapList(GET_CUSTOM_PROPERTIES_METHOD_NAME, VecCustomProperty.class);
-            thickness = CustomPropertyNavs.customPropertyOfType(THICKNESS_CUSTOM_PROPERTY,
-                                                                VecNumericalValueProperty.class)
-                    .apply(vecCustomProperties)
-                    .map(VecNumericalValueProperty::getValue)
-                    .orElse(null);
+            thickness = THICKNESS.orElseNull(() -> customProperties);
         }
 
         return thickness;

--- a/docs/api-evolution.md
+++ b/docs/api-evolution.md
@@ -1,0 +1,80 @@
+# API Evolution
+
+## Overview
+
+Every module in this repository is published to Maven Central and exports its packages via JPMS, so
+essentially all of it is public API. At the same time, in-repo usage of that API is thin: several
+public packages have no in-repo callers and no test coverage at all. A signature change can therefore
+pass the whole build here and still break every downstream consumer.
+
+This document records the patterns used to change API anyway.
+
+## How It Works
+
+### Version-suffixed modules
+
+The primary coexistence mechanism operates at the artifact level, not the class level. Incompatible
+generations of a model live side by side as separate modules with separate root packages and separate
+JPMS module names — `vec-v113` / `vec-v12x` / `vec-v2x`, `kbl-v24` / `kbl-v25`. Old versions are kept
+indefinitely rather than deprecated, because they model a different version of an external standard,
+not an older idea of the same thing.
+
+Bridging between generations is done by dedicated modules (`compatibility/*`) using dynamic-proxy
+wrappers, and by dedicated converter modules (`kbl2vec`), never by compatibility shims inside the
+model modules.
+
+### New package, deprecate, delegate
+
+When a *concept* rather than a model version is replaced, the replacement is introduced as a **new
+package inside the same module**, and the old one is deprecated in place. The steps:
+
+1. **Build the replacement under a clearly distinct package name.** Distinct means a different word,
+   not a singular/plural or numeric variant of the old name, so that both can be imported without
+   ambiguity for as long as they coexist.
+2. **Mark the superseded classes and methods `@Deprecated(forRemoval = true)`**, each with a javadoc
+   `@deprecated` line naming its concrete replacement. This is the established form in this
+   repository; `since` is conventionally omitted.
+3. **Rewrite the deprecated bodies to delegate to the replacement.** No logic is left behind, so
+   there is a single source of truth and the two generations cannot drift apart while both exist.
+   Deprecated signatures are preserved exactly, adapting shapes at the boundary where the new API
+   uses a different result type.
+4. **Add characterisation tests asserting old and new agree**, marked
+   `@SuppressWarnings({"deprecation", "removal"})`. These are the safety net for the delegation
+   rewrite and are deleted together with the deprecated classes.
+5. **Port incrementally.** One catalog, class or subject area per commit rather than a big-bang
+   rewrite, so each step is reviewable and the build stays green throughout.
+6. **Remove in a future major release.**
+
+The delegation direction is deliberately old → new. Making the deprecated class the implementation
+and the new one a wrapper would keep the old semantics as the source of truth and prevent the new API
+from fixing anything.
+
+## Key Design Decisions
+
+- **Tests accompany the new API, not the old one.** Because the legacy API is typically untested,
+  writing tests for the replacement plus old-versus-new characterisation tests is what makes the
+  delegation rewrite verifiable at all. This is the point at which coverage gets introduced.
+- **Deprecation is scoped to what has actually been replaced.** Classes are deprecated as they are
+  ported, not upfront, so consumers never get a deprecation warning without a replacement to move to.
+- **Deprecation warnings are kept at zero outside the suppressed tests.** Any in-repo caller of a
+  newly deprecated API is migrated in the same change, so the warnings that remain are meaningful.
+- **`forRemoval = true` needs `@SuppressWarnings("removal")`.** `removal` is a separate javac lint
+  category from `deprecation`; suppressing only the latter leaves the warnings in place. Both are
+  needed on intentional uses of a deprecated-for-removal API.
+- **Behaviour-preserving beats correct, in the deprecated path.** Where the replacement fixes a flaw,
+  the deprecated method keeps its original observable behaviour. Consumers get the fix by migrating,
+  not by upgrading.
+
+## Relationships
+
+- **[VEC Navigation API](vec-navigation-api.md)** — the first concept replaced with this pattern; the
+  legacy `navigations` catalogs delegate to the typed `traversal` catalogs.
+- **`compatibility/*` modules** — the cross-version counterpart of this pattern, bridging different
+  model generations rather than different generations of a hand-written API.
+
+## Notes
+
+There is no formally documented deprecation policy or semantic-versioning statement in the
+repository. Observed practice is that breaking changes land in major releases — version 5.x was the
+Jakarta-namespace break — and that `.github/CONTRIBUTING.md` governs commit and code conventions but
+says nothing about API compatibility.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,21 @@
+# Architecture Documentation
+
+Abstract documentation of the architectural concepts, patterns and decisions in this repository.
+These documents describe *what* the parts do and *why* they are built that way; the module `README.md`
+files cover usage and the code covers the details.
+
+## VEC
+
+- [VEC Navigation API](vec-navigation-api.md) — reusable, composable ways through the VEC model: the
+  typed `Navigation` interface hierarchy, the per-version catalogs, and the legacy `*Navs` generation.
+
+## Cross-cutting
+
+- [API Evolution](api-evolution.md) — how public API is replaced without breaking downstream
+  consumers: version-suffixed modules, and the deprecate-and-delegate pattern for superseded concepts.
+
+## Module-level documents
+
+Some modules keep their own in-depth architecture document next to the code:
+
+- [`kbl2vec/ARCHITECTURE.md`](../kbl2vec/ARCHITECTURE.md) — the two-phase KBL-to-VEC conversion.

--- a/docs/vec-navigation-api.md
+++ b/docs/vec-navigation-api.md
@@ -79,7 +79,7 @@ over the accumulated elements, and are grouped into their own catalogs — `Loca
 reductions, not navigations:
 
 ```java
-Descriptions.descriptions().collect(LocalizedStrings.valueIn(VecLanguageCode.DE))
+Descriptions.toDescriptions().collect(LocalizedStrings.valueIn(VecLanguageCode.DE))
 ```
 
 Recognising a reduction matters for modelling, not just for tidiness. Before `collect` existed, the
@@ -96,10 +96,42 @@ static factory methods returning the navigation interfaces. A catalog contribute
 caller composes them into a path with the operators above. Reductions are grouped the same way, in
 catalogs of their own.
 
+### Naming the factories
+
+**A navigation that is a pure structural step is named `toX()`; one that selects a particular result
+keeps a noun phrase.** The dividing line is whether the result depends on anything beyond the model's
+own structure:
+
+| | Named | Because |
+| --- | --- | --- |
+| `Placements.toLocations()` | `to…` | follows an association |
+| `PlaceableElementRoles.toOnWayPlacements()` | `to…` | association plus a narrowing along the type hierarchy |
+| `ViewItems.toPlaceableElementRole()` | `to…` | association, reduced to the expected single result |
+| `Descriptions.descriptionIn(DE)` | noun | a domain value picks the result |
+| `Descriptions.germanDescription()` | noun | a preset of a selector, so it inherits its naming |
+| `LocalizedStrings.valueIn(DE)` | noun | a reduction, not a navigation at all |
+
+The `to` earns its place at the chain's start, where no operator precedes it, and keeps the whole chain
+reading as one sentence — *"view items **to** placeable element role, then **to** on-way placements,
+then **to** locations"*:
+
+```java
+ViewItems.toPlaceableElementRole()
+        .then(PlaceableElementRoles.toOnWayPlacements())
+        .then(Placements.toLocations())
+```
+
+Note that the sibling `predicates` catalog goes the other way: commit `07a8bd1a` deliberately stripped
+the `is` prefix from every `VecPredicates` method, because `filter(…)` already supplies the verb. The
+difference is that `is` was purely redundant with `Predicate`, whereas `to` states a direction that a
+bare noun leaves the reader to infer. Selectors do not state a direction — they name a thing — which is
+why they keep the predicates style.
+
 ### Catalog organisation
 
 **A navigation belongs to the catalog of its source type `S`.** The catalog is named after that type
-in plural with the `Vec` prefix dropped, and method names state only the *target*, never the source.
+in plural with the `Vec` prefix dropped, and method names state only the *target*, never the source —
+see [Naming the factories](#naming-the-factories) above.
 
 Granularity is the **nearest model supertype** that has navigations, so a type shares a catalog with
 its subtypes, and `Has*` mixin interfaces are legitimate source types with their own catalogs. A
@@ -115,7 +147,7 @@ catalog enumerates everything reachable. Two consequences of the rule are worth 
   `parentDocumentVersionOfOccurrence()`. Since the factories take no arguments, they cannot be
   overloaded, which means a catalog mixing source types is *forced* to encode the source in its method
   names — the legacy `PartOccurrenceOrUsageNavs` shows the result.
-- **Where a family shares a target, the navigation belongs at the family level.** `Placements.locations()`
+- **Where a family shares a target, the navigation belongs at the family level.** `Placements.toLocations()`
   starts at `VecPlacement` and resolves the subtype internally, rather than offering separate
   `onPointLocations()`/`onWayLocations()` entries that would reintroduce source-encoded names.
 
@@ -134,12 +166,12 @@ order the model is traversed:
 
 ```java
 // as a catalog method taking a navigation — nests, reads inside-out
-ViewItems.locations(PlaceableElementRoles.onWayPlacements().then(Placements.locations()))
+ViewItems.locations(PlaceableElementRoles.toOnWayPlacements().then(Placements.toLocations()))
 
 // composed by the caller — reads in traversal order, no extra API
-ViewItems.placeableElementRole()
-        .then(PlaceableElementRoles.onWayPlacements())
-        .then(Placements.locations())
+ViewItems.toPlaceableElementRole()
+        .then(PlaceableElementRoles.toOnWayPlacements())
+        .then(Placements.toLocations())
 ```
 
 Two kinds of parameter remain legitimate, because neither is expressible by chaining:
@@ -148,8 +180,8 @@ Two kinds of parameter remain legitimate, because neither is expressible by chai
   `Descriptions.descriptionIn(VecLanguageCode)` or the property type in
   `LocalizedStrings.typedValueBy(String, VecLanguageCode)`.
 - **Nothing at all**: zero-argument named presets are vocabulary, not indirection, and are encouraged.
-  `PlaceableElementRoles.onPointPlacements()` and `Descriptions.germanDescription()` are just
-  `placements().ofType(VecOnPointPlacement.class)` and `descriptionIn(DE)`, but they name a concept the
+  `PlaceableElementRoles.toOnPointPlacements()` and `Descriptions.germanDescription()` are just
+  `toPlacements().ofType(VecOnPointPlacement.class)` and `descriptionIn(DE)`, but they name a concept the
   domain actually has.
 
 A navigation-typed parameter is only justified when the catalog wraps logic *around* the passed
@@ -157,9 +189,9 @@ navigation that the caller could not otherwise express — not when the body is 
 
 The same applies **inside** a catalog. Where a navigation is just a sequence of getter steps and type
 narrowings, it is composed from the operators rather than written as a stream pipeline, so that the
-implementation reads like the path it describes — `ViewItems.placeableElementRole()` is the reference
+implementation reads like the path it describes — `ViewItems.toPlaceableElementRole()` is the reference
 example. Raw stream code and hand-written lambdas stay appropriate for *leaf* steps, where there is
-genuine logic and nothing to compose: `Placements.locations()` dispatches on the placement subtype, and
+genuine logic and nothing to compose: `Placements.toLocations()` dispatches on the placement subtype, and
 the body of a reduction such as `LocalizedStrings.valueIn(…)` weighs the elements against each other.
 Forcing those through the operators would make them longer, not clearer.
 

--- a/docs/vec-navigation-api.md
+++ b/docs/vec-navigation-api.md
@@ -50,17 +50,44 @@ smaller ones rather than by writing new traversal code:
 `nullable`, `stream`, `collection`). It is the intended entry point of a chain: a plain getter
 becomes a navigation, and operators take it from there.
 
-Concrete navigations are grouped into **catalogs** — one final class per subject area, named after
-the plural of the domain concept (`Descriptions`, `Placements`), with a private constructor and
-static factory methods returning the navigation interfaces. Because the factories return the
-interface type and not a raw `Function`, a navigation can be *passed to* another navigation as a
-typed parameter. That is what makes higher-order navigations expressible.
+Concrete navigations are grouped into **catalogs**: final classes with a private constructor and
+static factory methods returning the navigation interfaces. Because the factories return the interface
+type and not a raw `Function`, a navigation can be *passed to* another navigation as a typed
+parameter. That is what makes higher-order navigations expressible.
+
+### Catalog organisation
+
+**A navigation belongs to the catalog of its source type `S`.** The catalog is named after that type
+in plural with the `Vec` prefix dropped, and method names state only the *target*, never the source.
+
+Granularity is the **nearest model supertype** that has navigations, so a type shares a catalog with
+its subtypes, and `Has*` mixin interfaces are legitimate source types with their own catalogs. A
+catalog is split only once it grows unwieldy. This bounds the number of catalogs — the model has
+several hundred classes — without making the lookup ambiguous.
+
+That gives a mechanical answer to *"I am holding an `x`, where can I go from here?"*: the navigation
+is in the catalog named after `x`'s type or one of its supertypes or mixins, and autocomplete on that
+catalog enumerates everything reachable. Two consequences of the rule are worth stating explicitly:
+
+- **The source never appears in a method name.** A catalog with a single source type does not need to
+  disambiguate, so `parentDocumentVersion()` stays as it is instead of becoming
+  `parentDocumentVersionOfOccurrence()`. Since the factories take no arguments, they cannot be
+  overloaded, which means a catalog mixing source types is *forced* to encode the source in its method
+  names — the legacy `PartOccurrenceOrUsageNavs` shows the result.
+- **Where a family shares a target, the navigation belongs at the family level.** `Placements.locations()`
+  starts at `VecPlacement` and resolves the subtype internally, rather than offering separate
+  `onPointLocations()`/`onWayLocations()` entries that would reintroduce source-encoded names.
+
+The rule deliberately optimises the "from" direction. *"Which navigations lead to a `VecLocation`?"* is
+not answerable from the class layout, because a target is reachable from many sources while a
+navigation has exactly one source; that direction is served by documentation and by search, not by
+where the code lives.
 
 ### The legacy API (`navigations`)
 
-The older generation follows the same catalog idea — one final class per subject area, named
-`<Concept>Navs`, with static factory methods — but every factory returns a raw
-`java.util.function.Function`. Consequences:
+The older generation uses catalogs too — final classes named `<Concept>Navs` with static factory
+methods — but every factory returns a raw `java.util.function.Function`, and the catalogs follow no
+single grouping rule. Consequences:
 
 - A navigation has no type identity and cannot be distinguished from any other function.
 - Result shapes are inconsistent across the catalogs: bare values, `Optional`, `List` and `Stream`
@@ -68,6 +95,14 @@ The older generation follows the same catalog idea — one final class per subje
 - Composition is limited to `Function#andThen`, and a navigation taken as a parameter has to be
   typed as a concrete raw `Function`. This is not merely inelegant: it made
   `PlacementNavs.locationsOf` document a usage its own parameter type rejected.
+- **Three competing grouping criteria coexist**, so there is no way to predict which catalog holds a
+  given navigation. Most catalogs group by source type (`DocumentVersionNavs`, `ContentNavs`,
+  `SegmentNavs`, `ConfigurableElementNavs`); some group by *target* concept and therefore mix unrelated
+  source types (`PlacementNavs`, `DescriptionNavs`, `CustomPropertyNavs`); `SpecificationNavs` groups by
+  types whose *name* ends in `Specification`; and `VecNavs` is a catch-all. The visible symptoms are
+  `parentDocumentNumber()` existing in three catalogs, `parentDocumentVersion()` in three,
+  `geometryNode2dBy`/`geometryNode3dBy` in two, and the `OfUsage`/`OfOccurrence` method-name suffixes
+  in `PartOccurrenceOrUsageNavs`.
 
 ## Key Design Decisions
 
@@ -84,6 +119,10 @@ The older generation follows the same catalog idea — one final class per subje
 - **Abstraction in `vec-common`, catalogs per version module.** The interfaces are
   version-independent and therefore shared, matching how the `Has*` mixin interfaces are already
   organised. The catalogs reference version-specific model classes and must stay per module.
+- **Catalogs are keyed on the source type, not the target.** A navigation has exactly one source but a
+  target is reachable from many sources, so only the source yields a total, unambiguous assignment. It
+  also matches the question developers actually ask at the call site, and it is what frees method names
+  from having to name the source.
 - **A distinct package name, not a singular/plural pair.** `traversal` was chosen over
   `navigation` precisely because the old package is called `navigations`; while both exist, a
   singular/plural pair would create permanent import ambiguity.
@@ -138,8 +177,23 @@ they are public API.
 | Module | Typed catalogs | Legacy catalogs |
 | --- | --- | --- |
 | `vec-common` | interfaces and factory | — |
-| `vec-v2x` | `Descriptions`, `Placements` | 10 `*Navs`, two of them deprecated and delegating |
+| `vec-v2x` | 5 catalogs, see below | 10 `*Navs`, two of them deprecated and delegating |
 | `vec-v12x` | — | 10 `*Navs` |
 | `vec-v113` | — | none |
+
+The `vec-v2x` catalogs and their source types:
+
+| Catalog | Source type `S` |
+| --- | --- |
+| `Descriptions` | `HasDescription<? extends VecAbstractLocalizedString>` |
+| `LocalizedStrings` | `List<? extends VecAbstractLocalizedString>` |
+| `Placements` | `VecPlacement` (and its on-point/on-way subtypes) |
+| `PlaceableElementRoles` | `VecPlaceableElementRole` |
+| `ViewItems` | `HasOccurrenceOrUsages` |
+
+Note that the two legacy catalogs ported so far each split across several of these, because they
+grouped by target concept: `DescriptionNavs` became `Descriptions` plus `LocalizedStrings`, and
+`PlacementNavs` became `Placements`, `PlaceableElementRoles` and `ViewItems`. Expect the same when
+porting the remaining catalogs — the mapping from old catalog to new is not one-to-one.
 
 The remaining `vec-v2x` catalogs are ported one at a time; `vec-v12x` follows afterwards.

--- a/docs/vec-navigation-api.md
+++ b/docs/vec-navigation-api.md
@@ -126,6 +126,14 @@ Two kinds of parameter remain legitimate, because neither is expressible by chai
 A navigation-typed parameter is only justified when the catalog wraps logic *around* the passed
 navigation that the caller could not otherwise express — not when the body is pure composition.
 
+The same applies **inside** a catalog. Where a navigation is just a sequence of getter steps and type
+narrowings, it is composed from the operators rather than written as a stream pipeline, so that the
+implementation reads like the path it describes — `ViewItems.placeableElementRole()` is the reference
+example. Raw stream code and hand-written lambdas stay appropriate for *leaf* steps, where there is
+genuine logic and nothing to compose: `Placements.locations()` dispatches on the placement subtype, and
+`LocalizedStrings.stringIn(…)` applies rules that depend on the size of the list. Forcing those through
+the operators would make them longer, not clearer.
+
 ### The legacy API (`navigations`)
 
 The older generation uses catalogs too — final classes named `<Concept>Navs` with static factory

--- a/docs/vec-navigation-api.md
+++ b/docs/vec-navigation-api.md
@@ -51,9 +51,8 @@ smaller ones rather than by writing new traversal code:
 becomes a navigation, and operators take it from there.
 
 Concrete navigations are grouped into **catalogs**: final classes with a private constructor and
-static factory methods returning the navigation interfaces. Because the factories return the interface
-type and not a raw `Function`, a navigation can be *passed to* another navigation as a typed
-parameter. That is what makes higher-order navigations expressible.
+static factory methods returning the navigation interfaces. A catalog contributes the *steps*; the
+caller composes them into a path with the operators above.
 
 ### Catalog organisation
 
@@ -82,6 +81,37 @@ The rule deliberately optimises the "from" direction. *"Which navigations lead t
 not answerable from the class layout, because a target is reachable from many sources while a
 navigation has exactly one source; that direction is served by documentation and by search, not by
 where the code lives.
+
+### Catalogs hold steps, callers compose paths
+
+**A catalog factory must not take a parameter that it merely forwards to one of the interface's own
+operators.** If `Catalog.x(arg)` would be nothing but `Catalog.y().someOperator(arg)`, it does not
+belong in the catalog: it adds API surface and an argument without adding meaning, and it forces the
+reader inside-out. Composition belongs at the call site, where the chain reads left to right in the
+order the model is traversed:
+
+```java
+// as a catalog method taking a navigation — nests, reads inside-out
+ViewItems.locations(PlaceableElementRoles.onWayPlacements().thenEach(Placements.locations()))
+
+// composed by the caller — reads in traversal order, no extra API
+ViewItems.placeableElementRole()
+        .thenEach(PlaceableElementRoles.onWayPlacements())
+        .thenEach(Placements.locations())
+```
+
+Two kinds of parameter remain legitimate, because neither is expressible by chaining:
+
+- **Domain values that feed the traversal logic**, such as the language in
+  `LocalizedStrings.stringIn(VecLanguageCode)` or the property type in
+  `LocalizedStrings.typedStringBy(String, VecLanguageCode)`.
+- **Nothing at all**: zero-argument named presets are vocabulary, not indirection, and are encouraged.
+  `PlaceableElementRoles.onPointPlacements()` and `Descriptions.germanDescription()` are just
+  `placements().ofType(VecOnPointPlacement.class)` and `descriptionIn(DE)`, but they name a concept the
+  domain actually has.
+
+A navigation-typed parameter is only justified when the catalog wraps logic *around* the passed
+navigation that the caller could not otherwise express — not when the body is pure composition.
 
 ### The legacy API (`navigations`)
 
@@ -126,10 +156,11 @@ single grouping rule. Consequences:
 - **A distinct package name, not a singular/plural pair.** `traversal` was chosen over
   `navigation` precisely because the old package is called `navigations`; while both exist, a
   singular/plural pair would create permanent import ambiguity.
-- **Higher-order navigations take a navigation, not a placement.** Where a navigation needs a
-  sub-path supplied by the caller, the parameter is a `MultiNavigation`/`SingleNavigation` describing
-  the whole remaining way. This is more general than accepting an intermediate element type and it is
-  what allows one navigation to serve several kinds of placement.
+- **Catalogs expose steps, not composed paths.** Composition happens at the call site, so a catalog
+  factory never takes a parameter it would only forward to one of the interface's operators. The chained
+  form reads in traversal order and needs no API surface; a wrapper method reads inside-out and hides
+  nothing. The composition operators on the interface are what make this possible — without them, the
+  wrapper method would be the only option, which is the position the legacy API is in.
 
 ## Relationships
 

--- a/docs/vec-navigation-api.md
+++ b/docs/vec-navigation-api.md
@@ -1,0 +1,145 @@
+# VEC Navigation API
+
+## Overview
+
+The VEC model is a large, generated JAXB object graph. Getting from one element to a related one
+often takes several steps — filtering by type, following a collection, picking the single expected
+element. The navigation API packages those recurring ways through the model as named, reusable,
+composable objects instead of leaving them spelled out at every call site.
+
+There are currently **two generations** of this API. The typed `traversal` API is the target state;
+the older `navigations` packages remain in place for existing consumers. See
+[API Evolution](api-evolution.md) for how the two coexist.
+
+> **Naming caution:** "navigation" means two unrelated things in this repository. The `navext` XJC
+> plugin generates *back-reference and parent accessors* into the model (`@XmlBackReference`,
+> `@XmlParent`). The navigation API described here is a hand-written layer of *navigation functions*
+> on top of the generated model. They are unrelated concepts that happen to share a word.
+
+## How It Works
+
+### The typed API (`traversal`)
+
+The abstraction lives once in `vec-common`; the concrete navigations live per VEC version module.
+
+A navigation is a function from a source element to a result, expressed through a small interface
+hierarchy:
+
+- `Navigation<S, T>` — the base type, extending `java.util.function.Function<S, T>`. `apply` remains
+  the single abstract method, so lambdas work and a navigation can be handed to any API expecting a
+  `Function` (`Stream#map`, `Stream#flatMap`, …). It mainly serves as a base type and as an escape
+  hatch for result shapes the sub types do not cover.
+- `SingleNavigation<S, T>` — a navigation to *at most one* element, so the result is an `Optional`.
+  An absent target is part of the contract rather than a `null` return value.
+- `MultiNavigation<S, T>` — a navigation to *any number* of elements, so the result is a `Stream`.
+  A fresh stream is produced on every application, which keeps the navigation lazy and reusable.
+
+Both sub types carry composition operators as default methods, so navigations are built by combining
+smaller ones rather than by writing new traversal code:
+
+| Operator | Meaning |
+| --- | --- |
+| `then` | continue with a single-valued navigation |
+| `thenEach` | continue with a multi-valued navigation |
+| `filter` | keep only elements matching a predicate |
+| `ofType` | narrow the navigation to a sub type |
+| `atMostOne` | reduce many results to at most one |
+| `asMulti` / `asList` | convert between result shapes |
+
+`Navigations` is the factory that lifts ordinary model getters into navigations (`optional`,
+`nullable`, `stream`, `collection`). It is the intended entry point of a chain: a plain getter
+becomes a navigation, and operators take it from there.
+
+Concrete navigations are grouped into **catalogs** — one final class per subject area, named after
+the plural of the domain concept (`Descriptions`, `Placements`), with a private constructor and
+static factory methods returning the navigation interfaces. Because the factories return the
+interface type and not a raw `Function`, a navigation can be *passed to* another navigation as a
+typed parameter. That is what makes higher-order navigations expressible.
+
+### The legacy API (`navigations`)
+
+The older generation follows the same catalog idea — one final class per subject area, named
+`<Concept>Navs`, with static factory methods — but every factory returns a raw
+`java.util.function.Function`. Consequences:
+
+- A navigation has no type identity and cannot be distinguished from any other function.
+- Result shapes are inconsistent across the catalogs: bare values, `Optional`, `List` and `Stream`
+  all occur, and some navigations return `null` for an absent target.
+- Composition is limited to `Function#andThen`, and a navigation taken as a parameter has to be
+  typed as a concrete raw `Function`. This is not merely inelegant: it made
+  `PlacementNavs.locationsOf` document a usage its own parameter type rejected.
+
+## Key Design Decisions
+
+- **A dedicated interface instead of a raw `Function`.** The interface is what makes navigations a
+  first-class concept: it carries the composition operators, gives the type a name, and lets a
+  navigation be a typed parameter of another navigation. Extending `Function` keeps full
+  interoperability with the streams and APIs that already exist.
+- **`apply` stays the single abstract method.** A domain-named method such as `from` is added as a
+  default rather than as a second abstract method, so the interfaces remain functional interfaces
+  and lambda-implementable.
+- **Result shape is part of the type.** `SingleNavigation` always yields `Optional`,
+  `MultiNavigation` always yields `Stream`. Callers no longer need to know per navigation whether
+  absence is signalled by `null`, an empty `Optional` or an empty collection.
+- **Abstraction in `vec-common`, catalogs per version module.** The interfaces are
+  version-independent and therefore shared, matching how the `Has*` mixin interfaces are already
+  organised. The catalogs reference version-specific model classes and must stay per module.
+- **A distinct package name, not a singular/plural pair.** `traversal` was chosen over
+  `navigation` precisely because the old package is called `navigations`; while both exist, a
+  singular/plural pair would create permanent import ambiguity.
+- **Higher-order navigations take a navigation, not a placement.** Where a navigation needs a
+  sub-path supplied by the caller, the parameter is a `MultiNavigation`/`SingleNavigation` describing
+  the whole remaining way. This is more general than accepting an intermediate element type and it is
+  what allows one navigation to serve several kinds of placement.
+
+## Relationships
+
+- **[API Evolution](api-evolution.md)** — how the legacy `navigations` catalogs are deprecated and
+  delegated to their replacements while both generations coexist.
+- **`Has*` mixin interfaces** (`vec-common`) — `HasDescription`, `HasCustomProperties`, `HasRoles`,
+  `HasSpecifications`, … are the version-independent source types that navigations accept, which is
+  what lets one navigation apply across many model classes.
+- **`StreamUtils`** (`vec-common`) — supplies the traversal primitives the navigations and operators
+  build on, notably the "expect at most one" collector used by `atMostOne`.
+- **`predicates`** (per version module) — reusable `Predicate` factories, the sibling concept to
+  navigations; used as arguments to `filter`.
+- **`navext`** — generates the back-reference and parent accessors that navigations against the
+  parent direction depend on. Navigations requiring them are annotated with `@RequiresBackReferences`,
+  since they only work on a model read with back references enabled.
+- **`visitor`** (per version module) — the alternative traversal mechanism, for walking the whole
+  model rather than following a specific known path.
+
+## File Locations
+
+```
+vec/vec-common/src/main/java/com/foursoft/harness/vec/common/
+├── traversal/                    ← the abstraction (version-independent)
+│   ├── Navigation.java
+│   ├── SingleNavigation.java
+│   ├── MultiNavigation.java
+│   └── Navigations.java
+├── util/StreamUtils.java         ← traversal primitives
+├── annotations/RequiresBackReferences.java
+└── Has*.java                     ← mixin source types
+
+vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/
+├── traversal/                    ← typed catalogs
+└── navigations/                  ← legacy catalogs (deprecated for removal)
+
+vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/
+└── navigations/                  ← legacy catalogs, not yet ported
+```
+
+Both packages are exported in each module's `module-info.java` and published to Maven Central, so
+they are public API.
+
+## Migration Status
+
+| Module | Typed catalogs | Legacy catalogs |
+| --- | --- | --- |
+| `vec-common` | interfaces and factory | — |
+| `vec-v2x` | `Descriptions`, `Placements` | 10 `*Navs`, two of them deprecated and delegating |
+| `vec-v12x` | — | 10 `*Navs` |
+| `vec-v113` | — | none |
+
+The remaining `vec-v2x` catalogs are ported one at a time; `vec-v12x` follows afterwards.

--- a/docs/vec-navigation-api.md
+++ b/docs/vec-navigation-api.md
@@ -42,7 +42,8 @@ smaller ones rather than by writing new traversal code:
 | `then` | continue with the next step, overloaded on its kind |
 | `filter` | keep only elements matching a predicate |
 | `ofType` | narrow the navigation to a sub type |
-| `atMostOne` | reduce many results to at most one |
+| `collect` | reduce many results to at most one, with given rules |
+| `atMostOne` | the most common reduction: expect a single result |
 | `asMulti` / `asList` | convert between result shapes |
 
 `then` is **overloaded on the kind of the following step** rather than split into `then`/`thenEach`
@@ -63,9 +64,37 @@ One consequence of the overload is worth knowing: since both kinds are functiona
 — the intended form anyway — or use an exact method reference or an explicitly typed lambda, all of
 which resolve. `SingleNavigationTest` pins these forms.
 
+### Reductions
+
+Going from many elements to one is not always "expect a single result". Which of several localized
+strings is *the* description, for instance, follows rules over the strings as a whole — a lone untyped
+string counts regardless of its language, but among several the typed ones are ignored. No sequence of
+filters and mappings expresses that.
+
+`collect` is therefore the general `Multi → Single` operator, taking a reduction as a
+`java.util.stream.Collector` that yields an `Optional`. `atMostOne()` is simply the most common one,
+defined as `collect(StreamUtils.findOneOrNone())` rather than as a mechanism of its own. Domain
+reductions are authored with `StreamUtils.reducing(…)`, which builds such a collector from a function
+over the accumulated elements, and are grouped into their own catalogs — `LocalizedStrings` holds
+reductions, not navigations:
+
+```java
+Descriptions.descriptions().collect(LocalizedStrings.valueIn(VecLanguageCode.DE))
+```
+
+Recognising a reduction matters for modelling, not just for tidiness. Before `collect` existed, the
+only place for these rules was a pretend navigation *from the collection* — which forced `List<…>` to
+be a source type, forced an identity lift to get back to the elements, and forced the step leading to
+the descriptions to be a private list-valued navigation instead of a public `MultiNavigation`. All
+three disappeared once the reduction was named as such. **If a navigation's source is a collection,
+that is the signal: it is probably a reduction wearing a navigation's clothes.**
+
+### Catalogs
+
 Concrete navigations are grouped into **catalogs**: final classes with a private constructor and
 static factory methods returning the navigation interfaces. A catalog contributes the *steps*; the
-caller composes them into a path with the operators above.
+caller composes them into a path with the operators above. Reductions are grouped the same way, in
+catalogs of their own.
 
 ### Catalog organisation
 
@@ -116,8 +145,8 @@ ViewItems.placeableElementRole()
 Two kinds of parameter remain legitimate, because neither is expressible by chaining:
 
 - **Domain values that feed the traversal logic**, such as the language in
-  `LocalizedStrings.stringIn(VecLanguageCode)` or the property type in
-  `LocalizedStrings.typedStringBy(String, VecLanguageCode)`.
+  `Descriptions.descriptionIn(VecLanguageCode)` or the property type in
+  `LocalizedStrings.typedValueBy(String, VecLanguageCode)`.
 - **Nothing at all**: zero-argument named presets are vocabulary, not indirection, and are encouraged.
   `PlaceableElementRoles.onPointPlacements()` and `Descriptions.germanDescription()` are just
   `placements().ofType(VecOnPointPlacement.class)` and `descriptionIn(DE)`, but they name a concept the
@@ -131,8 +160,8 @@ narrowings, it is composed from the operators rather than written as a stream pi
 implementation reads like the path it describes — `ViewItems.placeableElementRole()` is the reference
 example. Raw stream code and hand-written lambdas stay appropriate for *leaf* steps, where there is
 genuine logic and nothing to compose: `Placements.locations()` dispatches on the placement subtype, and
-`LocalizedStrings.stringIn(…)` applies rules that depend on the size of the list. Forcing those through
-the operators would make them longer, not clearer.
+the body of a reduction such as `LocalizedStrings.valueIn(…)` weighs the elements against each other.
+Forcing those through the operators would make them longer, not clearer.
 
 ### The legacy API (`navigations`)
 
@@ -238,14 +267,16 @@ The `vec-v2x` catalogs and their source types:
 | Catalog | Source type `S` |
 | --- | --- |
 | `Descriptions` | `HasDescription<? extends VecAbstractLocalizedString>` |
-| `LocalizedStrings` | `List<? extends VecAbstractLocalizedString>` |
 | `Placements` | `VecPlacement` (and its on-point/on-way subtypes) |
 | `PlaceableElementRoles` | `VecPlaceableElementRole` |
 | `ViewItems` | `HasOccurrenceOrUsages` |
 
+Plus one reduction catalog: `LocalizedStrings`, over `VecAbstractLocalizedString`.
+
 Note that the two legacy catalogs ported so far each split across several of these, because they
-grouped by target concept: `DescriptionNavs` became `Descriptions` plus `LocalizedStrings`, and
-`PlacementNavs` became `Placements`, `PlaceableElementRoles` and `ViewItems`. Expect the same when
-porting the remaining catalogs — the mapping from old catalog to new is not one-to-one.
+grouped by target concept: `DescriptionNavs` became `Descriptions` plus the `LocalizedStrings`
+reductions, and `PlacementNavs` became `Placements`, `PlaceableElementRoles` and `ViewItems`. Expect the
+same when porting the remaining catalogs — the mapping from old catalog to new is not one-to-one, and
+some legacy navigations turn out to be reductions rather than navigations at all.
 
 The remaining `vec-v2x` catalogs are ported one at a time; `vec-v12x` follows afterwards.

--- a/docs/vec-navigation-api.md
+++ b/docs/vec-navigation-api.md
@@ -39,16 +39,29 @@ smaller ones rather than by writing new traversal code:
 
 | Operator | Meaning |
 | --- | --- |
-| `then` | continue with a single-valued navigation |
-| `thenEach` | continue with a multi-valued navigation |
+| `then` | continue with the next step, overloaded on its kind |
 | `filter` | keep only elements matching a predicate |
 | `ofType` | narrow the navigation to a sub type |
 | `atMostOne` | reduce many results to at most one |
 | `asMulti` / `asList` | convert between result shapes |
 
+`then` is **overloaded on the kind of the following step** rather than split into `then`/`thenEach`
+variants: the argument's type already says whether the next step is single- or multi-valued, so a
+suffix would only restate it. The result stays single-valued exactly when both steps are:
+
+| | `.then(single)` | `.then(multi)` |
+| --- | --- | --- |
+| `single` | single | multi |
+| `multi` | multi | multi |
+
 `Navigations` is the factory that lifts ordinary model getters into navigations (`optional`,
 `nullable`, `stream`, `collection`). It is the intended entry point of a chain: a plain getter
 becomes a navigation, and operators take it from there.
+
+One consequence of the overload is worth knowing: since both kinds are functional interfaces, an
+*implicitly* typed lambda (`x -> …`) is ambiguous as an argument to `then`. Lift it with `Navigations`
+— the intended form anyway — or use an exact method reference or an explicitly typed lambda, all of
+which resolve. `SingleNavigationTest` pins these forms.
 
 Concrete navigations are grouped into **catalogs**: final classes with a private constructor and
 static factory methods returning the navigation interfaces. A catalog contributes the *steps*; the
@@ -92,12 +105,12 @@ order the model is traversed:
 
 ```java
 // as a catalog method taking a navigation — nests, reads inside-out
-ViewItems.locations(PlaceableElementRoles.onWayPlacements().thenEach(Placements.locations()))
+ViewItems.locations(PlaceableElementRoles.onWayPlacements().then(Placements.locations()))
 
 // composed by the caller — reads in traversal order, no extra API
 ViewItems.placeableElementRole()
-        .thenEach(PlaceableElementRoles.onWayPlacements())
-        .thenEach(Placements.locations())
+        .then(PlaceableElementRoles.onWayPlacements())
+        .then(Placements.locations())
 ```
 
 Two kinds of parameter remain legitimate, because neither is expressible by chaining:

--- a/docs/vec-navigation-api.md
+++ b/docs/vec-navigation-api.md
@@ -131,7 +131,10 @@ why they keep the predicates style.
 
 **A navigation belongs to the catalog of its source type `S`.** The catalog is named after that type
 in plural with the `Vec` prefix dropped, and method names state only the *target*, never the source —
-see [Naming the factories](#naming-the-factories) above.
+see [Naming the factories](#naming-the-factories) above. A `Has*` mixin drops the `Has` instead, which is
+where `Descriptions` and `CustomProperties` come from; where that would collide with the catalog of the
+element itself, the mixin catalog says whose it is — `HasSpecifications` becomes `SpecificationOwners`,
+because `Specifications` is the catalog of `VecSpecification`.
 
 Granularity is the **nearest model supertype** that has navigations, so a type shares a catalog with
 its subtypes, and `Has*` mixin interfaces are legitimate source types with their own catalogs. A
@@ -140,7 +143,7 @@ several hundred classes — without making the lookup ambiguous.
 
 That gives a mechanical answer to *"I am holding an `x`, where can I go from here?"*: the navigation
 is in the catalog named after `x`'s type or one of its supertypes or mixins, and autocomplete on that
-catalog enumerates everything reachable. Two consequences of the rule are worth stating explicitly:
+catalog enumerates everything reachable. Three consequences of the rule are worth stating explicitly:
 
 - **The source never appears in a method name.** A catalog with a single source type does not need to
   disambiguate, so `parentDocumentVersion()` stays as it is instead of becoming
@@ -150,6 +153,17 @@ catalog enumerates everything reachable. Two consequences of the rule are worth 
 - **Where a family shares a target, the navigation belongs at the family level.** `Placements.toLocations()`
   starts at `VecPlacement` and resolves the subtype internally, rather than offering separate
   `onPointLocations()`/`onWayLocations()` entries that would reintroduce source-encoded names.
+  `OccurrenceOrUsages` is the larger case: `toParentDocumentVersion()`, `toPrimaryPartType()` and
+  `toPartOrUsageRelatedSpecifications()` each start at `VecOccurrenceOrUsage` and switch on the subtype,
+  which is what retires the `OfOccurrence`/`OfUsage` suffixes of the legacy catalog. Such a switch covers
+  every subtype the model has, so its `default` arm throws a `VecException` rather than returning an empty
+  result: reaching it means a subtype was missed when the navigation was written, and an empty result would
+  hide that as a legitimately empty path.
+- **A mixin catalog is generic in its source.** `SpecificationOwners.toSpecifications()` is declared
+  `<S extends HasSpecifications<VecSpecification>>`, so a chain starting at a `VecDocumentVersion` keeps
+  that type — `SpecificationOwners.<VecDocumentVersion>toSpecifications().ofType(…)` — instead of widening
+  to the mixin and forcing every catalog downstream to widen too. Without the type parameter, `DocumentVersions`
+  could not build on the mixin's steps and would have to duplicate them.
 
 The rule deliberately optimises the "from" direction. *"Which navigations lead to a `VecLocation`?"* is
 not answerable from the class layout, because a target is reachable from many sources while a
@@ -199,7 +213,9 @@ Forcing those through the operators would make them longer, not clearer.
 
 The older generation uses catalogs too — final classes named `<Concept>Navs` with static factory
 methods — but every factory returns a raw `java.util.function.Function`, and the catalogs follow no
-single grouping rule. Consequences:
+single grouping rule. All of them are now deprecated for removal and delegate to the typed catalogs, so
+what follows describes the surface that is being retired, not behaviour that still lives anywhere.
+Consequences:
 
 - A navigation has no type identity and cannot be distinguished from any other function.
 - Result shapes are inconsistent across the catalogs: bare values, `Optional`, `List` and `Stream`
@@ -279,7 +295,8 @@ vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/
 └── navigations/                  ← legacy catalogs (deprecated for removal)
 
 vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/
-└── navigations/                  ← legacy catalogs, not yet ported
+├── traversal/                    ← typed catalogs, the same set as v2x
+└── navigations/                  ← legacy catalogs (deprecated for removal)
 ```
 
 Both packages are exported in each module's `module-info.java` and published to Maven Central, so
@@ -290,25 +307,49 @@ they are public API.
 | Module | Typed catalogs | Legacy catalogs |
 | --- | --- | --- |
 | `vec-common` | interfaces and factory | — |
-| `vec-v2x` | 5 catalogs, see below | 10 `*Navs`, two of them deprecated and delegating |
-| `vec-v12x` | — | 10 `*Navs` |
+| `vec-v2x` | 15 catalogs, see below | 10 `*Navs`, all deprecated and delegating |
+| `vec-v12x` | the same 15 catalogs | 10 `*Navs`, all deprecated and delegating |
 | `vec-v113` | — | none |
 
-The `vec-v2x` catalogs and their source types:
+Every legacy navigation has a replacement, so both `navigations` packages are deprecated in full and
+carry no logic of their own. The catalogs and their source types, identical in both modules:
 
 | Catalog | Source type `S` |
 | --- | --- |
+| `ConfigurableElements` | `VecConfigurableElement` |
+| `Contents` | `VecContent` |
+| `CustomProperties` | `HasCustomProperties<VecCustomProperty>` |
 | `Descriptions` | `HasDescription<? extends VecAbstractLocalizedString>` |
-| `Placements` | `VecPlacement` (and its on-point/on-way subtypes) |
+| `DocumentVersions` | `VecDocumentVersion` |
+| `ExtendableElements` | `VecExtendableElement` |
+| `LocalizedStringProperties` | `VecLocalizedStringProperty` |
+| `OccurrenceOrUsages` | `VecOccurrenceOrUsage` (and its occurrence/usage subtypes) |
 | `PlaceableElementRoles` | `VecPlaceableElementRole` |
+| `Placements` | `VecPlacement` (and its on-point/on-way subtypes) |
+| `Roles` | `VecRole` |
+| `Specifications` | `VecSpecification` (and its subtypes) |
+| `SpecificationOwners` | `HasSpecifications<VecSpecification>` |
+| `TopologySegments` | `VecTopologySegment` |
 | `ViewItems` | `HasOccurrenceOrUsages` |
 
 Plus one reduction catalog: `LocalizedStrings`, over `VecAbstractLocalizedString`.
 
-Note that the two legacy catalogs ported so far each split across several of these, because they
-grouped by target concept: `DescriptionNavs` became `Descriptions` plus the `LocalizedStrings`
-reductions, and `PlacementNavs` became `Placements`, `PlaceableElementRoles` and `ViewItems`. Expect the
-same when porting the remaining catalogs — the mapping from old catalog to new is not one-to-one, and
-some legacy navigations turn out to be reductions rather than navigations at all.
+The mapping from old catalog to new is not one-to-one. Catalogs which grouped by target concept split
+across several source types — `DescriptionNavs` became `Descriptions` plus the `LocalizedStrings`
+reductions, `PlacementNavs` became `Placements`, `PlaceableElementRoles` and `ViewItems`, and
+`CustomPropertyNavs` became `CustomProperties` plus `LocalizedStringProperties` — while the catch-all
+`VecNavs` split into `ExtendableElements` and `Roles`. In the other direction, the `OfOccurrence` and
+`OfUsage` pairs of `PartOccurrenceOrUsageNavs` collapsed into one family-level navigation each.
 
-The remaining `vec-v2x` catalogs are ported one at a time; `vec-v12x` follows afterwards.
+A few legacy signatures had no navigation shape at all and are deprecated without a one-to-one
+replacement:
+
+- `PartOccurrenceOrUsageNavs.occurrence()` / `usage()` are `ofType` on whatever navigation leads to the
+  occurrences.
+- `PartOccurrenceOrUsageNavs.findNodeOfComponent()` took two sources; it became
+  `DocumentVersions.topologyNodeOf(VecOccurrenceOrUsage)`, a navigation from the document version with the
+  component as a domain value.
+- `CustomPropertyNavs.customPropertyOfType(…)` (v12x only) starts at a collection of properties, the
+  signal of a navigation in the wrong shape; it is a filter and a narrowing at the call site.
+
+`vec-v113` has no navigations of either generation.

--- a/vec/vec-common/src/main/java/com/foursoft/harness/vec/common/traversal/MultiNavigation.java
+++ b/vec/vec-common/src/main/java/com/foursoft/harness/vec/common/traversal/MultiNavigation.java
@@ -30,6 +30,7 @@ import com.foursoft.harness.vec.common.util.StreamUtils;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
+import java.util.stream.Collector;
 import java.util.stream.Stream;
 
 /**
@@ -92,7 +93,24 @@ public interface MultiNavigation<S, T> extends Navigation<S, Stream<T>> {
     }
 
     /**
-     * Returns a navigation leading to the only element of this navigation.
+     * Reduces this navigation to a single valued one with the given reduction.
+     * <p>
+     * This is the general way from many elements to at most one. Use it whenever choosing the result needs
+     * rules of its own rather than a filter or a mapping of the single elements; author such reductions with
+     * {@link StreamUtils#reducing(java.util.function.Function)}.
+     *
+     * @param reduction Reduction of the navigated elements to at most one result.
+     * @param <R>       Type of the element the returned navigation leads to.
+     * @return A navigation from {@code S} to at most one {@code R}.
+     * @see #atMostOne()
+     */
+    default <R> SingleNavigation<S, R> collect(final Collector<? super T, ?, Optional<R>> reduction) {
+        return source -> from(source).collect(reduction);
+    }
+
+    /**
+     * Returns a navigation leading to the only element of this navigation, the most common
+     * {@linkplain #collect(Collector) reduction}.
      * <p>
      * If this navigation leads to more than one element, the first one is chosen and a debug log entry is
      * fired, see {@link StreamUtils#findOneOrNone()}.
@@ -100,7 +118,7 @@ public interface MultiNavigation<S, T> extends Navigation<S, Stream<T>> {
      * @return A single valued view on this navigation.
      */
     default SingleNavigation<S, T> atMostOne() {
-        return source -> from(source).collect(StreamUtils.findOneOrNone());
+        return collect(StreamUtils.findOneOrNone());
     }
 
     /**

--- a/vec/vec-common/src/main/java/com/foursoft/harness/vec/common/traversal/MultiNavigation.java
+++ b/vec/vec-common/src/main/java/com/foursoft/harness/vec/common/traversal/MultiNavigation.java
@@ -58,13 +58,13 @@ public interface MultiNavigation<S, T> extends Navigation<S, Stream<T>> {
     }
 
     /**
-     * Continues this navigation with another multi valued navigation.
+     * Continues this navigation with another multi valued navigation, flattening the results.
      *
      * @param next Navigation to apply to each element of this navigation.
      * @param <R>  Type of the elements the returned navigation leads to.
      * @return A navigation from {@code S} to an arbitrary number of {@code R}.
      */
-    default <R> MultiNavigation<S, R> thenEach(final MultiNavigation<? super T, R> next) {
+    default <R> MultiNavigation<S, R> then(final MultiNavigation<? super T, R> next) {
         return source -> from(source).flatMap(next);
     }
 

--- a/vec/vec-common/src/main/java/com/foursoft/harness/vec/common/traversal/MultiNavigation.java
+++ b/vec/vec-common/src/main/java/com/foursoft/harness/vec/common/traversal/MultiNavigation.java
@@ -1,0 +1,125 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC Common
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.common.traversal;
+
+import com.foursoft.harness.vec.common.util.StreamUtils;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+/**
+ * A {@link Navigation} leading to an arbitrary number of elements.
+ * <p>
+ * The result is always a {@link Stream}, so the navigation stays lazy and can be composed without creating
+ * intermediate collections. A fresh stream is returned on every application.
+ *
+ * @param <S> Type of the source object to navigate from.
+ * @param <T> Type of the elements navigated to.
+ */
+@FunctionalInterface
+public interface MultiNavigation<S, T> extends Navigation<S, Stream<T>> {
+
+    /**
+     * Continues this navigation with a single valued navigation, dropping the elements without a target.
+     *
+     * @param next Navigation to apply to each element of this navigation.
+     * @param <R>  Type of the elements the returned navigation leads to.
+     * @return A navigation from {@code S} to an arbitrary number of {@code R}.
+     */
+    default <R> MultiNavigation<S, R> then(final SingleNavigation<? super T, R> next) {
+        return source -> from(source)
+                .map(next)
+                .flatMap(Optional::stream);
+    }
+
+    /**
+     * Continues this navigation with another multi valued navigation.
+     *
+     * @param next Navigation to apply to each element of this navigation.
+     * @param <R>  Type of the elements the returned navigation leads to.
+     * @return A navigation from {@code S} to an arbitrary number of {@code R}.
+     */
+    default <R> MultiNavigation<S, R> thenEach(final MultiNavigation<? super T, R> next) {
+        return source -> from(source).flatMap(next);
+    }
+
+    /**
+     * Returns a navigation which only leads to the elements matching the given predicate.
+     *
+     * @param predicate Predicate the navigated elements have to match.
+     * @return A navigation leading to the filtered elements.
+     */
+    default MultiNavigation<S, T> filter(final Predicate<? super T> predicate) {
+        return source -> from(source).filter(predicate);
+    }
+
+    /**
+     * Returns a navigation which only leads to the elements which are an instance of the given type.
+     *
+     * @param type Type the navigated elements have to have.
+     * @param <R>  Type to narrow the navigation to.
+     * @return A navigation leading to the narrowed elements.
+     */
+    default <R extends T> MultiNavigation<S, R> ofType(final Class<R> type) {
+        return source -> from(source)
+                .filter(type::isInstance)
+                .map(type::cast);
+    }
+
+    /**
+     * Returns a navigation leading to the only element of this navigation.
+     * <p>
+     * If this navigation leads to more than one element, the first one is chosen and a debug log entry is
+     * fired, see {@link StreamUtils#findOneOrNone()}.
+     *
+     * @return A single valued view on this navigation.
+     */
+    default SingleNavigation<S, T> atMostOne() {
+        return source -> from(source).collect(StreamUtils.findOneOrNone());
+    }
+
+    /**
+     * Applies this navigation to the given source object and collects the result into a {@link List}.
+     *
+     * @param source Source object to navigate from.
+     * @return The navigated elements, an empty list if there are none.
+     */
+    default List<T> listFrom(final S source) {
+        return from(source).toList();
+    }
+
+    /**
+     * Returns this navigation as a navigation to a {@link List} instead of a {@link Stream}.
+     *
+     * @return A navigation leading to the navigated elements as a list.
+     */
+    default Navigation<S, List<T>> asList() {
+        return this::listFrom;
+    }
+
+}

--- a/vec/vec-common/src/main/java/com/foursoft/harness/vec/common/traversal/Navigation.java
+++ b/vec/vec-common/src/main/java/com/foursoft/harness/vec/common/traversal/Navigation.java
@@ -1,0 +1,63 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC Common
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.common.traversal;
+
+import java.util.function.Function;
+
+/**
+ * A reusable, typed navigation from a source object of type {@code S} to a result of type {@code T}.
+ * <p>
+ * A navigation encapsulates the way from one element of the model to another one, so that this way can be
+ * named, reused and composed instead of being spelled out at every call site.
+ * <p>
+ * This interface is the common base type of the navigation hierarchy and mainly serves as an escape hatch for
+ * results which are neither {@link java.util.Optional} nor {@link java.util.stream.Stream}. Prefer the more
+ * specific sub types, as only those offer composition:
+ * <ul>
+ *     <li>{@link SingleNavigation} for navigations leading to at most one element.</li>
+ *     <li>{@link MultiNavigation} for navigations leading to an arbitrary number of elements.</li>
+ * </ul>
+ * A navigation is a {@link Function} and can therefore be used wherever a function is expected.
+ *
+ * @param <S> Type of the source object to navigate from.
+ * @param <T> Type of the navigation result.
+ */
+@FunctionalInterface
+public interface Navigation<S, T> extends Function<S, T> {
+
+    /**
+     * Applies this navigation to the given source object.
+     * <p>
+     * Equivalent to {@link #apply(Object)}, but reads better at the call site.
+     *
+     * @param source Source object to navigate from.
+     * @return The result of the navigation.
+     */
+    default T from(final S source) {
+        return apply(source);
+    }
+
+}

--- a/vec/vec-common/src/main/java/com/foursoft/harness/vec/common/traversal/Navigation.java
+++ b/vec/vec-common/src/main/java/com/foursoft/harness/vec/common/traversal/Navigation.java
@@ -41,6 +41,16 @@ import java.util.function.Function;
  *     <li>{@link MultiNavigation} for navigations leading to an arbitrary number of elements.</li>
  * </ul>
  * A navigation is a {@link Function} and can therefore be used wherever a function is expected.
+ * <p>
+ * Steps are composed with {@code then}, which is overloaded on the kind of the following step, so the
+ * chain never has to name the kinds itself. The result stays single valued only if both steps are:
+ * <pre>
+ * single.then(single) -&gt; single      multi.then(single) -&gt; multi
+ * single.then(multi)  -&gt; multi       multi.then(multi)  -&gt; multi
+ * </pre>
+ * Since both kinds are functional interfaces, an <em>implicitly</em> typed lambda is ambiguous as an
+ * argument to {@code then}. Lift plain getters with {@link Navigations} instead, which is the intended
+ * way to start a chain; an explicitly typed lambda or an exact method reference also resolves.
  *
  * @param <S> Type of the source object to navigate from.
  * @param <T> Type of the navigation result.

--- a/vec/vec-common/src/main/java/com/foursoft/harness/vec/common/traversal/Navigations.java
+++ b/vec/vec-common/src/main/java/com/foursoft/harness/vec/common/traversal/Navigations.java
@@ -39,7 +39,7 @@ import java.util.stream.Stream;
  * MultiNavigation<VecPlaceableElementRole, VecLocation> locations =
  *     Navigations.collection(VecPlaceableElementRole::getRefPlacement)
  *         .ofType(VecOnPointPlacement.class)
- *         .thenEach(Navigations.collection(VecOnPointPlacement::getLocations));
+ *         .then(Navigations.collection(VecOnPointPlacement::getLocations));
  * }
  * </pre>
  */

--- a/vec/vec-common/src/main/java/com/foursoft/harness/vec/common/traversal/Navigations.java
+++ b/vec/vec-common/src/main/java/com/foursoft/harness/vec/common/traversal/Navigations.java
@@ -1,0 +1,103 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC Common
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.common.traversal;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+/**
+ * Factory methods to create {@link Navigation}s from plain functions, typically from getters of the model.
+ * <p>
+ * These adapters are the intended starting point of a navigation chain, for example
+ * <pre>
+ * {@code
+ * MultiNavigation<VecPlaceableElementRole, VecLocation> locations =
+ *     Navigations.collection(VecPlaceableElementRole::getRefPlacement)
+ *         .ofType(VecOnPointPlacement.class)
+ *         .thenEach(Navigations.collection(VecOnPointPlacement::getLocations));
+ * }
+ * </pre>
+ */
+public final class Navigations {
+
+    private Navigations() {
+        // hide default constructor
+    }
+
+    /**
+     * Creates a {@link SingleNavigation} from a function already returning an {@link Optional}.
+     *
+     * @param function Function to adapt.
+     * @param <S>      Type of the source object to navigate from.
+     * @param <T>      Type of the element navigated to.
+     * @return A navigation leading to at most one element.
+     */
+    public static <S, T> SingleNavigation<S, T> optional(final Function<S, Optional<T>> function) {
+        return function::apply;
+    }
+
+    /**
+     * Creates a {@link SingleNavigation} from a function which may return {@code null}.
+     *
+     * @param function Function to adapt.
+     * @param <S>      Type of the source object to navigate from.
+     * @param <T>      Type of the element navigated to.
+     * @return A navigation leading to at most one element.
+     */
+    public static <S, T> SingleNavigation<S, T> nullable(final Function<S, T> function) {
+        return source -> Optional.ofNullable(function.apply(source));
+    }
+
+    /**
+     * Creates a {@link MultiNavigation} from a function already returning a {@link Stream}.
+     *
+     * @param function Function to adapt.
+     * @param <S>      Type of the source object to navigate from.
+     * @param <T>      Type of the elements navigated to.
+     * @return A navigation leading to an arbitrary number of elements.
+     */
+    public static <S, T> MultiNavigation<S, T> stream(final Function<S, Stream<T>> function) {
+        return function::apply;
+    }
+
+    /**
+     * Creates a {@link MultiNavigation} from a function returning a {@link Collection}, usually a getter of
+     * a to-many association of the model.
+     *
+     * @param function Function to adapt.
+     * @param <S>      Type of the source object to navigate from.
+     * @param <T>      Type of the elements navigated to.
+     * @return A navigation leading to an arbitrary number of elements.
+     */
+    public static <S, T> MultiNavigation<S, T> collection(
+            final Function<S, ? extends Collection<? extends T>> function) {
+        return source -> function.apply(source).stream()
+                .map(element -> element);
+    }
+
+}

--- a/vec/vec-common/src/main/java/com/foursoft/harness/vec/common/traversal/SingleNavigation.java
+++ b/vec/vec-common/src/main/java/com/foursoft/harness/vec/common/traversal/SingleNavigation.java
@@ -1,0 +1,130 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC Common
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.common.traversal;
+
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+/**
+ * A {@link Navigation} leading to at most one element.
+ * <p>
+ * The result is always an {@link Optional}, so an absent target is part of the contract instead of being
+ * expressed by a {@code null} return value.
+ *
+ * @param <S> Type of the source object to navigate from.
+ * @param <T> Type of the element navigated to.
+ */
+@FunctionalInterface
+public interface SingleNavigation<S, T> extends Navigation<S, Optional<T>> {
+
+    /**
+     * Continues this navigation with another single valued navigation.
+     *
+     * @param next Navigation to apply to the result of this navigation.
+     * @param <R>  Type of the element the returned navigation leads to.
+     * @return A navigation from {@code S} to at most one {@code R}.
+     */
+    default <R> SingleNavigation<S, R> then(final SingleNavigation<? super T, R> next) {
+        return source -> from(source).flatMap(next);
+    }
+
+    /**
+     * Continues this navigation with a multi valued navigation.
+     *
+     * @param next Navigation to apply to the result of this navigation.
+     * @param <R>  Type of the elements the returned navigation leads to.
+     * @return A navigation from {@code S} to an arbitrary number of {@code R}.
+     */
+    default <R> MultiNavigation<S, R> thenEach(final MultiNavigation<? super T, R> next) {
+        return source -> from(source).stream()
+                .flatMap(next);
+    }
+
+    /**
+     * Returns a navigation which only leads to the element if it matches the given predicate.
+     *
+     * @param predicate Predicate the navigated element has to match.
+     * @return A navigation leading to the filtered element.
+     */
+    default SingleNavigation<S, T> filter(final Predicate<? super T> predicate) {
+        return source -> from(source).filter(predicate);
+    }
+
+    /**
+     * Returns a navigation which only leads to the element if it is an instance of the given type.
+     *
+     * @param type Type the navigated element has to have.
+     * @param <R>  Type to narrow the navigation to.
+     * @return A navigation leading to the narrowed element.
+     */
+    default <R extends T> SingleNavigation<S, R> ofType(final Class<R> type) {
+        return source -> from(source)
+                .filter(type::isInstance)
+                .map(type::cast);
+    }
+
+    /**
+     * Returns this navigation as a multi valued navigation leading to zero or one element.
+     *
+     * @return A multi valued view on this navigation.
+     */
+    default MultiNavigation<S, T> asMulti() {
+        return source -> from(source).stream();
+    }
+
+    /**
+     * Applies this navigation to the given source object and returns {@code null} if there is no target.
+     *
+     * @param source Source object to navigate from.
+     * @return The navigated element or {@code null} if there is none.
+     */
+    default T orElseNull(final S source) {
+        return from(source).orElse(null);
+    }
+
+    /**
+     * Applies this navigation to the given source object and returns the given fallback if there is no target.
+     *
+     * @param source   Source object to navigate from.
+     * @param fallback Value to return if the navigation does not lead to an element.
+     * @return The navigated element or the given fallback if there is none.
+     */
+    default T orElse(final S source, final T fallback) {
+        return from(source).orElse(fallback);
+    }
+
+    /**
+     * Applies this navigation to the given source object and returns the result as a {@link Stream}.
+     *
+     * @param source Source object to navigate from.
+     * @return A stream containing the navigated element, or an empty stream if there is none.
+     */
+    default Stream<T> streamFrom(final S source) {
+        return from(source).stream();
+    }
+
+}

--- a/vec/vec-common/src/main/java/com/foursoft/harness/vec/common/traversal/SingleNavigation.java
+++ b/vec/vec-common/src/main/java/com/foursoft/harness/vec/common/traversal/SingleNavigation.java
@@ -42,7 +42,7 @@ import java.util.stream.Stream;
 public interface SingleNavigation<S, T> extends Navigation<S, Optional<T>> {
 
     /**
-     * Continues this navigation with another single valued navigation.
+     * Continues this navigation with another single valued navigation, which stays single valued.
      *
      * @param next Navigation to apply to the result of this navigation.
      * @param <R>  Type of the element the returned navigation leads to.
@@ -53,13 +53,13 @@ public interface SingleNavigation<S, T> extends Navigation<S, Optional<T>> {
     }
 
     /**
-     * Continues this navigation with a multi valued navigation.
+     * Continues this navigation with a multi valued navigation, which makes the result multi valued.
      *
      * @param next Navigation to apply to the result of this navigation.
      * @param <R>  Type of the elements the returned navigation leads to.
      * @return A navigation from {@code S} to an arbitrary number of {@code R}.
      */
-    default <R> MultiNavigation<S, R> thenEach(final MultiNavigation<? super T, R> next) {
+    default <R> MultiNavigation<S, R> then(final MultiNavigation<? super T, R> next) {
         return source -> from(source).stream()
                 .flatMap(next);
     }

--- a/vec/vec-common/src/main/java/com/foursoft/harness/vec/common/util/StreamUtils.java
+++ b/vec/vec-common/src/main/java/com/foursoft/harness/vec/common/util/StreamUtils.java
@@ -106,6 +106,25 @@ public final class StreamUtils {
     }
 
     /**
+     * Returns a {@link Collector} which applies the given function to all collected elements.
+     * <p>
+     * Intended for reductions whose rules depend on the elements as a whole, for example on how many there
+     * are, which cannot be expressed as a filter or a mapping of the single elements.
+     *
+     * @param reduction Function reducing the collected elements to at most one result.
+     * @param <T>       Type of the elements to collect.
+     * @param <R>       Type of the reduction result.
+     * @return A collector reducing the elements with the given function.
+     */
+    public static <T, R> Collector<T, List<T>, Optional<R>> reducing(
+            final Function<List<T>, Optional<R>> reduction) {
+        return Collector.of(ArrayList::new, List::add, (left, right) -> {
+            left.addAll(right);
+            return left;
+        }, reduction::apply);
+    }
+
+    /**
      * Returns the only element in the list. If zero or more than one element is in the list, an exception is thrown.
      */
     public static <T> Collector<T, List<T>, T> findOne() {

--- a/vec/vec-common/src/main/java/module-info.java
+++ b/vec/vec-common/src/main/java/module-info.java
@@ -29,5 +29,6 @@ module com.foursoft.harness.vec.common {
     exports com.foursoft.harness.vec.common;
     exports com.foursoft.harness.vec.common.annotations;
     exports com.foursoft.harness.vec.common.exception;
+    exports com.foursoft.harness.vec.common.traversal;
     exports com.foursoft.harness.vec.common.util;
 }

--- a/vec/vec-common/src/test/java/com/foursoft/harness/vec/common/traversal/MultiNavigationTest.java
+++ b/vec/vec-common/src/test/java/com/foursoft/harness/vec/common/traversal/MultiNavigationTest.java
@@ -78,10 +78,10 @@ class MultiNavigationTest {
     }
 
     @Test
-    void thenEachFlattensNestedNavigations() {
+    void thenFlattensNestedMultiNavigations() {
         final MultiNavigation<Plant, Part> allParts =
                 Navigations.<Plant, Assembly>collection(Plant::assemblies)
-                        .thenEach(PARTS);
+                        .then(PARTS);
 
         final Plant plant = new Plant(List.of(assemblyWith(SCREW_M6), assemblyWith(NUT, SCREW_M8)));
 
@@ -134,7 +134,7 @@ class MultiNavigationTest {
     @Test
     void navigatesAnEmptySourceWithoutFailing() {
         assertThat(Navigations.<Plant, Assembly>collection(Plant::assemblies)
-                           .thenEach(PARTS)
+                           .then(PARTS)
                            .listFrom(new Plant(Collections.emptyList()))).isEmpty();
     }
 

--- a/vec/vec-common/src/test/java/com/foursoft/harness/vec/common/traversal/MultiNavigationTest.java
+++ b/vec/vec-common/src/test/java/com/foursoft/harness/vec/common/traversal/MultiNavigationTest.java
@@ -31,10 +31,12 @@ import com.foursoft.harness.vec.common.traversal.TestModel.Nut;
 import com.foursoft.harness.vec.common.traversal.TestModel.Part;
 import com.foursoft.harness.vec.common.traversal.TestModel.Plant;
 import com.foursoft.harness.vec.common.traversal.TestModel.Screw;
+import com.foursoft.harness.vec.common.util.StreamUtils;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -98,6 +100,27 @@ class MultiNavigationTest {
     void ofTypeNarrowsTheNavigation() {
         assertThat(PARTS.ofType(Screw.class).listFrom(assemblyWith(SCREW_M6, NUT, SCREW_M8)))
                 .containsExactly(SCREW_M6, SCREW_M8);
+    }
+
+    /**
+     * The general way from many elements to at most one. Reductions whose rules depend on the elements as a
+     * whole cannot be expressed as a filter or a mapping, so they are authored as a collector.
+     */
+    @Test
+    void collectReducesWithCustomRules() {
+        final MultiNavigation<Assembly, Part> parts = PARTS;
+        final var onlyIfUnambiguous = StreamUtils.<Part, String>reducing(
+                list -> list.size() == 1 ? Optional.of(list.get(0).name()) : Optional.empty());
+
+        assertThat(parts.collect(onlyIfUnambiguous).from(assemblyWith(SCREW_M6))).contains("M6");
+        assertThat(parts.collect(onlyIfUnambiguous).from(assemblyWith(SCREW_M6, NUT))).isEmpty();
+        assertThat(parts.collect(onlyIfUnambiguous).from(assemblyWith())).isEmpty();
+    }
+
+    @Test
+    void atMostOneIsAReductionAsWell() {
+        assertThat(PARTS.collect(StreamUtils.<Part>findOneOrNone()).from(assemblyWith(SCREW_M6)))
+                .isEqualTo(PARTS.atMostOne().from(assemblyWith(SCREW_M6)));
     }
 
     @Test

--- a/vec/vec-common/src/test/java/com/foursoft/harness/vec/common/traversal/MultiNavigationTest.java
+++ b/vec/vec-common/src/test/java/com/foursoft/harness/vec/common/traversal/MultiNavigationTest.java
@@ -1,0 +1,141 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC Common
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.common.traversal;
+
+import com.foursoft.harness.vec.common.traversal.TestModel.Assembly;
+import com.foursoft.harness.vec.common.traversal.TestModel.Grade;
+import com.foursoft.harness.vec.common.traversal.TestModel.Nut;
+import com.foursoft.harness.vec.common.traversal.TestModel.Part;
+import com.foursoft.harness.vec.common.traversal.TestModel.Plant;
+import com.foursoft.harness.vec.common.traversal.TestModel.Screw;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MultiNavigationTest {
+
+    private static final Grade GRADE_8_8 = new Grade("8.8");
+    private static final Grade GRADE_10_9 = new Grade("10.9");
+    private static final Screw SCREW_M6 = new Screw("M6", GRADE_8_8);
+    private static final Screw SCREW_M8 = new Screw("M8", GRADE_10_9);
+    private static final Screw SCREW_WITHOUT_GRADE = new Screw("M10", null);
+    private static final Nut NUT = new Nut("M6");
+
+    private static final MultiNavigation<Assembly, Part> PARTS =
+            Navigations.collection(Assembly::parts);
+
+    private static Assembly assemblyWith(final Part... parts) {
+        return new Assembly("assembly", null, List.of(parts));
+    }
+
+    @Test
+    void fromReturnsAllElements() {
+        assertThat(PARTS.from(assemblyWith(SCREW_M6, NUT))).containsExactly(SCREW_M6, NUT);
+    }
+
+    @Test
+    void fromReturnsAFreshStreamOnEveryApplication() {
+        final Assembly assembly = assemblyWith(SCREW_M6, NUT);
+
+        assertThat(PARTS.from(assembly)).hasSize(2);
+        assertThat(PARTS.from(assembly)).hasSize(2);
+    }
+
+    @Test
+    void thenDropsElementsWithoutATarget() {
+        final MultiNavigation<Assembly, Grade> grades = PARTS
+                .ofType(Screw.class)
+                .then(Navigations.nullable(Screw::grade));
+
+        assertThat(grades.listFrom(assemblyWith(SCREW_M6, NUT, SCREW_WITHOUT_GRADE, SCREW_M8)))
+                .containsExactly(GRADE_8_8, GRADE_10_9);
+    }
+
+    @Test
+    void thenEachFlattensNestedNavigations() {
+        final MultiNavigation<Plant, Part> allParts =
+                Navigations.<Plant, Assembly>collection(Plant::assemblies)
+                        .thenEach(PARTS);
+
+        final Plant plant = new Plant(List.of(assemblyWith(SCREW_M6), assemblyWith(NUT, SCREW_M8)));
+
+        assertThat(allParts.listFrom(plant)).containsExactly(SCREW_M6, NUT, SCREW_M8);
+    }
+
+    @Test
+    void filterKeepsOnlyMatchingElements() {
+        assertThat(PARTS.filter(part -> "M6".equals(part.name())).listFrom(assemblyWith(SCREW_M6, NUT, SCREW_M8)))
+                .containsExactly(SCREW_M6, NUT);
+    }
+
+    @Test
+    void ofTypeNarrowsTheNavigation() {
+        assertThat(PARTS.ofType(Screw.class).listFrom(assemblyWith(SCREW_M6, NUT, SCREW_M8)))
+                .containsExactly(SCREW_M6, SCREW_M8);
+    }
+
+    @Test
+    void atMostOneReturnsEmptyForNoElement() {
+        assertThat(PARTS.atMostOne().from(assemblyWith())).isEmpty();
+    }
+
+    @Test
+    void atMostOneReturnsTheOnlyElement() {
+        assertThat(PARTS.atMostOne().from(assemblyWith(SCREW_M6))).contains(SCREW_M6);
+    }
+
+    @Test
+    void atMostOneReturnsTheFirstOfSeveralElements() {
+        assertThat(PARTS.atMostOne().from(assemblyWith(SCREW_M6, NUT))).contains(SCREW_M6);
+    }
+
+    @Test
+    void listFromAndAsListCollectTheElements() {
+        final Assembly assembly = assemblyWith(SCREW_M6, NUT);
+
+        assertThat(PARTS.listFrom(assembly)).containsExactly(SCREW_M6, NUT);
+        assertThat(PARTS.asList().from(assembly)).containsExactly(SCREW_M6, NUT);
+        assertThat(PARTS.listFrom(assemblyWith())).isEmpty();
+    }
+
+    @Test
+    void isUsableWhereverAFunctionIsExpected() {
+        final Plant plant = new Plant(List.of(assemblyWith(SCREW_M6), assemblyWith(NUT)));
+
+        assertThat(plant.assemblies().stream().flatMap(PARTS)).containsExactly(SCREW_M6, NUT);
+    }
+
+    @Test
+    void navigatesAnEmptySourceWithoutFailing() {
+        assertThat(Navigations.<Plant, Assembly>collection(Plant::assemblies)
+                           .thenEach(PARTS)
+                           .listFrom(new Plant(Collections.emptyList()))).isEmpty();
+    }
+
+}

--- a/vec/vec-common/src/test/java/com/foursoft/harness/vec/common/traversal/NavigationsTest.java
+++ b/vec/vec-common/src/test/java/com/foursoft/harness/vec/common/traversal/NavigationsTest.java
@@ -1,0 +1,88 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC Common
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.common.traversal;
+
+import com.foursoft.harness.vec.common.traversal.TestModel.Assembly;
+import com.foursoft.harness.vec.common.traversal.TestModel.Grade;
+import com.foursoft.harness.vec.common.traversal.TestModel.Kit;
+import com.foursoft.harness.vec.common.traversal.TestModel.Part;
+import com.foursoft.harness.vec.common.traversal.TestModel.Screw;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NavigationsTest {
+
+    private static final Grade GRADE_8_8 = new Grade("8.8");
+    private static final Screw SCREW = new Screw("M6", GRADE_8_8);
+
+    @Test
+    void optionalAdaptsAFunctionReturningAnOptional() {
+        final SingleNavigation<Screw, Grade> grade = Navigations.optional(screw -> Optional.ofNullable(screw.grade()));
+
+        assertThat(grade.from(SCREW)).contains(GRADE_8_8);
+        assertThat(grade.from(new Screw("M8", null))).isEmpty();
+    }
+
+    @Test
+    void nullableWrapsANullResultIntoAnEmptyOptional() {
+        final SingleNavigation<Screw, Grade> grade = Navigations.nullable(Screw::grade);
+
+        assertThat(grade.from(SCREW)).contains(GRADE_8_8);
+        assertThat(grade.from(new Screw("M8", null))).isEmpty();
+    }
+
+    @Test
+    void streamAdaptsAFunctionReturningAStream() {
+        final MultiNavigation<Assembly, Part> parts = Navigations.stream(assembly -> assembly.parts().stream());
+
+        assertThat(parts.listFrom(new Assembly("assembly", null, List.of(SCREW)))).containsExactly(SCREW);
+    }
+
+    @Test
+    void collectionAdaptsAFunctionReturningACollection() {
+        final MultiNavigation<Assembly, Part> parts = Navigations.collection(Assembly::parts);
+
+        assertThat(parts.listFrom(new Assembly("assembly", null, List.of(SCREW)))).containsExactly(SCREW);
+        assertThat(parts.listFrom(new Assembly("assembly", null, Collections.emptyList()))).isEmpty();
+    }
+
+    /**
+     * The result type of the adapted function only has to be a collection of a sub type of the navigated type,
+     * so getters of specialized associations can be widened to a navigation of the general type.
+     */
+    @Test
+    void collectionWidensTheElementType() {
+        final MultiNavigation<Kit, Part> parts = Navigations.collection(Kit::screws);
+
+        assertThat(parts.listFrom(new Kit(List.of(SCREW)))).containsExactly(SCREW);
+    }
+
+}

--- a/vec/vec-common/src/test/java/com/foursoft/harness/vec/common/traversal/SingleNavigationTest.java
+++ b/vec/vec-common/src/test/java/com/foursoft/harness/vec/common/traversal/SingleNavigationTest.java
@@ -84,16 +84,39 @@ class SingleNavigationTest {
     }
 
     @Test
-    void thenEachContinuesWithAMultiNavigation() {
+    void thenContinuesWithAMultiNavigation() {
         final MultiNavigation<Plant, Part> partsOfTheOnlyAssembly =
                 Navigations.<Plant, Assembly>collection(Plant::assemblies)
                         .atMostOne()
-                        .thenEach(Navigations.collection(Assembly::parts));
+                        .then(Navigations.collection(Assembly::parts));
 
         final Assembly assembly = new Assembly("assembly", null, List.of(SCREW, NUT));
 
         assertThat(partsOfTheOnlyAssembly.listFrom(new Plant(List.of(assembly)))).containsExactly(SCREW, NUT);
         assertThat(partsOfTheOnlyAssembly.listFrom(new Plant(Collections.emptyList()))).isEmpty();
+    }
+
+    private static Optional<Grade> gradeOf(final Screw screw) {
+        return Optional.ofNullable(screw.grade());
+    }
+
+    /**
+     * {@code then} is overloaded on the kind of the following navigation, so the argument has to have a
+     * known kind. This pins the forms which resolve; an implicitly typed lambda does not and has to be
+     * lifted with {@link Navigations} instead.
+     */
+    @Test
+    void thenResolvesTheOverloadForEveryUnambiguousArgumentForm() {
+        final SingleNavigation<Assembly, Screw> screw = MAIN_PART.ofType(Screw.class);
+        final Assembly assembly = assemblyWith(SCREW);
+
+        // lifted by the factory, the intended form
+        assertThat(screw.then(Navigations.nullable(Screw::grade)).from(assembly)).contains(GRADE_8_8);
+        // exact method reference
+        assertThat(screw.then(SingleNavigationTest::gradeOf).from(assembly)).contains(GRADE_8_8);
+        // explicitly typed lambda
+        assertThat(screw.then((final Screw s) -> Optional.ofNullable(s.grade())).from(assembly))
+                .contains(GRADE_8_8);
     }
 
     @Test

--- a/vec/vec-common/src/test/java/com/foursoft/harness/vec/common/traversal/SingleNavigationTest.java
+++ b/vec/vec-common/src/test/java/com/foursoft/harness/vec/common/traversal/SingleNavigationTest.java
@@ -1,0 +1,139 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC Common
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.common.traversal;
+
+import com.foursoft.harness.vec.common.traversal.TestModel.Assembly;
+import com.foursoft.harness.vec.common.traversal.TestModel.Grade;
+import com.foursoft.harness.vec.common.traversal.TestModel.Nut;
+import com.foursoft.harness.vec.common.traversal.TestModel.Part;
+import com.foursoft.harness.vec.common.traversal.TestModel.Plant;
+import com.foursoft.harness.vec.common.traversal.TestModel.Screw;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SingleNavigationTest {
+
+    private static final Grade GRADE_8_8 = new Grade("8.8");
+    private static final Screw SCREW = new Screw("M6", GRADE_8_8);
+    private static final Nut NUT = new Nut("M6");
+
+    private static final SingleNavigation<Assembly, Part> MAIN_PART =
+            Navigations.nullable(Assembly::mainPart);
+
+    private static Assembly assemblyWith(final Part mainPart) {
+        return new Assembly("assembly", mainPart, Collections.emptyList());
+    }
+
+    @Test
+    void fromReturnsThePresentElement() {
+        assertThat(MAIN_PART.from(assemblyWith(SCREW))).contains(SCREW);
+    }
+
+    @Test
+    void fromReturnsEmptyForAnAbsentElement() {
+        assertThat(MAIN_PART.from(assemblyWith(null))).isEmpty();
+    }
+
+    @Test
+    void thenComposesTwoSingleNavigations() {
+        final SingleNavigation<Assembly, Grade> grade = MAIN_PART
+                .ofType(Screw.class)
+                .then(Navigations.nullable(Screw::grade));
+
+        assertThat(grade.from(assemblyWith(SCREW))).contains(GRADE_8_8);
+    }
+
+    @Test
+    void thenPropagatesAnAbsentIntermediateElement() {
+        final SingleNavigation<Assembly, Grade> grade = MAIN_PART
+                .ofType(Screw.class)
+                .then(Navigations.nullable(Screw::grade));
+
+        assertThat(grade.from(assemblyWith(null))).isEmpty();
+        assertThat(grade.from(assemblyWith(NUT))).isEmpty();
+        assertThat(grade.from(assemblyWith(new Screw("M8", null)))).isEmpty();
+    }
+
+    @Test
+    void thenEachContinuesWithAMultiNavigation() {
+        final MultiNavigation<Plant, Part> partsOfTheOnlyAssembly =
+                Navigations.<Plant, Assembly>collection(Plant::assemblies)
+                        .atMostOne()
+                        .thenEach(Navigations.collection(Assembly::parts));
+
+        final Assembly assembly = new Assembly("assembly", null, List.of(SCREW, NUT));
+
+        assertThat(partsOfTheOnlyAssembly.listFrom(new Plant(List.of(assembly)))).containsExactly(SCREW, NUT);
+        assertThat(partsOfTheOnlyAssembly.listFrom(new Plant(Collections.emptyList()))).isEmpty();
+    }
+
+    @Test
+    void filterKeepsOnlyMatchingElements() {
+        final SingleNavigation<Assembly, Part> m6 = MAIN_PART.filter(part -> "M6".equals(part.name()));
+
+        assertThat(m6.from(assemblyWith(SCREW))).contains(SCREW);
+        assertThat(m6.from(assemblyWith(new Nut("M8")))).isEmpty();
+    }
+
+    @Test
+    void ofTypeNarrowsTheNavigation() {
+        final SingleNavigation<Assembly, Screw> screw = MAIN_PART.ofType(Screw.class);
+
+        assertThat(screw.from(assemblyWith(SCREW))).contains(SCREW);
+        assertThat(screw.from(assemblyWith(NUT))).isEmpty();
+    }
+
+    @Test
+    void asMultiYieldsZeroOrOneElement() {
+        assertThat(MAIN_PART.asMulti().listFrom(assemblyWith(SCREW))).containsExactly(SCREW);
+        assertThat(MAIN_PART.asMulti().listFrom(assemblyWith(null))).isEmpty();
+    }
+
+    @Test
+    void orElseNullAndOrElseUnwrapTheResult() {
+        assertThat(MAIN_PART.orElseNull(assemblyWith(SCREW))).isEqualTo(SCREW);
+        assertThat(MAIN_PART.orElseNull(assemblyWith(null))).isNull();
+        assertThat(MAIN_PART.orElse(assemblyWith(null), NUT)).isEqualTo(NUT);
+    }
+
+    @Test
+    void streamFromYieldsZeroOrOneElement() {
+        assertThat(MAIN_PART.streamFrom(assemblyWith(SCREW))).containsExactly(SCREW);
+        assertThat(MAIN_PART.streamFrom(assemblyWith(null))).isEmpty();
+    }
+
+    @Test
+    void isUsableWhereverAFunctionIsExpected() {
+        assertThat(Stream.of(assemblyWith(SCREW)).map(MAIN_PART)).containsExactly(Optional.of(SCREW));
+    }
+
+}

--- a/vec/vec-common/src/test/java/com/foursoft/harness/vec/common/traversal/TestModel.java
+++ b/vec/vec-common/src/test/java/com/foursoft/harness/vec/common/traversal/TestModel.java
@@ -1,8 +1,8 @@
 /*-
  * ========================LICENSE_START=================================
- * VEC 2.X
+ * VEC Common
  * %%
- * Copyright (C) 2020 - 2023 4Soft GmbH
+ * Copyright (C) 2020 - 2026 4Soft GmbH
  * %%
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -10,10 +10,10 @@
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * 
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -23,38 +23,41 @@
  * THE SOFTWARE.
  * =========================LICENSE_END==================================
  */
-package com.foursoft.harness.vec.v2x.navigations;
-
-import com.foursoft.harness.vec.common.annotations.RequiresBackReferences;
-import com.foursoft.harness.vec.v2x.VecDocumentVersion;
-import com.foursoft.harness.vec.v2x.VecExtendableElement;
-import com.foursoft.harness.vec.v2x.VecOccurrenceOrUsage;
-import com.foursoft.harness.vec.v2x.VecRole;
+package com.foursoft.harness.vec.common.traversal;
 
 import java.util.List;
-import java.util.function.Function;
 
 /**
- * Navigation methods which don't fit into a special category.
+ * Minimal model to test the navigation combinators without depending on a generated VEC model.
  */
-public final class VecNavs {
+final class TestModel {
 
-    private VecNavs() {
+    private TestModel() {
         // hide default constructor
     }
 
-    public static Function<VecExtendableElement, List<String>> externalDocumentNumbers() {
-        return element -> element.getReferencedExternalDocuments().stream()
-                .map(VecDocumentVersion::getDocumentNumber)
-                .toList();
+    interface Part {
+
+        String name();
+
     }
 
-    @RequiresBackReferences
-    public static Function<VecRole, VecDocumentVersion> parentDocumentVersion() {
-        return role -> {
-            final VecOccurrenceOrUsage parentOccurrenceOrUsage = role.getParentOccurrenceOrUsage();
-            return PartOccurrenceOrUsageNavs.parentDocumentVersion().apply(parentOccurrenceOrUsage);
-        };
+    record Grade(String designation) {
+    }
+
+    record Screw(String name, Grade grade) implements Part {
+    }
+
+    record Nut(String name) implements Part {
+    }
+
+    record Assembly(String name, Part mainPart, List<Part> parts) {
+    }
+
+    record Plant(List<Assembly> assemblies) {
+    }
+
+    record Kit(List<Screw> screws) {
     }
 
 }

--- a/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/ConfigurableElementNavs.java
+++ b/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/ConfigurableElementNavs.java
@@ -2,7 +2,7 @@
  * ========================LICENSE_START=================================
  * VEC 1.2.X
  * %%
- * Copyright (C) 2020 - 2023 4Soft GmbH
+ * Copyright (C) 2020 - 2026 4Soft GmbH
  * %%
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -10,10 +10,10 @@
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * 
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -27,34 +27,48 @@ package com.foursoft.harness.vec.v12x.navigations;
 
 import com.foursoft.harness.vec.v12x.VecConfigurableElement;
 import com.foursoft.harness.vec.v12x.VecVariantConfiguration;
+import com.foursoft.harness.vec.v12x.traversal.ConfigurableElements;
 
 import java.util.Optional;
 import java.util.function.Function;
 
 /**
  * Navigation methods for the {@link VecConfigurableElement}.
+ *
+ * @deprecated Use {@link ConfigurableElements} instead.
  */
+@Deprecated(forRemoval = true)
 public final class ConfigurableElementNavs {
 
     private ConfigurableElementNavs() {
         // hide default constructor
     }
 
+    /**
+     * @deprecated Use {@link ConfigurableElements#toVariantConfiguration()} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecConfigurableElement, Optional<VecVariantConfiguration>> variantConfiguration() {
         return configurableElement -> Optional.ofNullable(configurableElement)
-                .map(VecConfigurableElement::getConfigInfo);
+                .flatMap(ConfigurableElements.toVariantConfiguration());
     }
 
+    /**
+     * @deprecated Use {@link ConfigurableElements#toLogisticControlString()} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecConfigurableElement, Optional<String>> controlInformation() {
         return configurableElement -> Optional.ofNullable(configurableElement)
-                .map(VecConfigurableElement::getConfigInfo)
-                .map(VecVariantConfiguration::getLogisticControlString);
+                .flatMap(ConfigurableElements.toLogisticControlString());
     }
 
+    /**
+     * @deprecated Use {@link ConfigurableElements#toLogisticControlExpression()} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecConfigurableElement, Optional<String>> controlExpression() {
         return configurableElement -> Optional.ofNullable(configurableElement)
-                .map(VecConfigurableElement::getConfigInfo)
-                .map(VecVariantConfiguration::getLogisticControlExpression);
+                .flatMap(ConfigurableElements.toLogisticControlExpression());
     }
 
 }

--- a/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/ContentNavs.java
+++ b/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/ContentNavs.java
@@ -2,7 +2,7 @@
  * ========================LICENSE_START=================================
  * VEC 1.2.X
  * %%
- * Copyright (C) 2020 - 2023 4Soft GmbH
+ * Copyright (C) 2020 - 2026 4Soft GmbH
  * %%
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -10,10 +10,10 @@
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * 
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -25,37 +25,47 @@
  */
 package com.foursoft.harness.vec.v12x.navigations;
 
-import com.foursoft.harness.vec.common.util.StreamUtils;
+import com.foursoft.harness.vec.common.traversal.MultiNavigation;
 import com.foursoft.harness.vec.v12x.VecContent;
 import com.foursoft.harness.vec.v12x.VecDocumentVersion;
 import com.foursoft.harness.vec.v12x.VecSpecification;
+import com.foursoft.harness.vec.v12x.traversal.Contents;
+import com.foursoft.harness.vec.v12x.traversal.SpecificationOwners;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 /**
  * Navigation methods for the {@link VecContent}.
+ *
+ * @deprecated Use {@link Contents} instead.
  */
+@Deprecated(forRemoval = true)
 public final class ContentNavs {
 
     private ContentNavs() {
         // hide default constructor
     }
 
+    /**
+     * @deprecated Compose the navigation at the call site instead:
+     * {@code Contents.toDocumentVersions().then(SpecificationOwners.toSpecifications()).ofType(clazz)}.
+     */
+    @Deprecated(forRemoval = true)
     public static <T extends VecSpecification> Function<VecContent, List<T>> allSpecificationsOf(final Class<T> clazz) {
-        return vecContent -> vecContent.getDocumentVersions()
-                .stream()
-                .flatMap(StreamUtils.toStream(documentVersion -> documentVersion.getSpecificationsWithType(clazz)))
-                .toList();
+        final MultiNavigation<VecContent, T> specifications = Contents.toDocumentVersions()
+                .then(SpecificationOwners.<VecDocumentVersion>toSpecifications())
+                .ofType(clazz);
+        return specifications::listFrom;
     }
 
-    public static Function<VecContent, Optional<VecDocumentVersion>> documentVersionBy(
-            final String documentNumber) {
-        return content -> content.getDocumentVersions().stream()
-                .filter(documentVersion -> documentVersion.getDocumentNumber().equals(documentNumber))
-                .collect(StreamUtils.findOneOrNone());
+    /**
+     * @deprecated Use {@link Contents#documentVersionBy(String)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    public static Function<VecContent, Optional<VecDocumentVersion>> documentVersionBy(final String documentNumber) {
+        return Contents.documentVersionBy(documentNumber);
     }
 
 }

--- a/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/CustomPropertyNavs.java
+++ b/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/CustomPropertyNavs.java
@@ -2,7 +2,7 @@
  * ========================LICENSE_START=================================
  * VEC 1.2.X
  * %%
- * Copyright (C) 2020 - 2023 4Soft GmbH
+ * Copyright (C) 2020 - 2026 4Soft GmbH
  * %%
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -10,10 +10,10 @@
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * 
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,95 +26,131 @@
 package com.foursoft.harness.vec.v12x.navigations;
 
 import com.foursoft.harness.vec.common.HasCustomProperties;
-import com.foursoft.harness.vec.common.util.StreamUtils;
-import com.foursoft.harness.vec.v12x.*;
-import com.foursoft.harness.vec.v12x.predicates.VecPredicates;
+import com.foursoft.harness.vec.common.traversal.SingleNavigation;
+import com.foursoft.harness.vec.v12x.VecCustomProperty;
+import com.foursoft.harness.vec.v12x.VecExtendableElement;
+import com.foursoft.harness.vec.v12x.VecLanguageCode;
+import com.foursoft.harness.vec.v12x.VecLocalizedStringProperty;
+import com.foursoft.harness.vec.v12x.VecValueRange;
+import com.foursoft.harness.vec.v12x.traversal.CustomProperties;
+import com.foursoft.harness.vec.v12x.traversal.LocalizedStringProperties;
 
 import java.math.BigInteger;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 
 /**
  * Navigation methods for custom properties of a {@link VecExtendableElement}.
+ *
+ * @deprecated Use {@link CustomProperties} instead, and {@link LocalizedStringProperties} for the navigations
+ * starting at a {@link VecLocalizedStringProperty}.
  */
+@Deprecated(forRemoval = true)
 public final class CustomPropertyNavs {
 
     private CustomPropertyNavs() {
         // hide default constructor
     }
 
+    /**
+     * @deprecated Use {@link CustomProperties#stringValueOf(String)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<HasCustomProperties<VecCustomProperty>, Optional<String>> customPropertyValueStringOf(
             final String customProperty) {
-        return element -> element.getCustomProperty(VecSimpleValueProperty.class, customProperty)
-                .map(VecSimpleValueProperty::getValue);
+        return CustomProperties.stringValueOf(customProperty);
     }
 
+    /**
+     * @deprecated Use {@link CustomProperties#integerValueOf(String)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<HasCustomProperties<VecCustomProperty>, Optional<BigInteger>> customPropertyValueIntegerOf(
             final String customProperty) {
-        return element -> element.getCustomProperty(VecIntegerValueProperty.class, customProperty)
-                .map(VecIntegerValueProperty::getValue);
+        return CustomProperties.integerValueOf(customProperty);
     }
 
+    /**
+     * @deprecated Use {@link CustomProperties#stringValuesOf(String)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<HasCustomProperties<VecCustomProperty>, List<String>> customPropertyValueStringsOf(
             final String customProperty) {
-        return element -> element.getCustomPropertiesWithType(VecSimpleValueProperty.class).stream()
-                .filter(c -> c.getPropertyType().equals(customProperty))
-                .map(VecSimpleValueProperty::getValue)
-                .toList();
+        return CustomProperties.stringValuesOf(customProperty)::listFrom;
     }
 
+    /**
+     * @deprecated Use {@link CustomProperties#doubleValueOf(String)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<HasCustomProperties<VecCustomProperty>, Optional<Double>> customPropertyValueDoubleOf(
             final String customProperty) {
-        return element -> element.getCustomProperty(VecDoubleValueProperty.class, customProperty)
-                .map(VecDoubleValueProperty::getValue);
+        return CustomProperties.doubleValueOf(customProperty);
     }
 
+    /**
+     * @deprecated Use {@link CustomProperties#valueRangeOf(String)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<HasCustomProperties<VecCustomProperty>, Optional<VecValueRange>> customPropertyValueRangeOf(
             final String customProperty) {
-        return element -> element.getCustomProperty(VecValueRangeProperty.class, customProperty)
-                .map(VecValueRangeProperty::getValue);
+        return CustomProperties.valueRangeOf(customProperty);
     }
 
+    /**
+     * @deprecated Use {@link CustomProperties#booleanValueOf(String)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<HasCustomProperties<VecCustomProperty>, Optional<Boolean>> customPropertyValueBooleanOf(
             final String customProperty) {
-        return element -> element.getCustomProperty(VecBooleanValueProperty.class, customProperty)
-                .map(VecBooleanValueProperty::isValue);
+        return CustomProperties.booleanValueOf(customProperty);
     }
 
+    /**
+     * @deprecated Use {@link CustomProperties#nestedPropertiesOf(String)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<HasCustomProperties<VecCustomProperty>, List<VecCustomProperty>> customPropertyValuesOf(
             final String customProperty) {
-        return element -> element.getCustomProperty(VecComplexProperty.class, customProperty)
-                .map(VecComplexProperty::getCustomProperties)
-                .orElseGet(Collections::emptyList);
+        return CustomProperties.nestedPropertiesOf(customProperty)::listFrom;
     }
 
+    /**
+     * @deprecated Use {@link CustomProperties#localizedValueOf(String, VecLanguageCode)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<HasCustomProperties<VecCustomProperty>, Optional<String>> customPropertyValueLocalizedString(
             final String customProperty, final VecLanguageCode languageCode) {
-        return element -> element.getCustomProperty(VecLocalizedStringProperty.class, customProperty)
-                .stream()
-                .map(convertLocalizedStringProperty(languageCode))
-                .flatMap(StreamUtils.unwrapOptional())
-                .collect(StreamUtils.findOneOrNone());
+        return CustomProperties.localizedValueOf(customProperty, languageCode);
     }
 
+    /**
+     * @deprecated Use {@link LocalizedStringProperties#valueIn(VecLanguageCode)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecLocalizedStringProperty, Optional<String>> convertLocalizedStringProperty(
             final VecLanguageCode languageCode) {
         return localizedString -> Optional.ofNullable(localizedString)
-                .map(VecLocalizedStringProperty::getValue)
-                .filter(VecPredicates.languageCode(languageCode))
-                .map(VecLocalizedString::getValue);
+                .flatMap(LocalizedStringProperties.valueIn(languageCode));
     }
 
+    /**
+     * @deprecated Narrow a navigation leading to the custom properties at the call site instead, for example
+     * {@code CustomProperties.toCustomProperties().filter(…).ofType(targetClass).atMostOne()}. This one takes
+     * the properties themselves rather than the element holding them, so there is nothing to navigate from.
+     */
+    @Deprecated(forRemoval = true)
     public static <T extends VecCustomProperty> Function<Collection<VecCustomProperty>, Optional<T>> customPropertyOfType(
             final String propertyType, final Class<T> targetClass) {
-        return customProperties -> customProperties.stream()
-                .filter(customProperty -> customProperty.getPropertyType().equalsIgnoreCase(propertyType))
-                .filter(targetClass::isInstance)
-                .map(targetClass::cast)
-                .collect(StreamUtils.findOneOrNone());
+        final SingleNavigation<HasCustomProperties<VecCustomProperty>, T> property =
+                CustomProperties.toCustomProperties()
+                        .filter(customProperty -> customProperty.getPropertyType().equalsIgnoreCase(propertyType))
+                        .ofType(targetClass)
+                        .atMostOne();
+        return customProperties -> property.from(() -> new ArrayList<>(customProperties));
     }
 
 }

--- a/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/DescriptionNavs.java
+++ b/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/DescriptionNavs.java
@@ -26,95 +26,110 @@
 package com.foursoft.harness.vec.v12x.navigations;
 
 import com.foursoft.harness.vec.common.HasDescription;
-import com.foursoft.harness.vec.common.util.StreamUtils;
-import com.foursoft.harness.vec.common.util.StringUtils;
 import com.foursoft.harness.vec.v12x.VecAbstractLocalizedString;
 import com.foursoft.harness.vec.v12x.VecLanguageCode;
-import com.foursoft.harness.vec.v12x.VecLocalizedTypedString;
-import com.foursoft.harness.vec.v12x.predicates.VecPredicates;
+import com.foursoft.harness.vec.v12x.traversal.Descriptions;
+import com.foursoft.harness.vec.v12x.traversal.LocalizedStrings;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 
 /**
  * Navigation methods for {@link HasDescription} with {@link VecAbstractLocalizedString}s.
+ *
+ * @deprecated Use {@link Descriptions} instead.
  */
+@Deprecated(forRemoval = true)
 public final class DescriptionNavs {
 
     private DescriptionNavs() {
         // hide default constructor
     }
 
+    /**
+     * @deprecated Use {@link Descriptions#germanDescription()} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<HasDescription<? extends VecAbstractLocalizedString>, Optional<String>> germanDescription() {
-        return descriptionIn(VecLanguageCode.DE);
+        return Descriptions.germanDescription();
     }
 
+    /**
+     * @deprecated Use {@link Descriptions#englishDescription()} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<HasDescription<? extends VecAbstractLocalizedString>, Optional<String>> englishDescription() {
-        return descriptionIn(VecLanguageCode.EN);
+        return Descriptions.englishDescription();
     }
 
+    /**
+     * @deprecated Use {@link Descriptions#descriptionIn(VecLanguageCode)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<HasDescription<? extends VecAbstractLocalizedString>, Optional<String>> descriptionIn(
             final VecLanguageCode vecLanguageCode) {
-        return descHolder -> {
-            final List<? extends VecAbstractLocalizedString> localizedStrings = descHolder.getDescriptions();
-            return stringIn(vecLanguageCode).apply(localizedStrings);
-        };
+        return Descriptions.descriptionIn(vecLanguageCode);
     }
 
+    /**
+     * @deprecated Reduce the localized strings with {@link LocalizedStrings#valueIn(VecLanguageCode)}
+     * instead, which composes onto any navigation leading to them, for example
+     * {@link Descriptions#toDescriptions()}.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<List<? extends VecAbstractLocalizedString>, Optional<String>> germanString() {
         return stringIn(VecLanguageCode.DE);
     }
 
+    /**
+     * @deprecated Reduce the localized strings with {@link LocalizedStrings#valueIn(VecLanguageCode)}
+     * instead, which composes onto any navigation leading to them, for example
+     * {@link Descriptions#toDescriptions()}.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<List<? extends VecAbstractLocalizedString>, Optional<String>> englishString() {
         return stringIn(VecLanguageCode.EN);
     }
 
+    /**
+     * @deprecated Reduce the localized strings with {@link LocalizedStrings#valueIn(VecLanguageCode)}
+     * instead, which composes onto any navigation leading to them, for example
+     * {@link Descriptions#toDescriptions()}.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<List<? extends VecAbstractLocalizedString>, Optional<String>> stringIn(
             final VecLanguageCode vecLanguageCode) {
-        return localizedStrings -> {
-            if (localizedStrings.isEmpty()) {
-                return Optional.empty();
-            }
-            if (localizedStrings.size() == 1) {
-                final VecAbstractLocalizedString localizedString = localizedStrings.get(0);
-                if (localizedString instanceof VecLocalizedTypedString &&
-                        !StringUtils.isEmpty(((VecLocalizedTypedString) localizedString).getType())) {
-                    return Optional.empty();
-                }
-                return Optional.ofNullable(localizedString).map(VecAbstractLocalizedString::getValue);
-            }
-
-            return localizedStrings.stream()
-                    .filter(Objects::nonNull)
-                    .filter(d -> !(d instanceof VecLocalizedTypedString))
-                    .filter(VecPredicates.languageCode(vecLanguageCode))
-                    .map(VecAbstractLocalizedString::getValue)
-                    .filter(Objects::nonNull)
-                    .collect(StreamUtils.findOneOrNone());
-        };
+        return localizedStrings -> localizedStrings.stream()
+                .map(VecAbstractLocalizedString.class::cast)
+                .collect(LocalizedStrings.valueIn(vecLanguageCode));
     }
 
+    /**
+     * @deprecated Use {@link Descriptions#germanTypedStringBy(String)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<HasDescription<? extends VecAbstractLocalizedString>, Optional<String>> germanTypedStringBy(
             final String descriptionType) {
-        return typedStringBy(descriptionType, VecLanguageCode.DE);
+        return Descriptions.germanTypedStringBy(descriptionType);
     }
 
+    /**
+     * @deprecated Use {@link Descriptions#englishTypedStringBy(String)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<HasDescription<? extends VecAbstractLocalizedString>, Optional<String>> englishTypedStringBy(
             final String descriptionType) {
-        return typedStringBy(descriptionType, VecLanguageCode.EN);
+        return Descriptions.englishTypedStringBy(descriptionType);
     }
 
+    /**
+     * @deprecated Use {@link Descriptions#typedStringBy(String, VecLanguageCode)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<HasDescription<? extends VecAbstractLocalizedString>, Optional<String>> typedStringBy(
             final String descriptionType, final VecLanguageCode vecLanguageCode) {
-        return hasDescription -> hasDescription.getDescriptions().stream()
-                .filter(VecPredicates.languageCode(vecLanguageCode))
-                .flatMap(StreamUtils.ofClass(VecLocalizedTypedString.class))
-                .filter(typedString -> descriptionType.equals(typedString.getType()))
-                .collect(StreamUtils.findOneOrNone())
-                .map(VecLocalizedTypedString::getValue)
-                .filter(StringUtils::isNotEmpty);
+        return Descriptions.typedStringBy(descriptionType, vecLanguageCode);
     }
 
 }

--- a/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/DocumentVersionNavs.java
+++ b/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/DocumentVersionNavs.java
@@ -2,7 +2,7 @@
  * ========================LICENSE_START=================================
  * VEC 1.2.X
  * %%
- * Copyright (C) 2020 - 2023 4Soft GmbH
+ * Copyright (C) 2020 - 2026 4Soft GmbH
  * %%
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -10,10 +10,10 @@
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * 
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -25,66 +25,75 @@
  */
 package com.foursoft.harness.vec.v12x.navigations;
 
-import com.foursoft.harness.vec.common.util.StreamUtils;
-import com.foursoft.harness.vec.v12x.*;
+import com.foursoft.harness.vec.v12x.VecBuildingBlockPositioning2D;
+import com.foursoft.harness.vec.v12x.VecBuildingBlockPositioning3D;
+import com.foursoft.harness.vec.v12x.VecBuildingBlockSpecification2D;
+import com.foursoft.harness.vec.v12x.VecBuildingBlockSpecification3D;
+import com.foursoft.harness.vec.v12x.VecDocumentVersion;
+import com.foursoft.harness.vec.v12x.VecGeometryNode2D;
+import com.foursoft.harness.vec.v12x.VecGeometryNode3D;
+import com.foursoft.harness.vec.v12x.VecGeometrySegment3D;
+import com.foursoft.harness.vec.v12x.VecNodeLocation;
+import com.foursoft.harness.vec.v12x.VecOccurrenceOrUsage;
+import com.foursoft.harness.vec.v12x.VecOccurrenceOrUsageViewItem2D;
+import com.foursoft.harness.vec.v12x.VecOccurrenceOrUsageViewItem3D;
+import com.foursoft.harness.vec.v12x.VecOnPointPlacement;
+import com.foursoft.harness.vec.v12x.VecPlaceableElementRole;
+import com.foursoft.harness.vec.v12x.VecPlacement;
+import com.foursoft.harness.vec.v12x.VecTopologyNode;
+import com.foursoft.harness.vec.v12x.VecTopologySegment;
+import com.foursoft.harness.vec.v12x.traversal.DocumentVersions;
 
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * Navigation methods for the {@link VecDocumentVersion}.
+ *
+ * @deprecated Use {@link DocumentVersions} instead.
  */
+@Deprecated(forRemoval = true)
 public final class DocumentVersionNavs {
 
     private DocumentVersionNavs() {
         // hide default constructor
     }
 
+    /**
+     * @deprecated Use {@link DocumentVersions#geometryNodes3dBy(VecTopologyNode)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecDocumentVersion, List<VecGeometryNode3D>> geometryNodes3dBy(
             final VecTopologyNode topologyNode) {
-        return documentVersion -> documentVersion.getSpecificationsWithType(VecBuildingBlockSpecification3D.class)
-                .stream()
-                .map(VecBuildingBlockSpecification3D::getGeometryNodes)
-                .flatMap(Collection::stream)
-                .filter(node3d -> node3d.getReferenceNode().equals(topologyNode))
-                .toList();
+        return DocumentVersions.geometryNodes3dBy(topologyNode)::listFrom;
     }
 
+    /**
+     * @deprecated Use {@link DocumentVersions#geometrySegments3dBy(VecTopologySegment)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecDocumentVersion, List<VecGeometrySegment3D>> geometrySegments3dBy(
             final VecTopologySegment topologySegment) {
-        return documentVersion -> documentVersion.getSpecificationsWithType(VecBuildingBlockSpecification3D.class)
-                .stream()
-                .map(VecBuildingBlockSpecification3D::getGeometrySegments)
-                .flatMap(Collection::stream)
-                .filter(segment3d -> segment3d.getReferenceSegment().equals(topologySegment))
-                .toList();
+        return DocumentVersions.geometrySegments3dBy(topologySegment)::listFrom;
     }
 
+    /**
+     * @deprecated Use {@link DocumentVersions#viewItems3dBy(VecOccurrenceOrUsage)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecDocumentVersion, List<VecOccurrenceOrUsageViewItem3D>> viewItems3dBy(
             final VecOccurrenceOrUsage occurrence) {
-        return documentVersion -> documentVersion.getSpecificationsWithType(VecBuildingBlockSpecification3D.class)
-                .stream()
-                .map(specification -> specification
-                        .getPlacedElementViewItem3Ds().stream()
-                        .filter(viewItem -> viewItem.getOccurrenceOrUsage().contains(occurrence))
-                        .toList())
-                .flatMap(Collection::stream)
-                .toList();
+        return DocumentVersions.viewItems3dBy(occurrence)::listFrom;
     }
 
+    /**
+     * @deprecated Use {@link DocumentVersions#topologyNodeBy(String)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecDocumentVersion, Optional<VecTopologyNode>> topologyNodeBy(
             final String occurrenceIdentification) {
-        return documentVersion -> SpecificationNavs.components().apply(documentVersion)
-                .stream()
-                .filter(occurrence -> occurrence.getIdentification().equals(occurrenceIdentification))
-                .map(PartOccurrenceOrUsageNavs.topologyNodeByOccurrenceOrUsage())
-                .flatMap(StreamUtils.unwrapOptional())
-                .collect(StreamUtils.findOneOrNone());
+        return DocumentVersions.topologyNodeBy(occurrenceIdentification);
     }
 
     /**
@@ -93,142 +102,107 @@ public final class DocumentVersionNavs {
      * @param placedElement Placed Element the {@link VecOnPointPlacement} needs to contain.
      *                      May be {@code null} to not filter for this.
      * @return A possibly-empty list of VecNodeLocations.
+     * @deprecated Use {@link DocumentVersions#nodeLocationsOf(VecPlaceableElementRole)} instead, or
+     * {@link DocumentVersions#toNodeLocations()} for the unfiltered navigation which passing {@code null}
+     * stood for.
      */
+    @Deprecated(forRemoval = true)
     public static Function<VecDocumentVersion, List<VecNodeLocation>> nodeLocationsBy(
             final VecPlaceableElementRole placedElement) {
-        return documentVersion -> documentVersion
-                .getSpecificationsWithType(VecPlacementSpecification.class).stream()
-                .map(VecPlacementSpecification::getPlacements)
-                .flatMap(Collection::stream)
-                .filter(VecOnPointPlacement.class::isInstance)
-                .map(VecOnPointPlacement.class::cast)
-                .filter(c -> placedElement == null || c.getPlacedElement().contains(placedElement))
-                .map(VecOnPointPlacement::getLocations)
-                .flatMap(Collection::stream)
-                .filter(VecNodeLocation.class::isInstance)
-                .map(VecNodeLocation.class::cast)
-                .toList();
+        return placedElement == null
+                ? DocumentVersions.toNodeLocations()::listFrom
+                : DocumentVersions.nodeLocationsOf(placedElement)::listFrom;
     }
 
+    /**
+     * @deprecated Use {@link DocumentVersions#placeableElementRoleBy(String, String)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecDocumentVersion, VecPlaceableElementRole> placeableElementRoleBy(
             final String compositionSpecificationId,
             final String occurrenceOrUsageId) {
-        return documentVersion -> SpecificationNavs.componentsBy(compositionSpecificationId).apply(documentVersion)
-                .stream()
-                .filter(c -> c.getIdentification().equals(occurrenceOrUsageId))
-                .map(VecPartOccurrence::getRoles)
-                .flatMap(Collection::stream)
-                .filter(VecPlaceableElementRole.class::isInstance)
-                .map(VecPlaceableElementRole.class::cast)
-                .collect(StreamUtils.findOneOrNone()).orElse(null);
+        return DocumentVersions.placeableElementRoleBy(compositionSpecificationId, occurrenceOrUsageId)::orElseNull;
     }
 
+    /**
+     * @deprecated Use {@link DocumentVersions#placementBy(String, String)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecDocumentVersion, VecPlacement> placementBy(final String compositionSpecificationId,
-                                                                         final String occurrenceOrUsageId) {
-        return documentVersion -> {
-            final VecPlaceableElementRole role =
-                    placeableElementRoleBy(compositionSpecificationId, occurrenceOrUsageId).apply(documentVersion);
-
-            return documentVersion.getSpecificationsWithType(VecPlacementSpecification.class).stream()
-                    .map(VecPlacementSpecification::getPlacements)
-                    .flatMap(Collection::stream)
-                    .filter(p -> p.getPlacedElement().stream().anyMatch(r -> r.equals(role)))
-                    .collect(StreamUtils.findOneOrNone()).orElse(null);
-        };
+                                                                        final String occurrenceOrUsageId) {
+        return DocumentVersions.placementBy(compositionSpecificationId, occurrenceOrUsageId)::orElseNull;
     }
 
+    /**
+     * @deprecated Use {@link DocumentVersions#geometryNode2dBy(VecNodeLocation)} instead, which searches all
+     * {@link VecBuildingBlockSpecification2D}s of the document version rather than only the first one.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecDocumentVersion, VecGeometryNode2D> geometryNode2dBy(final VecNodeLocation location) {
-        return documentVersion -> {
-            final List<VecGeometryNode2D> nodes = documentVersion
-                    .getSpecificationWithType(VecBuildingBlockSpecification2D.class)
-                    .map(VecBuildingBlockSpecification2D::getGeometryNodes)
-                    .orElseGet(Collections::emptyList);
-            return getGeometryNode(nodes, location);
-        };
+        return DocumentVersions.geometryNode2dBy(location)::orElseNull;
     }
 
+    /**
+     * @deprecated Use {@link DocumentVersions#geometryNode3dBy(VecNodeLocation)} instead, which searches all
+     * {@link VecBuildingBlockSpecification3D}s of the document version rather than only the first one.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecDocumentVersion, VecGeometryNode3D> geometryNode3dBy(final VecNodeLocation location) {
-        return documentVersion -> {
-            final List<VecGeometryNode3D> nodes = documentVersion
-                    .getSpecificationWithType(VecBuildingBlockSpecification3D.class)
-                    .map(VecBuildingBlockSpecification3D::getGeometryNodes)
-                    .orElseGet(Collections::emptyList);
-            return getGeometryNode(nodes, location);
-        };
+        return DocumentVersions.geometryNode3dBy(location)::orElseNull;
     }
 
+    /**
+     * @deprecated Use {@link DocumentVersions#viewItem2dBy(String)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecDocumentVersion, Optional<VecOccurrenceOrUsageViewItem2D>> viewItem2dBy(
             final String occurrenceOrUsageId) {
-        return documentVersion -> {
-            final Stream<VecOccurrenceOrUsageViewItem2D> stream = documentVersion
-                    .getSpecificationsWithType(VecBuildingBlockSpecification2D.class)
-                    .stream()
-                    .map(VecBuildingBlockSpecification2D::getPlacedElementViewItems)
-                    .flatMap(Collection::stream);
-            return getViewItem(stream, occurrenceOrUsageId);
-        };
+        return DocumentVersions.viewItem2dBy(occurrenceOrUsageId);
     }
 
+    /**
+     * @deprecated Use {@link DocumentVersions#viewItem3dBy(String)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecDocumentVersion, Optional<VecOccurrenceOrUsageViewItem3D>> viewItem3dBy(
             final String occurrenceOrUsageId) {
-        return documentVersion -> {
-            final Stream<VecOccurrenceOrUsageViewItem3D> stream = documentVersion
-                    .getSpecificationsWithType(VecBuildingBlockSpecification3D.class)
-                    .stream()
-                    .map(VecBuildingBlockSpecification3D::getPlacedElementViewItem3Ds)
-                    .flatMap(Collection::stream);
-            return getViewItem(stream, occurrenceOrUsageId);
-        };
+        return DocumentVersions.viewItem3dBy(occurrenceOrUsageId);
     }
 
+    /**
+     * @deprecated Use {@link DocumentVersions#buildingBlockSpecification2dBy(String)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecDocumentVersion, Optional<VecBuildingBlockSpecification2D>> buildingBlockSpecification2dBy(
             final String specificationId) {
-        return documentVersion -> documentVersion
-                .getSpecificationWith(VecBuildingBlockSpecification2D.class, specificationId);
+        return DocumentVersions.buildingBlockSpecification2dBy(specificationId);
     }
 
+    /**
+     * @deprecated Use {@link DocumentVersions#buildingBlockSpecification3dBy(String)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecDocumentVersion, Optional<VecBuildingBlockSpecification3D>> buildingBlockSpecification3dBy(
             final String specificationId) {
-        return documentVersion -> documentVersion
-                .getSpecificationWith(VecBuildingBlockSpecification3D.class, specificationId);
+        return DocumentVersions.buildingBlockSpecification3dBy(specificationId);
     }
 
+    /**
+     * @deprecated Use {@link DocumentVersions#positioning2dWith(VecBuildingBlockSpecification2D)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecDocumentVersion, Optional<VecBuildingBlockPositioning2D>> positioning2dWith(
             final VecBuildingBlockSpecification2D buildingBlock) {
-        return documentVersion -> documentVersion
-                .getSpecificationsWithType(VecHarnessDrawingSpecification2D.class).stream()
-                .map(VecHarnessDrawingSpecification2D::getBuildingBlockPositionings)
-                .flatMap(Collection::stream)
-                .filter(positioning -> buildingBlock.equals(positioning.getReferenced2DBuildingBlock()))
-                .collect(StreamUtils.findOneOrNone());
+        return DocumentVersions.positioning2dWith(buildingBlock);
     }
 
+    /**
+     * @deprecated Use {@link DocumentVersions#positioning3dWith(VecBuildingBlockSpecification3D)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecDocumentVersion, Optional<VecBuildingBlockPositioning3D>> positioning3dWith(
             final VecBuildingBlockSpecification3D buildingBlock) {
-        return documentVersion -> documentVersion
-                .getSpecificationsWithType(VecHarnessGeometrySpecification3D.class).stream()
-                .map(VecHarnessGeometrySpecification3D::getBuildingBlockPositionings)
-                .flatMap(Collection::stream)
-                .filter(positioning -> buildingBlock.equals(positioning.getReferenced3DBuildingBlock()))
-                .collect(StreamUtils.findOneOrNone());
-    }
-
-    private static <T extends VecGeometryNode> T getGeometryNode(final List<T> nodes,
-                                                                 final VecNodeLocation location) {
-        return nodes.stream()
-                .filter(node -> node.getReferenceNode().equals(location.getReferencedNode()))
-                .collect(StreamUtils.findOneOrNone()).orElse(null);
-    }
-
-    private static <T extends HasOccurrenceOrUsages> Optional<T> getViewItem(final Stream<T> stream,
-                                                                             final String occurrenceOrUsageId) {
-        return stream
-                .filter(item -> item.getOccurrenceOrUsage().stream()
-                        .collect(StreamUtils.findOneOrNone())
-                        .map(VecOccurrenceOrUsage::getIdentification)
-                        .map(id -> id.equals(occurrenceOrUsageId))
-                        .orElse(false))
-                .collect(StreamUtils.findOneOrNone());
+        return DocumentVersions.positioning3dWith(buildingBlock);
     }
 
 }

--- a/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/PartOccurrenceOrUsageNavs.java
+++ b/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/PartOccurrenceOrUsageNavs.java
@@ -2,7 +2,7 @@
  * ========================LICENSE_START=================================
  * VEC 1.2.X
  * %%
- * Copyright (C) 2020 - 2023 4Soft GmbH
+ * Copyright (C) 2020 - 2026 4Soft GmbH
  * %%
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -10,10 +10,10 @@
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * 
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,13 +26,19 @@
 package com.foursoft.harness.vec.v12x.navigations;
 
 import com.foursoft.harness.vec.common.annotations.RequiresBackReferences;
-import com.foursoft.harness.vec.common.util.StreamUtils;
-import com.foursoft.harness.vec.common.util.StringUtils;
-import com.foursoft.harness.vec.v12x.*;
-import com.foursoft.harness.vec.v12x.visitor.ReferencedNodeLocationVisitor;
+import com.foursoft.harness.vec.common.traversal.MultiNavigation;
+import com.foursoft.harness.vec.v12x.VecDocumentVersion;
+import com.foursoft.harness.vec.v12x.VecModuleFamily;
+import com.foursoft.harness.vec.v12x.VecOccurrenceOrUsage;
+import com.foursoft.harness.vec.v12x.VecPartOccurrence;
+import com.foursoft.harness.vec.v12x.VecPartOrUsageRelatedSpecification;
+import com.foursoft.harness.vec.v12x.VecPartUsage;
+import com.foursoft.harness.vec.v12x.VecPrimaryPartType;
+import com.foursoft.harness.vec.v12x.VecTopologyNode;
+import com.foursoft.harness.vec.v12x.traversal.DocumentVersions;
+import com.foursoft.harness.vec.v12x.traversal.OccurrenceOrUsages;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.BiFunction;
@@ -40,7 +46,11 @@ import java.util.function.Function;
 
 /**
  * Navigation methods for the {@link VecOccurrenceOrUsage} including {@link VecPartOccurrence} and {@link VecPartUsage}.
+ *
+ * @deprecated Use {@link OccurrenceOrUsages} instead, which starts at the family wherever both sub types lead
+ * to the same target and therefore needs no {@code OfOccurrence} and {@code OfUsage} suffixes.
  */
+@Deprecated(forRemoval = true)
 public final class PartOccurrenceOrUsageNavs {
 
     private PartOccurrenceOrUsageNavs() {
@@ -49,57 +59,67 @@ public final class PartOccurrenceOrUsageNavs {
 
     // VecPartUsage
 
+    /**
+     * @deprecated Use {@link OccurrenceOrUsages#toParentDocumentNumber()} instead.
+     */
+    @Deprecated(forRemoval = true)
     @RequiresBackReferences
     public static Function<VecPartUsage, String> parentDocumentNumberOfUsage() {
-        return usage -> parentDocumentVersionOfUsage().apply(usage).getDocumentNumber();
+        return OccurrenceOrUsages.toParentDocumentNumber()::orElseNull;
     }
 
+    /**
+     * @deprecated Use {@link OccurrenceOrUsages#toParentDocumentVersion()} instead.
+     */
+    @Deprecated(forRemoval = true)
     @RequiresBackReferences
     public static Function<VecPartUsage, VecDocumentVersion> parentDocumentVersionOfUsage() {
-        return usage -> {
-            final VecPartUsageSpecification partUsageSpec = usage.getParentPartUsageSpecification();
-            return SpecificationNavs.parentDocumentVersion().apply(partUsageSpec);
-        };
+        return OccurrenceOrUsages.toParentDocumentVersion()::orElseNull;
     }
 
     // VecPartOccurrence
 
+    /**
+     * @deprecated Use {@link OccurrenceOrUsages#toParentDocumentNumber()} instead.
+     */
+    @Deprecated(forRemoval = true)
     @RequiresBackReferences
     public static Function<VecPartOccurrence, String> parentDocumentNumberOfOccurrence() {
-        return occurrence -> parentDocumentVersionOfOccurrence().apply(occurrence).getDocumentNumber();
+        return OccurrenceOrUsages.toParentDocumentNumber()::orElseNull;
     }
 
+    /**
+     * @deprecated Use {@link OccurrenceOrUsages#toPartNumber()} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecPartOccurrence, Optional<String>> partNumber() {
-        return occurrence -> Optional.of(occurrence)
-                .map(VecPartOccurrence::getPart)
-                .map(VecPartVersion::getPartNumber)
-                .map(StringUtils::collapseMultipleWhitespaces);
+        return OccurrenceOrUsages.toPartNumber();
     }
 
+    /**
+     * @deprecated Use {@link OccurrenceOrUsages#toPartVersion()} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecPartOccurrence, Optional<String>> partVersion() {
-        return occurrence -> Optional.of(occurrence)
-                .map(VecPartOccurrence::getPart)
-                .map(VecPartVersion::getPartVersion)
-                .map(StringUtils::collapseMultipleWhitespaces);
+        return OccurrenceOrUsages.toPartVersion();
     }
 
+    /**
+     * @deprecated Use {@link OccurrenceOrUsages#toPrimaryPartType()} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecPartOccurrence, VecPrimaryPartType> primaryPartTypeOfOccurrence() {
-        return occurrence -> {
-            final VecPartVersion partVersion = occurrence.getPart();
-            return partVersion != null
-                    ? partVersion.getPrimaryPartType()
-                    :
-                    occurrence.getRealizedPartUsage()
-                            .stream()
-                            .collect(StreamUtils.findOneOrNone())
-                            .map(VecPartUsage::getPrimaryPartUsageType)
-                            .orElse(VecPrimaryPartType.OTHER);
-        };
+        return OccurrenceOrUsages.toPrimaryPartType()::orElseNull;
     }
 
+    /**
+     * @deprecated Use {@link OccurrenceOrUsages#toPartOrUsageRelatedSpecifications()} instead.
+     */
+    @Deprecated(forRemoval = true)
     @RequiresBackReferences
     public static Function<VecPartOccurrence, List<VecPartOrUsageRelatedSpecification>> partOrUsageRelatedSpecificationsOfOccurrence() {
-        return occurrence -> new ArrayList<>(occurrence.getPart().getRefPartOrUsageRelatedSpecification());
+        return occurrence -> new ArrayList<>(
+                OccurrenceOrUsages.toPartOrUsageRelatedSpecifications().listFrom(occurrence));
     }
 
     /**
@@ -108,16 +128,12 @@ public final class PartOccurrenceOrUsageNavs {
      * <b>Warning: This uses {@link RequiresBackReferences back references}!</b>
      *
      * @return The parent VecDocumentVersion of a VecPartOccurrence.
+     * @deprecated Use {@link OccurrenceOrUsages#toParentDocumentVersion()} instead.
      */
+    @Deprecated(forRemoval = true)
     @RequiresBackReferences
     public static Function<VecPartOccurrence, VecDocumentVersion> parentDocumentVersionOfOccurrence() {
-        return occurrence -> {
-
-            final VecCompositionSpecification parentCompositionSpecification =
-                    occurrence.getParentCompositionSpecification();
-
-            return SpecificationNavs.parentDocumentVersion().apply(parentCompositionSpecification);
-        };
+        return OccurrenceOrUsages.toParentDocumentVersion()::orElseNull;
     }
 
     /**
@@ -125,86 +141,86 @@ public final class PartOccurrenceOrUsageNavs {
      * Note that the PartOccurrence has to be a module in order to be checked.
      *
      * @return An empty optional if the tested PartOccurrence is not a module or if no family was found.
+     * @deprecated Use {@link OccurrenceOrUsages#toModuleFamily()} instead.
      */
+    @Deprecated(forRemoval = true)
     public static Function<VecPartOccurrence, Optional<VecModuleFamily>> moduleFamily() {
-        return occurrence -> {
-            // Can also be an assembly though!
-            final boolean isModule = occurrence.getPart().getPrimaryPartType() == VecPrimaryPartType.PART_STRUCTURE;
-
-            return !isModule
-                    ? Optional.empty()
-                    :
-                    occurrence.getRolesWithType(VecPartWithSubComponentsRole.class).stream()
-                            .flatMap(StreamUtils.toStream(VecPartWithSubComponentsRole::getRefModuleFamily))
-                            .collect(StreamUtils.findOneOrNone());
-        };
+        return OccurrenceOrUsages.toModuleFamily();
     }
 
     // VecOccurrenceOrUsage
 
+    /**
+     * @deprecated Use {@link OccurrenceOrUsages#toParentDocumentNumber()} instead.
+     */
+    @Deprecated(forRemoval = true)
     @RequiresBackReferences
     public static Function<VecOccurrenceOrUsage, String> parentDocumentNumber() {
-        return occurrenceOrUsage -> parentDocumentVersion().apply(occurrenceOrUsage).getDocumentNumber();
+        return OccurrenceOrUsages.toParentDocumentNumber()::orElseNull;
     }
 
+    /**
+     * @deprecated Use {@link OccurrenceOrUsages#toParentDocumentVersion()} instead.
+     */
+    @Deprecated(forRemoval = true)
     @RequiresBackReferences
     public static Function<VecOccurrenceOrUsage, VecDocumentVersion> parentDocumentVersion() {
-        return occurrenceOrUsage -> {
-            if (occurrenceOrUsage instanceof VecPartOccurrence) {
-                return parentDocumentVersionOfOccurrence().apply((VecPartOccurrence) occurrenceOrUsage);
-            }
-            return parentDocumentVersionOfUsage().apply((VecPartUsage) occurrenceOrUsage);
-        };
+        return OccurrenceOrUsages.toParentDocumentVersion()::orElseNull;
     }
 
+    /**
+     * @deprecated Use {@link DocumentVersions#topologyNodeOf(VecOccurrenceOrUsage)} instead, which is a
+     * navigation from the document version rather than a function of two arguments.
+     */
+    @Deprecated(forRemoval = true)
     public static BiFunction<VecOccurrenceOrUsage, VecDocumentVersion, Optional<VecTopologyNode>> findNodeOfComponent() {
-        return (component, documentVersion) -> component.getRoleWithType(VecPlaceableElementRole.class)
-                .flatMap(placedElement -> DocumentVersionNavs
-                        .nodeLocationsBy(placedElement)
-                        .apply(documentVersion)
-                        .stream()
-                        .collect(StreamUtils.findOneOrNone()))
-                .map(VecNodeLocation::getReferencedNode);
+        return (component, documentVersion) -> DocumentVersions.topologyNodeOf(component).from(documentVersion);
     }
 
+    /**
+     * @deprecated Use {@link OccurrenceOrUsages#toReferencedTopologyNode()} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecOccurrenceOrUsage, Optional<VecTopologyNode>> topologyNodeByOccurrenceOrUsage() {
-        final ReferencedNodeLocationVisitor visitor = new ReferencedNodeLocationVisitor();
-        return occurrence -> occurrence.getRolesWithType(VecPlaceableElementRole.class).stream()
-                .map(VecPlaceableElementRole::getRefPlacement)
-                .flatMap(Collection::stream)
-                .filter(VecOnPointPlacement.class::isInstance)
-                .map(VecOnPointPlacement.class::cast)
-                .map(VecOnPointPlacement::getLocations)
-                .flatMap(Collection::stream)
-                .map(location -> location.accept(visitor))
-                .collect(StreamUtils.findOneOrNone());
+        return OccurrenceOrUsages.toReferencedTopologyNode();
     }
 
+    /**
+     * @deprecated Use {@link OccurrenceOrUsages#toPrimaryPartType()} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecOccurrenceOrUsage, VecPrimaryPartType> primaryPartType() {
-        return occurrenceOrUsage -> {
-            if (occurrenceOrUsage instanceof VecPartOccurrence) {
-                return primaryPartTypeOfOccurrence().apply((VecPartOccurrence) occurrenceOrUsage);
-            }
-            return ((VecPartUsage) occurrenceOrUsage).getPrimaryPartUsageType();
-        };
+        return OccurrenceOrUsages.toPrimaryPartType()::orElseNull;
     }
 
+    /**
+     * @deprecated Use {@link OccurrenceOrUsages#toPartOrUsageRelatedSpecifications()} instead.
+     */
+    @Deprecated(forRemoval = true)
     @RequiresBackReferences
     public static Function<VecOccurrenceOrUsage, List<VecPartOrUsageRelatedSpecification>> partOrUsageRelatedSpecifications() {
-        return occurrenceOrUsage -> {
-            if (occurrenceOrUsage instanceof VecPartOccurrence) {
-                return partOrUsageRelatedSpecificationsOfOccurrence().apply((VecPartOccurrence) occurrenceOrUsage);
-            }
-            return ((VecPartUsage) occurrenceOrUsage).getPartOrUsageRelatedSpecification();
-        };
+        return occurrenceOrUsage -> new ArrayList<>(
+                OccurrenceOrUsages.toPartOrUsageRelatedSpecifications().listFrom(occurrenceOrUsage));
     }
 
+    /**
+     * @deprecated Narrow the navigation leading to the occurrences or usages with
+     * {@link MultiNavigation#ofType(Class)} instead, for example
+     * {@code SpecificationOwners.toOccurrenceOrUsages().ofType(VecPartOccurrence.class)}.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecOccurrenceOrUsage, Optional<VecPartOccurrence>> occurrence() {
         return occurrenceOrUsage -> Optional.of(occurrenceOrUsage)
                 .filter(VecPartOccurrence.class::isInstance)
                 .map(VecPartOccurrence.class::cast);
     }
 
+    /**
+     * @deprecated Narrow the navigation leading to the occurrences or usages with
+     * {@link MultiNavigation#ofType(Class)} instead, for example
+     * {@code SpecificationOwners.toOccurrenceOrUsages().ofType(VecPartUsage.class)}.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecOccurrenceOrUsage, Optional<VecPartUsage>> usage() {
         return occurrenceOrUsage -> Optional.of(occurrenceOrUsage)
                 .filter(VecPartUsage.class::isInstance)

--- a/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/PlacementNavs.java
+++ b/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/PlacementNavs.java
@@ -25,34 +25,44 @@
  */
 package com.foursoft.harness.vec.v12x.navigations;
 
-import com.foursoft.harness.vec.common.util.StreamUtils;
+import com.foursoft.harness.vec.common.traversal.MultiNavigation;
+import com.foursoft.harness.vec.common.traversal.Navigations;
 import com.foursoft.harness.vec.v12x.*;
+import com.foursoft.harness.vec.v12x.traversal.PlaceableElementRoles;
+import com.foursoft.harness.vec.v12x.traversal.Placements;
+import com.foursoft.harness.vec.v12x.traversal.ViewItems;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
  * Navigation methods for getting {@link VecPlacement}s.
+ *
+ * @deprecated These navigations start at three different source types and are therefore spread over the
+ * catalogs of those types: {@link PlaceableElementRoles}, {@link Placements} and {@link ViewItems}.
  */
+@Deprecated(forRemoval = true)
 public final class PlacementNavs {
 
     private PlacementNavs() {
         // hide default constructor
     }
 
+    /**
+     * @deprecated Use {@link PlaceableElementRoles#toOnPointPlacements()} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecPlaceableElementRole, Stream<VecOnPointPlacement>> onPointPlacement() {
-        return role -> role.getRefPlacement().stream()
-                .filter(VecOnPointPlacement.class::isInstance)
-                .map(VecOnPointPlacement.class::cast);
+        return PlaceableElementRoles.toOnPointPlacements();
     }
 
+    /**
+     * @deprecated Use {@link PlaceableElementRoles#toOnWayPlacements()} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecPlaceableElementRole, Stream<VecOnWayPlacement>> onWayPlacement() {
-        return role -> role.getRefPlacement().stream()
-                .filter(VecOnWayPlacement.class::isInstance)
-                .map(VecOnWayPlacement.class::cast);
+        return PlaceableElementRoles.toOnWayPlacements();
     }
 
     /**
@@ -61,35 +71,29 @@ public final class PlacementNavs {
      * @param placement Placement Navigation method.
      * @return A function to get the locations from a
      * {@link VecOccurrenceOrUsageViewItem3D} or {@link VecOccurrenceOrUsageViewItem2D}.
-     * @see #onWayPlacement()
      * @see #onPointPlacement()
+     * @deprecated Compose the navigation at the call site instead, which also works for
+     * {@link PlaceableElementRoles#toOnWayPlacements()}:
+     * {@code ViewItems.toPlaceableElementRole().then(PlaceableElementRoles.toOnPointPlacements())
+     * .then(Placements.toLocations())}.
      */
+    @Deprecated(forRemoval = true)
     public static Function<HasOccurrenceOrUsages, List<VecLocation>> locationsOf(
             final Function<VecPlaceableElementRole, Stream<VecOnPointPlacement>> placement) {
-        return viewItem -> viewItem.getOccurrenceOrUsage().stream()
-                .filter(VecPartOccurrence.class::isInstance)
-                .map(VecPartOccurrence.class::cast)
-                .flatMap(StreamUtils.toStream(c -> c.getRolesWithType(VecPlaceableElementRole.class)))
-                .collect(StreamUtils.findOneOrNone())
-                .map(role -> placement.apply(role)
-                        .map(VecOnPointPlacement::getLocations)
-                        .flatMap(List::stream)
-                        .toList())
-                .orElseGet(Collections::emptyList);
+        final MultiNavigation<HasOccurrenceOrUsages, VecLocation> locations = ViewItems.toPlaceableElementRole()
+                .then(Navigations.stream(placement))
+                .then(Placements.toLocations());
+        return locations::listFrom;
     }
 
+    /**
+     * @deprecated Use {@code Placements.toLocations().ofType(locationType)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static <T extends VecLocation> Function<VecOnWayPlacement, List<T>> locationsWith(
             final Class<T> locationType) {
-        return placement ->
-                getLocationsByType(Stream.of(placement.getStartLocation(), placement.getEndLocation()), locationType)
-                        .toList();
-    }
-
-    private static <T extends VecLocation> Stream<T> getLocationsByType(final Stream<VecLocation> locations,
-                                                                        final Class<T> locationType) {
-        return locations
-                .filter(locationType::isInstance)
-                .map(locationType::cast);
+        final MultiNavigation<VecPlacement, T> locations = Placements.toLocations().ofType(locationType);
+        return locations::listFrom;
     }
 
 }

--- a/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/SegmentNavs.java
+++ b/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/SegmentNavs.java
@@ -2,7 +2,7 @@
  * ========================LICENSE_START=================================
  * VEC 1.2.X
  * %%
- * Copyright (C) 2020 - 2023 4Soft GmbH
+ * Copyright (C) 2020 - 2026 4Soft GmbH
  * %%
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -10,10 +10,10 @@
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * 
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,44 +26,47 @@
 package com.foursoft.harness.vec.v12x.navigations;
 
 import com.foursoft.harness.vec.common.annotations.RequiresBackReferences;
-import com.foursoft.harness.vec.common.util.StreamUtils;
-import com.foursoft.harness.vec.v12x.VecNumericalValue;
-import com.foursoft.harness.vec.v12x.VecSegmentCrossSectionArea;
-import com.foursoft.harness.vec.v12x.VecSegmentLength;
 import com.foursoft.harness.vec.v12x.VecTopologySegment;
+import com.foursoft.harness.vec.v12x.traversal.TopologySegments;
 
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 
 /**
  * Navigation methods for segments such as the {@link VecTopologySegment}.
+ *
+ * @deprecated Use {@link TopologySegments} instead.
  */
+@Deprecated(forRemoval = true)
 public final class SegmentNavs {
 
     private SegmentNavs() {
         // hide default constructor
     }
 
+    /**
+     * @deprecated Use {@link TopologySegments#toParentDocumentNumber()} instead.
+     */
+    @Deprecated(forRemoval = true)
     @RequiresBackReferences
     public static Function<VecTopologySegment, String> parentDocumentNumber() {
-        return segment -> segment.getParentTopologySpecification().getParentDocumentVersion().getDocumentNumber();
+        return TopologySegments.toParentDocumentNumber()::orElseNull;
     }
 
+    /**
+     * @deprecated Use {@link TopologySegments#lengthBy(String)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecTopologySegment, Optional<Double>> lengthBy(final String segmentLengthClassification) {
-        return segment -> StreamUtils.nonNullStream(segment.getLengthInformations())
-                .filter(segmentLength -> segmentLength.getClassification().equals(segmentLengthClassification))
-                .collect(StreamUtils.findOneOrNone())
-                .map(VecSegmentLength::getLength)
-                .map(VecNumericalValue::getValueComponent);
+        return TopologySegments.lengthBy(segmentLengthClassification);
     }
 
+    /**
+     * @deprecated Use {@link TopologySegments#crossSectionAreaBy(String)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecTopologySegment, Optional<Double>> crossSectionAreaBy(final String areaType) {
-        return segment -> StreamUtils.nonNullStream(segment.getCrossSectionAreaInformations())
-                .filter(seg -> Objects.equals(areaType, seg.getCrossSectionAreaType()))  // is nullable
-                .collect(StreamUtils.findOneOrNone())
-                .map(VecSegmentCrossSectionArea::getArea)
-                .map(VecNumericalValue::getValueComponent);
+        return TopologySegments.crossSectionAreaBy(areaType);
     }
 
 }

--- a/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/SpecificationNavs.java
+++ b/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/SpecificationNavs.java
@@ -2,7 +2,7 @@
  * ========================LICENSE_START=================================
  * VEC 1.2.X
  * %%
- * Copyright (C) 2020 - 2023 4Soft GmbH
+ * Copyright (C) 2020 - 2026 4Soft GmbH
  * %%
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -10,10 +10,10 @@
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * 
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -25,54 +25,62 @@
  */
 package com.foursoft.harness.vec.v12x.navigations;
 
-import com.foursoft.harness.vec.common.HasIdentification;
 import com.foursoft.harness.vec.common.HasSpecifications;
 import com.foursoft.harness.vec.common.annotations.RequiresBackReferences;
-import com.foursoft.harness.vec.common.util.StreamUtils;
-import com.foursoft.harness.vec.v12x.*;
+import com.foursoft.harness.vec.v12x.VecBuildingBlockSpecification2D;
+import com.foursoft.harness.vec.v12x.VecBuildingBlockSpecification3D;
+import com.foursoft.harness.vec.v12x.VecCompositionSpecification;
+import com.foursoft.harness.vec.v12x.VecDocumentVersion;
+import com.foursoft.harness.vec.v12x.VecGeometryNode2D;
+import com.foursoft.harness.vec.v12x.VecGeometryNode3D;
+import com.foursoft.harness.vec.v12x.VecGeometrySegment2D;
+import com.foursoft.harness.vec.v12x.VecGeometrySegment3D;
+import com.foursoft.harness.vec.v12x.VecOccurrenceOrUsage;
+import com.foursoft.harness.vec.v12x.VecPartOccurrence;
+import com.foursoft.harness.vec.v12x.VecSpecification;
+import com.foursoft.harness.vec.v12x.traversal.SpecificationOwners;
+import com.foursoft.harness.vec.v12x.traversal.Specifications;
 
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * Navigation methods for the {@link VecSpecification}.
+ *
+ * @deprecated These navigations start at a specification and at the element holding it, and are therefore
+ * spread over the catalogs of those types: {@link Specifications} and {@link SpecificationOwners}.
  */
+@Deprecated(forRemoval = true)
 public final class SpecificationNavs {
 
     private SpecificationNavs() {
         // hide default constructor
     }
 
+    /**
+     * @deprecated Use {@link Specifications#toParentDocumentNumber()} instead.
+     */
+    @Deprecated(forRemoval = true)
     @RequiresBackReferences
     public static Function<VecSpecification, String> parentDocumentNumber() {
-        return spec -> parentDocumentVersion().apply(spec).getDocumentNumber();
+        return Specifications.toParentDocumentNumber()::orElseNull;
     }
 
+    /**
+     * @deprecated Use {@link Specifications#toParentDocumentVersion()} instead.
+     */
+    @Deprecated(forRemoval = true)
     @RequiresBackReferences
     public static Function<VecSpecification, VecDocumentVersion> parentDocumentVersion() {
-        return specification -> {
-            final VecSheetOrChapter sheetOrChapter = specification.getParentSheetOrChapter();
-            final VecDocumentVersion documentVersion = specification.getParentDocumentVersion();
-            if (documentVersion != null) {
-                return documentVersion;
-            } else {
-                return sheetOrChapter.getParentDocumentVersion();
-            }
-        };
+        return Specifications.toParentDocumentVersion()::orElseNull;
     }
 
+    /**
+     * @deprecated Use {@link SpecificationOwners#toOccurrenceOrUsages()} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<HasSpecifications<VecSpecification>, List<VecOccurrenceOrUsage>> allOccurrenceOrUsages() {
-        return specifications -> Stream.concat(
-                        components().apply(specifications).stream(),
-                        specifications.getSpecificationsWithType(VecPartUsageSpecification.class)
-                                .stream()
-                                .map(VecPartUsageSpecification::getPartUsages)
-                                .flatMap(Collection::stream))
-                .toList();
+        return SpecificationOwners.<HasSpecifications<VecSpecification>>toOccurrenceOrUsages()::listFrom;
     }
 
     /**
@@ -80,14 +88,11 @@ public final class SpecificationNavs {
      * their {@link VecCompositionSpecification#getComponents() components}.
      *
      * @return A possibly-empty list of Components.
+     * @deprecated Use {@link SpecificationOwners#toComponents()} instead.
      */
+    @Deprecated(forRemoval = true)
     public static Function<HasSpecifications<VecSpecification>, List<VecPartOccurrence>> components() {
-        return specifications -> specifications
-                .getSpecificationsWithType(VecCompositionSpecification.class)
-                .stream()
-                .map(VecCompositionSpecification::getComponents)
-                .flatMap(Collection::stream)
-                .toList();
+        return SpecificationOwners.<HasSpecifications<VecSpecification>>toComponents()::listFrom;
     }
 
     /**
@@ -96,37 +101,47 @@ public final class SpecificationNavs {
      *
      * @param compositionSpecificationId Id the {@link VecCompositionSpecification} has to have.
      * @return A possibly-empty list of Components.
+     * @deprecated Use {@link SpecificationOwners#componentsBy(String)} instead.
      */
+    @Deprecated(forRemoval = true)
     public static Function<HasSpecifications<VecSpecification>, List<VecPartOccurrence>> componentsBy(
             final String compositionSpecificationId) {
-        return specifications -> specifications
-                .getSpecificationWith(VecCompositionSpecification.class, compositionSpecificationId)
-                .map(VecCompositionSpecification::getComponents)
-                .orElseGet(Collections::emptyList);
+        return SpecificationOwners.<HasSpecifications<VecSpecification>>componentsBy(
+                compositionSpecificationId)::listFrom;
     }
 
+    /**
+     * @deprecated Use {@link Specifications#geometrySegment2dBy(String)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecBuildingBlockSpecification2D, VecGeometrySegment2D> geometrySegment2dBy(
             final String segmentId) {
-        return specification -> findElementById(specification.getGeometrySegments(), segmentId);
+        return Specifications.geometrySegment2dBy(segmentId)::orElseNull;
     }
 
+    /**
+     * @deprecated Use {@link Specifications#geometrySegment3dBy(String)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecBuildingBlockSpecification3D, VecGeometrySegment3D> geometrySegment3dBy(
             final String segmentId) {
-        return specification -> findElementById(specification.getGeometrySegments(), segmentId);
+        return Specifications.geometrySegment3dBy(segmentId)::orElseNull;
     }
 
+    /**
+     * @deprecated Use {@link Specifications#geometryNode2dBy(String)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecBuildingBlockSpecification2D, VecGeometryNode2D> geometryNode2dBy(final String nodeId) {
-        return specification -> findElementById(specification.getGeometryNodes(), nodeId);
+        return Specifications.geometryNode2dBy(nodeId)::orElseNull;
     }
 
+    /**
+     * @deprecated Use {@link Specifications#geometryNode3dBy(String)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecBuildingBlockSpecification3D, VecGeometryNode3D> geometryNode3dBy(final String nodeId) {
-        return specification -> findElementById(specification.getGeometryNodes(), nodeId);
-    }
-
-    private static <T extends HasIdentification> T findElementById(final List<T> elements, final String id) {
-        return elements.stream()
-                .filter(element -> element.getIdentification().equals(id))
-                .collect(StreamUtils.findOneOrNone()).orElse(null);
+        return Specifications.geometryNode3dBy(nodeId)::orElseNull;
     }
 
 }

--- a/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/VecNavs.java
+++ b/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/VecNavs.java
@@ -2,7 +2,7 @@
  * ========================LICENSE_START=================================
  * VEC 1.2.X
  * %%
- * Copyright (C) 2020 - 2023 4Soft GmbH
+ * Copyright (C) 2020 - 2026 4Soft GmbH
  * %%
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -10,10 +10,10 @@
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * 
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -28,34 +28,41 @@ package com.foursoft.harness.vec.v12x.navigations;
 import com.foursoft.harness.vec.common.annotations.RequiresBackReferences;
 import com.foursoft.harness.vec.v12x.VecDocumentVersion;
 import com.foursoft.harness.vec.v12x.VecExtendableElement;
-import com.foursoft.harness.vec.v12x.VecOccurrenceOrUsage;
 import com.foursoft.harness.vec.v12x.VecRole;
+import com.foursoft.harness.vec.v12x.traversal.ExtendableElements;
+import com.foursoft.harness.vec.v12x.traversal.Roles;
 
 import java.util.List;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 /**
  * Navigation methods which don't fit into a special category.
+ *
+ * @deprecated These navigations start at two different source types and are therefore spread over the
+ * catalogs of those types: {@link ExtendableElements} and {@link Roles}.
  */
+@Deprecated(forRemoval = true)
 public final class VecNavs {
 
     private VecNavs() {
         // hide default constructor
     }
 
+    /**
+     * @deprecated Use {@link ExtendableElements#toExternalDocumentNumbers()} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecExtendableElement, List<String>> externalDocumentNumbers() {
-        return element -> element.getReferencedExternalDocuments().stream()
-                .map(VecDocumentVersion::getDocumentNumber)
-                .toList();
+        return ExtendableElements.toExternalDocumentNumbers()::listFrom;
     }
 
+    /**
+     * @deprecated Use {@link Roles#toParentDocumentVersion()} instead.
+     */
+    @Deprecated(forRemoval = true)
     @RequiresBackReferences
     public static Function<VecRole, VecDocumentVersion> parentDocumentVersion() {
-        return role -> {
-            final VecOccurrenceOrUsage parentOccurrenceOrUsage = role.getParentOccurrenceOrUsage();
-            return PartOccurrenceOrUsageNavs.parentDocumentVersion().apply(parentOccurrenceOrUsage);
-        };
+        return Roles.toParentDocumentVersion()::orElseNull;
     }
 
 }

--- a/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/traversal/ConfigurableElements.java
+++ b/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/traversal/ConfigurableElements.java
@@ -1,0 +1,72 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 1.2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v12x.traversal;
+
+import com.foursoft.harness.vec.common.traversal.Navigations;
+import com.foursoft.harness.vec.common.traversal.SingleNavigation;
+import com.foursoft.harness.vec.v12x.VecConfigurableElement;
+import com.foursoft.harness.vec.v12x.VecVariantConfiguration;
+
+/**
+ * Navigations starting at a {@link VecConfigurableElement}, that is at any element whose presence can be
+ * configured.
+ */
+public final class ConfigurableElements {
+
+    private ConfigurableElements() {
+        // hide default constructor
+    }
+
+    /**
+     * Navigates to the configuration of a configurable element.
+     *
+     * @return A navigation to the variant configuration of an element.
+     */
+    public static SingleNavigation<VecConfigurableElement, VecVariantConfiguration> toVariantConfiguration() {
+        return Navigations.nullable(VecConfigurableElement::getConfigInfo);
+    }
+
+    /**
+     * Navigates to the logistic control string of a configurable element.
+     *
+     * @return A navigation to the logistic control string of an element.
+     */
+    public static SingleNavigation<VecConfigurableElement, String> toLogisticControlString() {
+        return toVariantConfiguration()
+                .then(Navigations.nullable(VecVariantConfiguration::getLogisticControlString));
+    }
+
+    /**
+     * Navigates to the logistic control expression of a configurable element.
+     *
+     * @return A navigation to the logistic control expression of an element.
+     */
+    public static SingleNavigation<VecConfigurableElement, String> toLogisticControlExpression() {
+        return toVariantConfiguration()
+                .then(Navigations.nullable(VecVariantConfiguration::getLogisticControlExpression));
+    }
+
+}

--- a/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/traversal/Contents.java
+++ b/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/traversal/Contents.java
@@ -1,0 +1,73 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 1.2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v12x.traversal;
+
+import com.foursoft.harness.vec.common.traversal.MultiNavigation;
+import com.foursoft.harness.vec.common.traversal.Navigations;
+import com.foursoft.harness.vec.common.traversal.SingleNavigation;
+import com.foursoft.harness.vec.v12x.VecContent;
+import com.foursoft.harness.vec.v12x.VecDocumentVersion;
+
+/**
+ * Navigations starting at the {@link VecContent}, the root of a VEC model.
+ * <p>
+ * To reach the specifications of all document versions, continue this navigation at the call site, for example
+ * <pre>
+ * {@code
+ * Contents.toDocumentVersions()
+ *         .then(SpecificationOwners.toSpecifications())
+ *         .ofType(VecPlacementSpecification.class);
+ * }
+ * </pre>
+ */
+public final class Contents {
+
+    private Contents() {
+        // hide default constructor
+    }
+
+    /**
+     * Navigates to the document versions of a content.
+     *
+     * @return A navigation to the document versions of a content.
+     */
+    public static MultiNavigation<VecContent, VecDocumentVersion> toDocumentVersions() {
+        return Navigations.collection(VecContent::getDocumentVersions);
+    }
+
+    /**
+     * Navigates to the document version with the given document number.
+     *
+     * @param documentNumber Document number of the document version to navigate to.
+     * @return A navigation to the identified document version.
+     */
+    public static SingleNavigation<VecContent, VecDocumentVersion> documentVersionBy(final String documentNumber) {
+        return toDocumentVersions()
+                .filter(documentVersion -> documentNumber.equals(documentVersion.getDocumentNumber()))
+                .atMostOne();
+    }
+
+}

--- a/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/traversal/CustomProperties.java
+++ b/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/traversal/CustomProperties.java
@@ -1,0 +1,183 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 1.2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v12x.traversal;
+
+import com.foursoft.harness.vec.common.HasCustomProperties;
+import com.foursoft.harness.vec.common.traversal.MultiNavigation;
+import com.foursoft.harness.vec.common.traversal.Navigations;
+import com.foursoft.harness.vec.common.traversal.SingleNavigation;
+import com.foursoft.harness.vec.v12x.VecBooleanValueProperty;
+import com.foursoft.harness.vec.v12x.VecComplexProperty;
+import com.foursoft.harness.vec.v12x.VecCustomProperty;
+import com.foursoft.harness.vec.v12x.VecDoubleValueProperty;
+import com.foursoft.harness.vec.v12x.VecIntegerValueProperty;
+import com.foursoft.harness.vec.v12x.VecLanguageCode;
+import com.foursoft.harness.vec.v12x.VecLocalizedStringProperty;
+import com.foursoft.harness.vec.v12x.VecSimpleValueProperty;
+import com.foursoft.harness.vec.v12x.VecValueRange;
+import com.foursoft.harness.vec.v12x.VecValueRangeProperty;
+
+import java.math.BigInteger;
+import java.util.function.Predicate;
+
+/**
+ * Navigations starting at a {@link HasCustomProperties} holding {@link VecCustomProperty}s.
+ * <p>
+ * The value navigations are named after the value they lead to, since the property type given as their
+ * argument is what picks it. To reach the properties themselves, start at {@link #toCustomProperties()} and
+ * narrow it at the call site, for example
+ * <pre>
+ * {@code
+ * CustomProperties.toCustomProperties().ofType(VecSimpleValueProperty.class);
+ * }
+ * </pre>
+ */
+public final class CustomProperties {
+
+    private CustomProperties() {
+        // hide default constructor
+    }
+
+    /**
+     * Navigates to the custom properties of an element.
+     *
+     * @return A navigation to the custom properties of an element.
+     */
+    public static MultiNavigation<HasCustomProperties<VecCustomProperty>, VecCustomProperty> toCustomProperties() {
+        return Navigations.collection(HasCustomProperties::getCustomProperties);
+    }
+
+    /**
+     * Navigates to the string value of the {@link VecSimpleValueProperty} with the given property type.
+     *
+     * @param propertyType Type of the property to navigate to.
+     * @return A navigation to the string value of the given property.
+     */
+    public static SingleNavigation<HasCustomProperties<VecCustomProperty>, String> stringValueOf(
+            final String propertyType) {
+        return propertiesOf(propertyType, VecSimpleValueProperty.class).atMostOne()
+                .then(Navigations.nullable(VecSimpleValueProperty::getValue));
+    }
+
+    /**
+     * Navigates to the string values of all {@link VecSimpleValueProperty}s with the given property type.
+     *
+     * @param propertyType Type of the properties to navigate to.
+     * @return A navigation to the string values of the given properties.
+     */
+    public static MultiNavigation<HasCustomProperties<VecCustomProperty>, String> stringValuesOf(
+            final String propertyType) {
+        return propertiesOf(propertyType, VecSimpleValueProperty.class)
+                .then(Navigations.nullable(VecSimpleValueProperty::getValue));
+    }
+
+    /**
+     * Navigates to the integer value of the {@link VecIntegerValueProperty} with the given property type.
+     *
+     * @param propertyType Type of the property to navigate to.
+     * @return A navigation to the integer value of the given property.
+     */
+    public static SingleNavigation<HasCustomProperties<VecCustomProperty>, BigInteger> integerValueOf(
+            final String propertyType) {
+        return propertiesOf(propertyType, VecIntegerValueProperty.class).atMostOne()
+                .then(Navigations.nullable(VecIntegerValueProperty::getValue));
+    }
+
+    /**
+     * Navigates to the double value of the {@link VecDoubleValueProperty} with the given property type.
+     *
+     * @param propertyType Type of the property to navigate to.
+     * @return A navigation to the double value of the given property.
+     */
+    public static SingleNavigation<HasCustomProperties<VecCustomProperty>, Double> doubleValueOf(
+            final String propertyType) {
+        return propertiesOf(propertyType, VecDoubleValueProperty.class).atMostOne()
+                .then(Navigations.nullable(VecDoubleValueProperty::getValue));
+    }
+
+    /**
+     * Navigates to the boolean value of the {@link VecBooleanValueProperty} with the given property type.
+     *
+     * @param propertyType Type of the property to navigate to.
+     * @return A navigation to the boolean value of the given property.
+     */
+    public static SingleNavigation<HasCustomProperties<VecCustomProperty>, Boolean> booleanValueOf(
+            final String propertyType) {
+        return propertiesOf(propertyType, VecBooleanValueProperty.class).atMostOne()
+                .then(Navigations.nullable(VecBooleanValueProperty::isValue));
+    }
+
+    /**
+     * Navigates to the {@link VecValueRange} of the {@link VecValueRangeProperty} with the given property type.
+     *
+     * @param propertyType Type of the property to navigate to.
+     * @return A navigation to the value range of the given property.
+     */
+    public static SingleNavigation<HasCustomProperties<VecCustomProperty>, VecValueRange> valueRangeOf(
+            final String propertyType) {
+        return propertiesOf(propertyType, VecValueRangeProperty.class).atMostOne()
+                .then(Navigations.nullable(VecValueRangeProperty::getValue));
+    }
+
+    /**
+     * Navigates to the custom properties nested in the {@link VecComplexProperty} with the given property type.
+     *
+     * @param propertyType Type of the complex property to navigate into.
+     * @return A navigation to the custom properties of the given complex property.
+     */
+    public static MultiNavigation<HasCustomProperties<VecCustomProperty>, VecCustomProperty> nestedPropertiesOf(
+            final String propertyType) {
+        return propertiesOf(propertyType, VecComplexProperty.class).atMostOne()
+                .then(Navigations.collection(VecComplexProperty::getCustomProperties));
+    }
+
+    /**
+     * Navigates to the value of the {@link VecLocalizedStringProperty} with the given property type, if that
+     * value is in the given language.
+     *
+     * @param propertyType Type of the property to navigate to.
+     * @param languageCode Language the value has to be in.
+     * @return A navigation to the localized value of the given property.
+     * @see LocalizedStringProperties#valueIn(VecLanguageCode)
+     */
+    public static SingleNavigation<HasCustomProperties<VecCustomProperty>, String> localizedValueOf(
+            final String propertyType, final VecLanguageCode languageCode) {
+        return propertiesOf(propertyType, VecLocalizedStringProperty.class).atMostOne()
+                .then(LocalizedStringProperties.valueIn(languageCode));
+    }
+
+    private static <T extends VecCustomProperty> MultiNavigation<HasCustomProperties<VecCustomProperty>, T> propertiesOf(
+            final String propertyType, final Class<T> type) {
+        return toCustomProperties()
+                .ofType(type)
+                .filter(ofPropertyType(propertyType));
+    }
+
+    private static Predicate<VecCustomProperty> ofPropertyType(final String propertyType) {
+        return customProperty -> propertyType.equals(customProperty.getPropertyType());
+    }
+
+}

--- a/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/traversal/Descriptions.java
+++ b/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/traversal/Descriptions.java
@@ -1,0 +1,127 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 1.2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v12x.traversal;
+
+import com.foursoft.harness.vec.common.HasDescription;
+import com.foursoft.harness.vec.common.traversal.MultiNavigation;
+import com.foursoft.harness.vec.common.traversal.Navigations;
+import com.foursoft.harness.vec.common.traversal.SingleNavigation;
+import com.foursoft.harness.vec.v12x.VecAbstractLocalizedString;
+import com.foursoft.harness.vec.v12x.VecLanguageCode;
+import com.foursoft.harness.vec.v12x.VecLocalizedTypedString;
+
+/**
+ * Navigations starting at a {@link HasDescription} holding {@link VecAbstractLocalizedString}s.
+ * <p>
+ * Which of several descriptions applies is decided by a reduction from {@link LocalizedStrings}, not by the
+ * navigation itself.
+ */
+public final class Descriptions {
+
+    private Descriptions() {
+        // hide default constructor
+    }
+
+    /**
+     * Navigates to the localized strings describing an element.
+     *
+     * @return A navigation to the descriptions of an element.
+     */
+    public static MultiNavigation<HasDescription<? extends VecAbstractLocalizedString>,
+            VecAbstractLocalizedString> toDescriptions() {
+        return Navigations.collection(HasDescription::getDescriptions);
+    }
+
+    /**
+     * Navigates to the german description of an element.
+     *
+     * @return A navigation to the german description.
+     * @see #descriptionIn(VecLanguageCode)
+     */
+    public static SingleNavigation<HasDescription<? extends VecAbstractLocalizedString>, String> germanDescription() {
+        return descriptionIn(VecLanguageCode.DE);
+    }
+
+    /**
+     * Navigates to the english description of an element.
+     *
+     * @return A navigation to the english description.
+     * @see #descriptionIn(VecLanguageCode)
+     */
+    public static SingleNavigation<HasDescription<? extends VecAbstractLocalizedString>, String> englishDescription() {
+        return descriptionIn(VecLanguageCode.EN);
+    }
+
+    /**
+     * Navigates to the description of an element in the given language.
+     *
+     * @param languageCode Language of the description to navigate to.
+     * @return A navigation to the description in the given language.
+     * @see LocalizedStrings#valueIn(VecLanguageCode)
+     */
+    public static SingleNavigation<HasDescription<? extends VecAbstractLocalizedString>, String> descriptionIn(
+            final VecLanguageCode languageCode) {
+        return toDescriptions().collect(LocalizedStrings.valueIn(languageCode));
+    }
+
+    /**
+     * Navigates to the german {@link VecLocalizedTypedString} of the given type.
+     *
+     * @param descriptionType Type of the localized string to navigate to.
+     * @return A navigation to the german value of the given type.
+     * @see #typedStringBy(String, VecLanguageCode)
+     */
+    public static SingleNavigation<HasDescription<? extends VecAbstractLocalizedString>, String> germanTypedStringBy(
+            final String descriptionType) {
+        return typedStringBy(descriptionType, VecLanguageCode.DE);
+    }
+
+    /**
+     * Navigates to the english {@link VecLocalizedTypedString} of the given type.
+     *
+     * @param descriptionType Type of the localized string to navigate to.
+     * @return A navigation to the english value of the given type.
+     * @see #typedStringBy(String, VecLanguageCode)
+     */
+    public static SingleNavigation<HasDescription<? extends VecAbstractLocalizedString>, String> englishTypedStringBy(
+            final String descriptionType) {
+        return typedStringBy(descriptionType, VecLanguageCode.EN);
+    }
+
+    /**
+     * Navigates to the {@link VecLocalizedTypedString} of the given type in the given language.
+     *
+     * @param descriptionType Type of the localized string to navigate to.
+     * @param languageCode    Language of the localized string to navigate to.
+     * @return A navigation to the value of the given type and language.
+     * @see LocalizedStrings#typedValueBy(String, VecLanguageCode)
+     */
+    public static SingleNavigation<HasDescription<? extends VecAbstractLocalizedString>, String> typedStringBy(
+            final String descriptionType, final VecLanguageCode languageCode) {
+        return toDescriptions().collect(LocalizedStrings.typedValueBy(descriptionType, languageCode));
+    }
+
+}

--- a/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/traversal/DocumentVersions.java
+++ b/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/traversal/DocumentVersions.java
@@ -1,0 +1,435 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 1.2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v12x.traversal;
+
+import com.foursoft.harness.vec.common.HasIdentification;
+import com.foursoft.harness.vec.common.traversal.MultiNavigation;
+import com.foursoft.harness.vec.common.traversal.SingleNavigation;
+import com.foursoft.harness.vec.v12x.HasOccurrenceOrUsages;
+import com.foursoft.harness.vec.v12x.VecBuildingBlockPositioning2D;
+import com.foursoft.harness.vec.v12x.VecBuildingBlockPositioning3D;
+import com.foursoft.harness.vec.v12x.VecBuildingBlockSpecification2D;
+import com.foursoft.harness.vec.v12x.VecBuildingBlockSpecification3D;
+import com.foursoft.harness.vec.v12x.VecDocumentVersion;
+import com.foursoft.harness.vec.v12x.VecGeometryNode;
+import com.foursoft.harness.vec.v12x.VecGeometryNode2D;
+import com.foursoft.harness.vec.v12x.VecGeometryNode3D;
+import com.foursoft.harness.vec.v12x.VecGeometrySegment2D;
+import com.foursoft.harness.vec.v12x.VecGeometrySegment3D;
+import com.foursoft.harness.vec.v12x.VecHarnessDrawingSpecification2D;
+import com.foursoft.harness.vec.v12x.VecHarnessGeometrySpecification3D;
+import com.foursoft.harness.vec.v12x.VecNodeLocation;
+import com.foursoft.harness.vec.v12x.VecOccurrenceOrUsage;
+import com.foursoft.harness.vec.v12x.VecOccurrenceOrUsageViewItem2D;
+import com.foursoft.harness.vec.v12x.VecOccurrenceOrUsageViewItem3D;
+import com.foursoft.harness.vec.v12x.VecOnPointPlacement;
+import com.foursoft.harness.vec.v12x.VecPlaceableElementRole;
+import com.foursoft.harness.vec.v12x.VecPlacement;
+import com.foursoft.harness.vec.v12x.VecPlacementSpecification;
+import com.foursoft.harness.vec.v12x.VecSpecification;
+import com.foursoft.harness.vec.v12x.VecTopologyNode;
+import com.foursoft.harness.vec.v12x.VecTopologySegment;
+
+import java.util.Objects;
+import java.util.function.Predicate;
+
+/**
+ * Navigations starting at a {@link VecDocumentVersion}.
+ * <p>
+ * A document version reaches most of its content through its {@link VecSpecification}s, so the steps here are
+ * composed of {@link SpecificationOwners#toSpecifications()} and the matching step of {@link Specifications}.
+ * The navigations taking an argument select a single element among those, which is why they keep a noun
+ * phrase as their name.
+ */
+public final class DocumentVersions {
+
+    private DocumentVersions() {
+        // hide default constructor
+    }
+
+    /**
+     * Navigates to the 2D building blocks of a document version.
+     *
+     * @return A navigation to the 2D building block specifications of a document version.
+     */
+    public static MultiNavigation<VecDocumentVersion, VecBuildingBlockSpecification2D>
+    toBuildingBlockSpecifications2D() {
+        return SpecificationOwners.<VecDocumentVersion>toSpecifications()
+                .ofType(VecBuildingBlockSpecification2D.class);
+    }
+
+    /**
+     * Navigates to the 3D building blocks of a document version.
+     *
+     * @return A navigation to the 3D building block specifications of a document version.
+     */
+    public static MultiNavigation<VecDocumentVersion, VecBuildingBlockSpecification3D>
+    toBuildingBlockSpecifications3D() {
+        return SpecificationOwners.<VecDocumentVersion>toSpecifications()
+                .ofType(VecBuildingBlockSpecification3D.class);
+    }
+
+    /**
+     * Navigates to the 2D geometry nodes of all building blocks of a document version.
+     *
+     * @return A navigation to the 2D geometry nodes of a document version.
+     */
+    public static MultiNavigation<VecDocumentVersion, VecGeometryNode2D> toGeometryNodes2D() {
+        return toBuildingBlockSpecifications2D().then(Specifications.toGeometryNodes2D());
+    }
+
+    /**
+     * Navigates to the 3D geometry nodes of all building blocks of a document version.
+     *
+     * @return A navigation to the 3D geometry nodes of a document version.
+     */
+    public static MultiNavigation<VecDocumentVersion, VecGeometryNode3D> toGeometryNodes3D() {
+        return toBuildingBlockSpecifications3D().then(Specifications.toGeometryNodes3D());
+    }
+
+    /**
+     * Navigates to the 2D geometry segments of all building blocks of a document version.
+     *
+     * @return A navigation to the 2D geometry segments of a document version.
+     */
+    public static MultiNavigation<VecDocumentVersion, VecGeometrySegment2D> toGeometrySegments2D() {
+        return toBuildingBlockSpecifications2D().then(Specifications.toGeometrySegments2D());
+    }
+
+    /**
+     * Navigates to the 3D geometry segments of all building blocks of a document version.
+     *
+     * @return A navigation to the 3D geometry segments of a document version.
+     */
+    public static MultiNavigation<VecDocumentVersion, VecGeometrySegment3D> toGeometrySegments3D() {
+        return toBuildingBlockSpecifications3D().then(Specifications.toGeometrySegments3D());
+    }
+
+    /**
+     * Navigates to the 2D view items of all building blocks of a document version.
+     *
+     * @return A navigation to the 2D view items of a document version.
+     */
+    public static MultiNavigation<VecDocumentVersion, VecOccurrenceOrUsageViewItem2D> toViewItems2D() {
+        return toBuildingBlockSpecifications2D().then(Specifications.toViewItems2D());
+    }
+
+    /**
+     * Navigates to the 3D view items of all building blocks of a document version.
+     *
+     * @return A navigation to the 3D view items of a document version.
+     */
+    public static MultiNavigation<VecDocumentVersion, VecOccurrenceOrUsageViewItem3D> toViewItems3D() {
+        return toBuildingBlockSpecifications3D().then(Specifications.toViewItems3D());
+    }
+
+    /**
+     * Navigates to the placements of all {@link VecPlacementSpecification}s of a document version.
+     *
+     * @return A navigation to the placements of a document version.
+     */
+    public static MultiNavigation<VecDocumentVersion, VecPlacement> toPlacements() {
+        return SpecificationOwners.<VecDocumentVersion>toSpecifications()
+                .ofType(VecPlacementSpecification.class)
+                .then(Specifications.toPlacements());
+    }
+
+    /**
+     * Navigates to the {@link VecNodeLocation}s of all on point placements of a document version.
+     *
+     * @return A navigation to the node locations of a document version.
+     */
+    public static MultiNavigation<VecDocumentVersion, VecNodeLocation> toNodeLocations() {
+        return toPlacements()
+                .ofType(VecOnPointPlacement.class)
+                .then(Placements.toLocations())
+                .ofType(VecNodeLocation.class);
+    }
+
+    /**
+     * Navigates to the 2D building block positionings of all
+     * {@link VecHarnessDrawingSpecification2D}s of a document version.
+     *
+     * @return A navigation to the 2D building block positionings of a document version.
+     */
+    public static MultiNavigation<VecDocumentVersion, VecBuildingBlockPositioning2D>
+    toBuildingBlockPositionings2D() {
+        return SpecificationOwners.<VecDocumentVersion>toSpecifications()
+                .ofType(VecHarnessDrawingSpecification2D.class)
+                .then(Specifications.toBuildingBlockPositionings2D());
+    }
+
+    /**
+     * Navigates to the 3D building block positionings of all
+     * {@link VecHarnessGeometrySpecification3D}s of a document version.
+     *
+     * @return A navigation to the 3D building block positionings of a document version.
+     */
+    public static MultiNavigation<VecDocumentVersion, VecBuildingBlockPositioning3D>
+    toBuildingBlockPositionings3D() {
+        return SpecificationOwners.<VecDocumentVersion>toSpecifications()
+                .ofType(VecHarnessGeometrySpecification3D.class)
+                .then(Specifications.toBuildingBlockPositionings3D());
+    }
+
+    /**
+     * Navigates to the 2D building block with the given identification.
+     *
+     * @param specificationId Identification of the building block to navigate to.
+     * @return A navigation to the identified 2D building block specification.
+     */
+    public static SingleNavigation<VecDocumentVersion, VecBuildingBlockSpecification2D>
+    buildingBlockSpecification2dBy(final String specificationId) {
+        return toBuildingBlockSpecifications2D().filter(identifiedBy(specificationId)).atMostOne();
+    }
+
+    /**
+     * Navigates to the 3D building block with the given identification.
+     *
+     * @param specificationId Identification of the building block to navigate to.
+     * @return A navigation to the identified 3D building block specification.
+     */
+    public static SingleNavigation<VecDocumentVersion, VecBuildingBlockSpecification3D>
+    buildingBlockSpecification3dBy(final String specificationId) {
+        return toBuildingBlockSpecifications3D().filter(identifiedBy(specificationId)).atMostOne();
+    }
+
+    /**
+     * Navigates to the 3D geometry nodes representing the given {@link VecTopologyNode}.
+     *
+     * @param topologyNode Topology node the geometry nodes have to reference.
+     * @return A navigation to the 3D geometry nodes of the given topology node.
+     */
+    public static MultiNavigation<VecDocumentVersion, VecGeometryNode3D> geometryNodes3dBy(
+            final VecTopologyNode topologyNode) {
+        return toGeometryNodes3D().filter(referencing(topologyNode));
+    }
+
+    /**
+     * Navigates to the 3D geometry segments representing the given {@link VecTopologySegment}.
+     *
+     * @param topologySegment Topology segment the geometry segments have to reference.
+     * @return A navigation to the 3D geometry segments of the given topology segment.
+     */
+    public static MultiNavigation<VecDocumentVersion, VecGeometrySegment3D> geometrySegments3dBy(
+            final VecTopologySegment topologySegment) {
+        return toGeometrySegments3D()
+                .filter(segment -> Objects.equals(topologySegment, segment.getReferenceSegment()));
+    }
+
+    /**
+     * Navigates to the 2D geometry node representing the topology node of the given {@link VecNodeLocation}.
+     *
+     * @param location Location whose referenced topology node the geometry node has to reference.
+     * @return A navigation to the 2D geometry node of the given location.
+     */
+    public static SingleNavigation<VecDocumentVersion, VecGeometryNode2D> geometryNode2dBy(
+            final VecNodeLocation location) {
+        return toGeometryNodes2D().filter(referencing(location.getReferencedNode())).atMostOne();
+    }
+
+    /**
+     * Navigates to the 3D geometry node representing the topology node of the given {@link VecNodeLocation}.
+     *
+     * @param location Location whose referenced topology node the geometry node has to reference.
+     * @return A navigation to the 3D geometry node of the given location.
+     */
+    public static SingleNavigation<VecDocumentVersion, VecGeometryNode3D> geometryNode3dBy(
+            final VecNodeLocation location) {
+        return toGeometryNodes3D().filter(referencing(location.getReferencedNode())).atMostOne();
+    }
+
+    /**
+     * Navigates to the 3D view items showing the given occurrence or usage.
+     *
+     * @param occurrenceOrUsage Occurrence or usage the view items have to show.
+     * @return A navigation to the 3D view items of the given occurrence or usage.
+     */
+    public static MultiNavigation<VecDocumentVersion, VecOccurrenceOrUsageViewItem3D> viewItems3dBy(
+            final VecOccurrenceOrUsage occurrenceOrUsage) {
+        return toViewItems3D().filter(viewItem -> viewItem.getOccurrenceOrUsage().contains(occurrenceOrUsage));
+    }
+
+    /**
+     * Navigates to the 2D view item showing the occurrence or usage with the given identification.
+     *
+     * @param occurrenceOrUsageId Identification of the occurrence or usage the view item has to show.
+     * @return A navigation to the 2D view item of the identified occurrence or usage.
+     */
+    public static SingleNavigation<VecDocumentVersion, VecOccurrenceOrUsageViewItem2D> viewItem2dBy(
+            final String occurrenceOrUsageId) {
+        return toViewItems2D().filter(showing(occurrenceOrUsageId)).atMostOne();
+    }
+
+    /**
+     * Navigates to the 3D view item showing the occurrence or usage with the given identification.
+     *
+     * @param occurrenceOrUsageId Identification of the occurrence or usage the view item has to show.
+     * @return A navigation to the 3D view item of the identified occurrence or usage.
+     */
+    public static SingleNavigation<VecDocumentVersion, VecOccurrenceOrUsageViewItem3D> viewItem3dBy(
+            final String occurrenceOrUsageId) {
+        return toViewItems3D().filter(showing(occurrenceOrUsageId)).atMostOne();
+    }
+
+    /**
+     * Navigates to the 2D building block positioning referencing the given building block.
+     *
+     * @param buildingBlock Building block the positioning has to reference.
+     * @return A navigation to the positioning of the given 2D building block.
+     */
+    public static SingleNavigation<VecDocumentVersion, VecBuildingBlockPositioning2D> positioning2dWith(
+            final VecBuildingBlockSpecification2D buildingBlock) {
+        return toBuildingBlockPositionings2D()
+                .filter(positioning -> Objects.equals(buildingBlock, positioning.getReferenced2DBuildingBlock()))
+                .atMostOne();
+    }
+
+    /**
+     * Navigates to the 3D building block positioning referencing the given building block.
+     *
+     * @param buildingBlock Building block the positioning has to reference.
+     * @return A navigation to the positioning of the given 3D building block.
+     */
+    public static SingleNavigation<VecDocumentVersion, VecBuildingBlockPositioning3D> positioning3dWith(
+            final VecBuildingBlockSpecification3D buildingBlock) {
+        return toBuildingBlockPositionings3D()
+                .filter(positioning -> Objects.equals(buildingBlock, positioning.getReferenced3DBuildingBlock()))
+                .atMostOne();
+    }
+
+    /**
+     * Navigates to the placements placing the given {@link VecPlaceableElementRole}.
+     *
+     * @param placedElement Role the placements have to place.
+     * @return A navigation to the placements of the given role.
+     */
+    public static MultiNavigation<VecDocumentVersion, VecPlacement> placementsOf(
+            final VecPlaceableElementRole placedElement) {
+        return toPlacements().filter(placing(placedElement));
+    }
+
+    /**
+     * Navigates to the {@link VecNodeLocation}s of the on point placements placing the given
+     * {@link VecPlaceableElementRole}.
+     *
+     * @param placedElement Role the placements have to place.
+     * @return A navigation to the node locations of the given role.
+     */
+    public static MultiNavigation<VecDocumentVersion, VecNodeLocation> nodeLocationsOf(
+            final VecPlaceableElementRole placedElement) {
+        return toPlacements()
+                .ofType(VecOnPointPlacement.class)
+                .filter(placing(placedElement))
+                .then(Placements.toLocations())
+                .ofType(VecNodeLocation.class);
+    }
+
+    /**
+     * Navigates to the {@link VecPlaceableElementRole} of the component with the given identification, taken
+     * from the composition specification with the given identification.
+     *
+     * @param compositionSpecificationId Identification of the composition specification holding the component.
+     * @param occurrenceOrUsageId        Identification of the component.
+     * @return A navigation to the placeable element role of the identified component.
+     */
+    public static SingleNavigation<VecDocumentVersion, VecPlaceableElementRole> placeableElementRoleBy(
+            final String compositionSpecificationId, final String occurrenceOrUsageId) {
+        return SpecificationOwners.<VecDocumentVersion>componentsBy(compositionSpecificationId)
+                .filter(identifiedBy(occurrenceOrUsageId))
+                .then(OccurrenceOrUsages.toRoles())
+                .ofType(VecPlaceableElementRole.class)
+                .atMostOne();
+    }
+
+    /**
+     * Navigates to the placement of the component with the given identification, taken from the composition
+     * specification with the given identification.
+     *
+     * @param compositionSpecificationId Identification of the composition specification holding the component.
+     * @param occurrenceOrUsageId        Identification of the component.
+     * @return A navigation to the placement of the identified component.
+     * @see #placeableElementRoleBy(String, String)
+     */
+    public static SingleNavigation<VecDocumentVersion, VecPlacement> placementBy(
+            final String compositionSpecificationId, final String occurrenceOrUsageId) {
+        final SingleNavigation<VecDocumentVersion, VecPlaceableElementRole> placedElement =
+                placeableElementRoleBy(compositionSpecificationId, occurrenceOrUsageId);
+        return documentVersion -> placedElement.from(documentVersion)
+                .flatMap(role -> placementsOf(role).atMostOne().from(documentVersion));
+    }
+
+    /**
+     * Navigates to the {@link VecTopologyNode} the component with the given identification is placed on.
+     *
+     * @param occurrenceIdentification Identification of the component.
+     * @return A navigation to the topology node of the identified component.
+     */
+    public static SingleNavigation<VecDocumentVersion, VecTopologyNode> topologyNodeBy(
+            final String occurrenceIdentification) {
+        return SpecificationOwners.<VecDocumentVersion>toComponents()
+                .filter(identifiedBy(occurrenceIdentification))
+                .then(OccurrenceOrUsages.toReferencedTopologyNode())
+                .atMostOne();
+    }
+
+    /**
+     * Navigates to the {@link VecTopologyNode} the given component is placed on, by looking up the node
+     * locations of its {@link VecPlaceableElementRole} in the document version.
+     *
+     * @param component Occurrence or usage to find the topology node of.
+     * @return A navigation to the topology node of the given component.
+     */
+    public static SingleNavigation<VecDocumentVersion, VecTopologyNode> topologyNodeOf(
+            final VecOccurrenceOrUsage component) {
+        return documentVersion -> OccurrenceOrUsages.toPlaceableElementRole()
+                .from(component)
+                .flatMap(role -> nodeLocationsOf(role).atMostOne().from(documentVersion))
+                .map(VecNodeLocation::getReferencedNode);
+    }
+
+    private static Predicate<VecGeometryNode> referencing(final VecTopologyNode topologyNode) {
+        return geometryNode -> Objects.equals(topologyNode, geometryNode.getReferenceNode());
+    }
+
+    private static Predicate<VecPlacement> placing(final VecPlaceableElementRole placedElement) {
+        return placement -> placement.getPlacedElement().contains(placedElement);
+    }
+
+    private static Predicate<HasIdentification> identifiedBy(final String identification) {
+        return element -> identification.equals(element.getIdentification());
+    }
+
+    private static Predicate<HasOccurrenceOrUsages> showing(final String occurrenceOrUsageId) {
+        return viewItem -> ViewItems.toOccurrenceOrUsages()
+                .atMostOne()
+                .from(viewItem)
+                .map(VecOccurrenceOrUsage::getIdentification)
+                .filter(occurrenceOrUsageId::equals)
+                .isPresent();
+    }
+
+}

--- a/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/traversal/ExtendableElements.java
+++ b/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/traversal/ExtendableElements.java
@@ -1,0 +1,62 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 1.2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v12x.traversal;
+
+import com.foursoft.harness.vec.common.traversal.MultiNavigation;
+import com.foursoft.harness.vec.common.traversal.Navigations;
+import com.foursoft.harness.vec.v12x.VecDocumentVersion;
+import com.foursoft.harness.vec.v12x.VecExtendableElement;
+
+/**
+ * Navigations starting at a {@link VecExtendableElement}, the common super type of the elements which can
+ * carry custom properties and reference external documents.
+ */
+public final class ExtendableElements {
+
+    private ExtendableElements() {
+        // hide default constructor
+    }
+
+    /**
+     * Navigates to the external documents an element references.
+     *
+     * @return A navigation to the referenced external documents of an element.
+     */
+    public static MultiNavigation<VecExtendableElement, VecDocumentVersion> toReferencedExternalDocuments() {
+        return Navigations.collection(VecExtendableElement::getReferencedExternalDocuments);
+    }
+
+    /**
+     * Navigates to the document numbers of the external documents an element references.
+     *
+     * @return A navigation to the document numbers of the referenced external documents.
+     */
+    public static MultiNavigation<VecExtendableElement, String> toExternalDocumentNumbers() {
+        return toReferencedExternalDocuments()
+                .then(Navigations.nullable(VecDocumentVersion::getDocumentNumber));
+    }
+
+}

--- a/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/traversal/LocalizedStringProperties.java
+++ b/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/traversal/LocalizedStringProperties.java
@@ -1,0 +1,60 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 1.2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v12x.traversal;
+
+import com.foursoft.harness.vec.common.traversal.Navigations;
+import com.foursoft.harness.vec.common.traversal.SingleNavigation;
+import com.foursoft.harness.vec.v12x.VecLanguageCode;
+import com.foursoft.harness.vec.v12x.VecLocalizedString;
+import com.foursoft.harness.vec.v12x.VecLocalizedStringProperty;
+import com.foursoft.harness.vec.v12x.predicates.VecPredicates;
+
+/**
+ * Navigations starting at a {@link VecLocalizedStringProperty}.
+ * <p>
+ * A localized string property holds exactly one {@link VecLocalizedString}, so choosing between several
+ * languages does not arise here; the language is a condition on the one value, not a selection among many.
+ * Reducing several localized strings to one value is what {@link LocalizedStrings} is for.
+ */
+public final class LocalizedStringProperties {
+
+    private LocalizedStringProperties() {
+        // hide default constructor
+    }
+
+    /**
+     * Navigates to the value of a localized string property, if it is in the given language.
+     *
+     * @param languageCode Language the value has to be in.
+     * @return A navigation to the value in the given language.
+     */
+    public static SingleNavigation<VecLocalizedStringProperty, String> valueIn(final VecLanguageCode languageCode) {
+        return Navigations.nullable(VecLocalizedStringProperty::getValue)
+                .filter(VecPredicates.languageCode(languageCode))
+                .then(Navigations.nullable(VecLocalizedString::getValue));
+    }
+
+}

--- a/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/traversal/LocalizedStrings.java
+++ b/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/traversal/LocalizedStrings.java
@@ -1,0 +1,122 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 1.2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v12x.traversal;
+
+import com.foursoft.harness.vec.common.traversal.MultiNavigation;
+import com.foursoft.harness.vec.common.util.StreamUtils;
+import com.foursoft.harness.vec.common.util.StringUtils;
+import com.foursoft.harness.vec.v12x.VecAbstractLocalizedString;
+import com.foursoft.harness.vec.v12x.VecLanguageCode;
+import com.foursoft.harness.vec.v12x.VecLocalizedTypedString;
+import com.foursoft.harness.vec.v12x.predicates.VecPredicates;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collector;
+
+/**
+ * Reductions from several {@link VecAbstractLocalizedString}s to the one value that applies.
+ * <p>
+ * These are <em>not</em> navigations: choosing the right value needs rules over the localized strings as a
+ * whole, which no sequence of steps expresses. They are therefore used with
+ * {@link MultiNavigation#collect(Collector)} on a navigation leading to the localized strings, such as
+ * {@link Descriptions#toDescriptions()}:
+ * <pre>
+ * {@code
+ * Descriptions.toDescriptions().collect(LocalizedStrings.valueIn(VecLanguageCode.DE));
+ * }
+ * </pre>
+ */
+public final class LocalizedStrings {
+
+    private LocalizedStrings() {
+        // hide default constructor
+    }
+
+    /**
+     * Reduces localized strings to the value in the given language.
+     * <p>
+     * A single {@link VecLocalizedTypedString} with a type is not considered a description and therefore
+     * yields no value. A single untyped string is used regardless of its language, as there is nothing to
+     * choose from. Otherwise the typed strings are ignored and the value of the given language is used.
+     *
+     * @param languageCode Language of the value to reduce to.
+     * @return A reduction to the value in the given language.
+     */
+    public static Collector<VecAbstractLocalizedString, ?, Optional<String>> valueIn(
+            final VecLanguageCode languageCode) {
+        return StreamUtils.reducing(localizedStrings -> {
+            if (localizedStrings.isEmpty()) {
+                return Optional.empty();
+            }
+            if (localizedStrings.size() == 1) {
+                final VecAbstractLocalizedString localizedString = localizedStrings.get(0);
+                if (localizedString instanceof final VecLocalizedTypedString typedString
+                        && StringUtils.isNotEmpty(typedString.getType())) {
+                    return Optional.empty();
+                }
+                return Optional.ofNullable(localizedString)
+                        .map(VecAbstractLocalizedString::getValue);
+            }
+
+            return localizedStrings.stream()
+                    .filter(Objects::nonNull)
+                    .filter(localizedString -> !(localizedString instanceof VecLocalizedTypedString))
+                    .filter(VecPredicates.languageCode(languageCode))
+                    .map(VecAbstractLocalizedString::getValue)
+                    .filter(Objects::nonNull)
+                    .collect(StreamUtils.findOneOrNone());
+        });
+    }
+
+    /**
+     * Reduces localized strings to the value of the {@link VecLocalizedTypedString} with the given type and
+     * language.
+     *
+     * @param descriptionType Type of the localized string to reduce to.
+     * @param languageCode    Language of the localized string to reduce to.
+     * @return A reduction to the value of the given type and language.
+     */
+    public static Collector<VecAbstractLocalizedString, ?, Optional<String>> typedValueBy(
+            final String descriptionType, final VecLanguageCode languageCode) {
+        return StreamUtils.reducing(localizedStrings -> reduceToTypedValue(
+                localizedStrings, descriptionType, languageCode));
+    }
+
+    private static Optional<String> reduceToTypedValue(final List<VecAbstractLocalizedString> localizedStrings,
+                                                       final String descriptionType,
+                                                       final VecLanguageCode languageCode) {
+        return localizedStrings.stream()
+                .filter(VecPredicates.languageCode(languageCode))
+                .flatMap(StreamUtils.ofClass(VecLocalizedTypedString.class))
+                .filter(typedString -> descriptionType.equals(typedString.getType()))
+                .collect(StreamUtils.findOneOrNone())
+                .map(VecLocalizedTypedString::getValue)
+                .filter(StringUtils::isNotEmpty);
+    }
+
+}

--- a/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/traversal/OccurrenceOrUsages.java
+++ b/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/traversal/OccurrenceOrUsages.java
@@ -1,0 +1,247 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 1.2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v12x.traversal;
+
+import com.foursoft.harness.vec.common.annotations.RequiresBackReferences;
+import com.foursoft.harness.vec.common.exception.VecException;
+import com.foursoft.harness.vec.common.traversal.MultiNavigation;
+import com.foursoft.harness.vec.common.traversal.Navigations;
+import com.foursoft.harness.vec.common.traversal.SingleNavigation;
+import com.foursoft.harness.vec.common.util.StringUtils;
+import com.foursoft.harness.vec.v12x.VecCompositionSpecification;
+import com.foursoft.harness.vec.v12x.VecDocumentVersion;
+import com.foursoft.harness.vec.v12x.VecLocation;
+import com.foursoft.harness.vec.v12x.VecModuleFamily;
+import com.foursoft.harness.vec.v12x.VecOccurrenceOrUsage;
+import com.foursoft.harness.vec.v12x.VecPartOccurrence;
+import com.foursoft.harness.vec.v12x.VecPartOrUsageRelatedSpecification;
+import com.foursoft.harness.vec.v12x.VecPartUsage;
+import com.foursoft.harness.vec.v12x.VecPartUsageSpecification;
+import com.foursoft.harness.vec.v12x.VecPartVersion;
+import com.foursoft.harness.vec.v12x.VecPartWithSubComponentsRole;
+import com.foursoft.harness.vec.v12x.VecPlaceableElementRole;
+import com.foursoft.harness.vec.v12x.VecPrimaryPartType;
+import com.foursoft.harness.vec.v12x.VecRole;
+import com.foursoft.harness.vec.v12x.VecTopologyNode;
+import com.foursoft.harness.vec.v12x.visitor.ReferencedNodeLocationVisitor;
+
+import java.util.Optional;
+
+/**
+ * Navigations starting at a {@link VecOccurrenceOrUsage}, including its {@link VecPartOccurrence} and
+ * {@link VecPartUsage} sub types.
+ * <p>
+ * Where both sub types lead to the same target, the navigation starts at the family and resolves the sub type
+ * internally, so the source never shows up in the method name. Navigations which only a
+ * {@link VecPartOccurrence} has, such as {@link #toPart()}, start there.
+ */
+public final class OccurrenceOrUsages {
+
+    private OccurrenceOrUsages() {
+        // hide default constructor
+    }
+
+    /**
+     * Navigates to the roles of an occurrence or usage.
+     *
+     * @return A navigation to the roles of an occurrence or usage.
+     */
+    public static MultiNavigation<VecOccurrenceOrUsage, VecRole> toRoles() {
+        return Navigations.collection(VecOccurrenceOrUsage::getRoles);
+    }
+
+    /**
+     * Navigates to the {@link VecPlaceableElementRole} of an occurrence or usage.
+     * <p>
+     * An occurrence or usage is expected to have at most one such role. If there are several ones, the first
+     * is chosen, see {@link MultiNavigation#atMostOne()}.
+     *
+     * @return A navigation to the placeable element role of an occurrence or usage.
+     */
+    public static SingleNavigation<VecOccurrenceOrUsage, VecPlaceableElementRole> toPlaceableElementRole() {
+        return toRoles()
+                .ofType(VecPlaceableElementRole.class)
+                .atMostOne();
+    }
+
+    /**
+     * Navigates to the {@link VecDocumentVersion} an occurrence or usage belongs to, through the
+     * {@link VecCompositionSpecification} of an occurrence and the {@link VecPartUsageSpecification} of a
+     * usage.
+     *
+     * @return A navigation to the parent document version of an occurrence or usage.
+     */
+    @RequiresBackReferences
+    public static SingleNavigation<VecOccurrenceOrUsage, VecDocumentVersion> toParentDocumentVersion() {
+        return occurrenceOrUsage -> switch (occurrenceOrUsage) {
+            case final VecPartOccurrence occurrence -> Navigations
+                    .nullable(VecPartOccurrence::getParentCompositionSpecification)
+                    .then(Specifications.toParentDocumentVersion())
+                    .from(occurrence);
+            case final VecPartUsage usage -> Navigations
+                    .nullable(VecPartUsage::getParentPartUsageSpecification)
+                    .then(Specifications.toParentDocumentVersion())
+                    .from(usage);
+            default -> throw unhandledSubType(occurrenceOrUsage);
+        };
+    }
+
+    /**
+     * Navigates to the document number of the {@link VecDocumentVersion} an occurrence or usage belongs to.
+     *
+     * @return A navigation to the parent document number of an occurrence or usage.
+     * @see #toParentDocumentVersion()
+     */
+    @RequiresBackReferences
+    public static SingleNavigation<VecOccurrenceOrUsage, String> toParentDocumentNumber() {
+        return toParentDocumentVersion().then(Navigations.nullable(VecDocumentVersion::getDocumentNumber));
+    }
+
+    /**
+     * Navigates to the {@link VecPrimaryPartType} of an occurrence or usage.
+     * <p>
+     * A usage states its type itself. An occurrence takes it from its {@link VecPartVersion}, falling back to
+     * the part usage it realizes and finally to {@link VecPrimaryPartType#OTHER} if it has no part.
+     *
+     * @return A navigation to the primary part type of an occurrence or usage.
+     */
+    public static SingleNavigation<VecOccurrenceOrUsage, VecPrimaryPartType> toPrimaryPartType() {
+        return occurrenceOrUsage -> switch (occurrenceOrUsage) {
+            case final VecPartOccurrence occurrence -> occurrence.getPart() != null
+                    ? Optional.ofNullable(occurrence.getPart().getPrimaryPartType())
+                    : Optional.of(toRealizedPartUsages()
+                                          .then(Navigations.nullable(VecPartUsage::getPrimaryPartUsageType))
+                                          .atMostOne()
+                                          .orElse(occurrence, VecPrimaryPartType.OTHER));
+            case final VecPartUsage usage -> Optional.ofNullable(usage.getPrimaryPartUsageType());
+            default -> throw unhandledSubType(occurrenceOrUsage);
+        };
+    }
+
+    /**
+     * Navigates to the {@link VecPartOrUsageRelatedSpecification}s of an occurrence or usage, through the
+     * {@link VecPartVersion} of an occurrence.
+     *
+     * @return A navigation to the part or usage related specifications of an occurrence or usage.
+     */
+    @RequiresBackReferences
+    public static MultiNavigation<VecOccurrenceOrUsage, VecPartOrUsageRelatedSpecification>
+    toPartOrUsageRelatedSpecifications() {
+        return occurrenceOrUsage -> switch (occurrenceOrUsage) {
+            case final VecPartOccurrence occurrence -> toPart()
+                    .then(Navigations.collection(VecPartVersion::getRefPartOrUsageRelatedSpecification))
+                    .from(occurrence);
+            case final VecPartUsage usage -> Navigations
+                    .collection(VecPartUsage::getPartOrUsageRelatedSpecification)
+                    .from(usage);
+            default -> throw unhandledSubType(occurrenceOrUsage);
+        };
+    }
+
+    /**
+     * Navigates to the {@link VecTopologyNode} an occurrence or usage is placed on, by resolving the
+     * locations of its on point placements with the {@link ReferencedNodeLocationVisitor}.
+     *
+     * @return A navigation to the referenced topology node of an occurrence or usage.
+     */
+    public static SingleNavigation<VecOccurrenceOrUsage, VecTopologyNode> toReferencedTopologyNode() {
+        final ReferencedNodeLocationVisitor visitor = new ReferencedNodeLocationVisitor();
+        return toRoles()
+                .ofType(VecPlaceableElementRole.class)
+                .then(PlaceableElementRoles.toOnPointPlacements())
+                .then(Placements.toLocations())
+                .then(Navigations.<VecLocation, VecTopologyNode>nullable(location -> location.accept(visitor)))
+                .atMostOne();
+    }
+
+    /**
+     * Navigates to the {@link VecPartVersion} an occurrence is an occurrence of.
+     *
+     * @return A navigation to the part of an occurrence.
+     */
+    public static SingleNavigation<VecPartOccurrence, VecPartVersion> toPart() {
+        return Navigations.nullable(VecPartOccurrence::getPart);
+    }
+
+    /**
+     * Navigates to the part number of the {@link VecPartVersion} of an occurrence, with multiple whitespaces
+     * collapsed into one.
+     *
+     * @return A navigation to the part number of an occurrence.
+     */
+    public static SingleNavigation<VecPartOccurrence, String> toPartNumber() {
+        return toPart()
+                .then(Navigations.nullable(VecPartVersion::getPartNumber))
+                .then(Navigations.nullable(StringUtils::collapseMultipleWhitespaces));
+    }
+
+    /**
+     * Navigates to the part version of the {@link VecPartVersion} of an occurrence, with multiple whitespaces
+     * collapsed into one.
+     *
+     * @return A navigation to the part version of an occurrence.
+     */
+    public static SingleNavigation<VecPartOccurrence, String> toPartVersion() {
+        return toPart()
+                .then(Navigations.nullable(VecPartVersion::getPartVersion))
+                .then(Navigations.nullable(StringUtils::collapseMultipleWhitespaces));
+    }
+
+    /**
+     * Navigates to the part usages an occurrence realizes.
+     *
+     * @return A navigation to the realized part usages of an occurrence.
+     */
+    public static MultiNavigation<VecPartOccurrence, VecPartUsage> toRealizedPartUsages() {
+        return Navigations.collection(VecPartOccurrence::getRealizedPartUsage);
+    }
+
+    /**
+     * Navigates to the {@link VecModuleFamily} of an occurrence which is a module.
+     * <p>
+     * Only an occurrence of a {@link VecPrimaryPartType#PART_STRUCTURE} is a module, so any other occurrence
+     * leads nowhere. Note that an assembly is a part structure as well.
+     *
+     * @return A navigation to the module family of an occurrence.
+     */
+    public static SingleNavigation<VecPartOccurrence, VecModuleFamily> toModuleFamily() {
+        final SingleNavigation<VecOccurrenceOrUsage, VecModuleFamily> moduleFamily = toRoles()
+                .ofType(VecPartWithSubComponentsRole.class)
+                .then(Navigations.collection(VecPartWithSubComponentsRole::getRefModuleFamily))
+                .atMostOne();
+        return occurrence -> toPart()
+                .then(Navigations.nullable(VecPartVersion::getPrimaryPartType))
+                .from(occurrence)
+                .filter(VecPrimaryPartType.PART_STRUCTURE::equals)
+                .flatMap(partType -> moduleFamily.from(occurrence));
+    }
+
+    private static VecException unhandledSubType(final VecOccurrenceOrUsage occurrenceOrUsage) {
+        return new VecException("Unhandled sub type of VecOccurrenceOrUsage: "
+                                        + occurrenceOrUsage.getClass().getName());
+    }
+
+}

--- a/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/traversal/PlaceableElementRoles.java
+++ b/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/traversal/PlaceableElementRoles.java
@@ -1,0 +1,71 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 1.2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v12x.traversal;
+
+import com.foursoft.harness.vec.common.traversal.MultiNavigation;
+import com.foursoft.harness.vec.common.traversal.Navigations;
+import com.foursoft.harness.vec.v12x.VecOnPointPlacement;
+import com.foursoft.harness.vec.v12x.VecOnWayPlacement;
+import com.foursoft.harness.vec.v12x.VecPlaceableElementRole;
+import com.foursoft.harness.vec.v12x.VecPlacement;
+
+/**
+ * Navigations starting at a {@link VecPlaceableElementRole}.
+ */
+public final class PlaceableElementRoles {
+
+    private PlaceableElementRoles() {
+        // hide default constructor
+    }
+
+    /**
+     * Navigates to all placements of a role.
+     *
+     * @return A navigation to the placements of a role.
+     */
+    public static MultiNavigation<VecPlaceableElementRole, VecPlacement> toPlacements() {
+        return Navigations.collection(VecPlaceableElementRole::getRefPlacement);
+    }
+
+    /**
+     * Navigates to the {@link VecOnPointPlacement}s of a role.
+     *
+     * @return A navigation to the on point placements of a role.
+     */
+    public static MultiNavigation<VecPlaceableElementRole, VecOnPointPlacement> toOnPointPlacements() {
+        return toPlacements().ofType(VecOnPointPlacement.class);
+    }
+
+    /**
+     * Navigates to the {@link VecOnWayPlacement}s of a role.
+     *
+     * @return A navigation to the on way placements of a role.
+     */
+    public static MultiNavigation<VecPlaceableElementRole, VecOnWayPlacement> toOnWayPlacements() {
+        return toPlacements().ofType(VecOnWayPlacement.class);
+    }
+
+}

--- a/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/traversal/Placements.java
+++ b/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/traversal/Placements.java
@@ -1,6 +1,6 @@
 /*-
  * ========================LICENSE_START=================================
- * VEC 2.X
+ * VEC 1.2.X
  * %%
  * Copyright (C) 2020 - 2026 4Soft GmbH
  * %%
@@ -23,14 +23,14 @@
  * THE SOFTWARE.
  * =========================LICENSE_END==================================
  */
-package com.foursoft.harness.vec.v2x.traversal;
+package com.foursoft.harness.vec.v12x.traversal;
 
 import com.foursoft.harness.vec.common.exception.VecException;
 import com.foursoft.harness.vec.common.traversal.MultiNavigation;
-import com.foursoft.harness.vec.v2x.VecLocation;
-import com.foursoft.harness.vec.v2x.VecOnPointPlacement;
-import com.foursoft.harness.vec.v2x.VecOnWayPlacement;
-import com.foursoft.harness.vec.v2x.VecPlacement;
+import com.foursoft.harness.vec.v12x.VecLocation;
+import com.foursoft.harness.vec.v12x.VecOnPointPlacement;
+import com.foursoft.harness.vec.v12x.VecOnWayPlacement;
+import com.foursoft.harness.vec.v12x.VecPlacement;
 
 import java.util.Objects;
 import java.util.stream.Stream;

--- a/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/traversal/Roles.java
+++ b/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/traversal/Roles.java
@@ -1,0 +1,65 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 1.2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v12x.traversal;
+
+import com.foursoft.harness.vec.common.annotations.RequiresBackReferences;
+import com.foursoft.harness.vec.common.traversal.Navigations;
+import com.foursoft.harness.vec.common.traversal.SingleNavigation;
+import com.foursoft.harness.vec.v12x.VecDocumentVersion;
+import com.foursoft.harness.vec.v12x.VecOccurrenceOrUsage;
+import com.foursoft.harness.vec.v12x.VecRole;
+
+/**
+ * Navigations starting at a {@link VecRole}.
+ */
+public final class Roles {
+
+    private Roles() {
+        // hide default constructor
+    }
+
+    /**
+     * Navigates to the {@link VecOccurrenceOrUsage} a role belongs to.
+     *
+     * @return A navigation to the occurrence or usage of a role.
+     */
+    @RequiresBackReferences
+    public static SingleNavigation<VecRole, VecOccurrenceOrUsage> toParentOccurrenceOrUsage() {
+        return Navigations.nullable(VecRole::getParentOccurrenceOrUsage);
+    }
+
+    /**
+     * Navigates to the {@link VecDocumentVersion} the occurrence or usage of a role belongs to.
+     *
+     * @return A navigation to the parent document version of a role.
+     * @see OccurrenceOrUsages#toParentDocumentVersion()
+     */
+    @RequiresBackReferences
+    public static SingleNavigation<VecRole, VecDocumentVersion> toParentDocumentVersion() {
+        return toParentOccurrenceOrUsage().then(OccurrenceOrUsages.toParentDocumentVersion());
+    }
+
+}

--- a/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/traversal/SpecificationOwners.java
+++ b/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/traversal/SpecificationOwners.java
@@ -1,0 +1,130 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 1.2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v12x.traversal;
+
+import com.foursoft.harness.vec.common.HasSpecifications;
+import com.foursoft.harness.vec.common.traversal.MultiNavigation;
+import com.foursoft.harness.vec.common.traversal.Navigations;
+import com.foursoft.harness.vec.v12x.VecCompositionSpecification;
+import com.foursoft.harness.vec.v12x.VecDocumentVersion;
+import com.foursoft.harness.vec.v12x.VecOccurrenceOrUsage;
+import com.foursoft.harness.vec.v12x.VecPartOccurrence;
+import com.foursoft.harness.vec.v12x.VecPartUsage;
+import com.foursoft.harness.vec.v12x.VecPartUsageSpecification;
+import com.foursoft.harness.vec.v12x.VecSheetOrChapter;
+import com.foursoft.harness.vec.v12x.VecSpecification;
+
+import java.util.stream.Stream;
+
+/**
+ * Navigations starting at a {@link HasSpecifications} holding {@link VecSpecification}s, that is at a
+ * {@link VecDocumentVersion} or a {@link VecSheetOrChapter}.
+ * <p>
+ * The catalog is not named {@code Specifications}, which is the catalog of the specifications themselves;
+ * these navigations start at the element <em>holding</em> them. They are generic in their source, so a chain
+ * starting at one of the holders keeps that holder as its source type:
+ * <pre>
+ * {@code
+ * MultiNavigation<VecDocumentVersion, VecPlacementSpecification> placementSpecifications =
+ *     SpecificationOwners.<VecDocumentVersion>toSpecifications().ofType(VecPlacementSpecification.class);
+ * }
+ * </pre>
+ *
+ * @see Specifications
+ */
+public final class SpecificationOwners {
+
+    private SpecificationOwners() {
+        // hide default constructor
+    }
+
+    /**
+     * Navigates to the specifications of their holder.
+     *
+     * @param <S> Type of the specification holder to navigate from.
+     * @return A navigation to the specifications of a holder.
+     */
+    public static <S extends HasSpecifications<VecSpecification>> MultiNavigation<S, VecSpecification>
+    toSpecifications() {
+        return Navigations.collection(HasSpecifications::getSpecifications);
+    }
+
+    /**
+     * Navigates to the components of all {@link VecCompositionSpecification}s of a specification holder.
+     *
+     * @param <S> Type of the specification holder to navigate from.
+     * @return A navigation to the components of a holder.
+     */
+    public static <S extends HasSpecifications<VecSpecification>> MultiNavigation<S, VecPartOccurrence>
+    toComponents() {
+        return SpecificationOwners.<S>toSpecifications()
+                .ofType(VecCompositionSpecification.class)
+                .then(Specifications.toComponents());
+    }
+
+    /**
+     * Navigates to the part usages of all {@link VecPartUsageSpecification}s of a specification holder.
+     *
+     * @param <S> Type of the specification holder to navigate from.
+     * @return A navigation to the part usages of a holder.
+     */
+    public static <S extends HasSpecifications<VecSpecification>> MultiNavigation<S, VecPartUsage> toPartUsages() {
+        return SpecificationOwners.<S>toSpecifications()
+                .ofType(VecPartUsageSpecification.class)
+                .then(Specifications.toPartUsages());
+    }
+
+    /**
+     * Navigates to all occurrences and usages of a specification holder, that is to its
+     * {@linkplain #toComponents() components} followed by its {@linkplain #toPartUsages() part usages}.
+     *
+     * @param <S> Type of the specification holder to navigate from.
+     * @return A navigation to the occurrences and usages of a holder.
+     */
+    public static <S extends HasSpecifications<VecSpecification>> MultiNavigation<S, VecOccurrenceOrUsage>
+    toOccurrenceOrUsages() {
+        final MultiNavigation<S, VecPartOccurrence> components = toComponents();
+        final MultiNavigation<S, VecPartUsage> partUsages = toPartUsages();
+        return source -> Stream.concat(components.from(source), partUsages.from(source));
+    }
+
+    /**
+     * Navigates to the components of the {@link VecCompositionSpecification} with the given identification.
+     *
+     * @param compositionSpecificationId Identification of the composition specification to navigate into.
+     * @param <S>                        Type of the specification holder to navigate from.
+     * @return A navigation to the components of the identified composition specification.
+     */
+    public static <S extends HasSpecifications<VecSpecification>> MultiNavigation<S, VecPartOccurrence> componentsBy(
+            final String compositionSpecificationId) {
+        return SpecificationOwners.<S>toSpecifications()
+                .ofType(VecCompositionSpecification.class)
+                .filter(specification -> specification.getIdentification().equals(compositionSpecificationId))
+                .atMostOne()
+                .then(Specifications.toComponents());
+    }
+
+}

--- a/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/traversal/Specifications.java
+++ b/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/traversal/Specifications.java
@@ -1,0 +1,246 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 1.2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v12x.traversal;
+
+import com.foursoft.harness.vec.common.HasIdentification;
+import com.foursoft.harness.vec.common.annotations.RequiresBackReferences;
+import com.foursoft.harness.vec.common.traversal.MultiNavigation;
+import com.foursoft.harness.vec.common.traversal.Navigations;
+import com.foursoft.harness.vec.common.traversal.SingleNavigation;
+import com.foursoft.harness.vec.v12x.VecBuildingBlockPositioning2D;
+import com.foursoft.harness.vec.v12x.VecBuildingBlockPositioning3D;
+import com.foursoft.harness.vec.v12x.VecBuildingBlockSpecification2D;
+import com.foursoft.harness.vec.v12x.VecBuildingBlockSpecification3D;
+import com.foursoft.harness.vec.v12x.VecCompositionSpecification;
+import com.foursoft.harness.vec.v12x.VecDocumentVersion;
+import com.foursoft.harness.vec.v12x.VecGeometryNode2D;
+import com.foursoft.harness.vec.v12x.VecGeometryNode3D;
+import com.foursoft.harness.vec.v12x.VecGeometrySegment2D;
+import com.foursoft.harness.vec.v12x.VecGeometrySegment3D;
+import com.foursoft.harness.vec.v12x.VecHarnessDrawingSpecification2D;
+import com.foursoft.harness.vec.v12x.VecHarnessGeometrySpecification3D;
+import com.foursoft.harness.vec.v12x.VecOccurrenceOrUsageViewItem2D;
+import com.foursoft.harness.vec.v12x.VecOccurrenceOrUsageViewItem3D;
+import com.foursoft.harness.vec.v12x.VecPartOccurrence;
+import com.foursoft.harness.vec.v12x.VecPartUsage;
+import com.foursoft.harness.vec.v12x.VecPartUsageSpecification;
+import com.foursoft.harness.vec.v12x.VecPlacement;
+import com.foursoft.harness.vec.v12x.VecPlacementSpecification;
+import com.foursoft.harness.vec.v12x.VecSheetOrChapter;
+import com.foursoft.harness.vec.v12x.VecSpecification;
+
+import java.util.Optional;
+import java.util.function.Predicate;
+
+/**
+ * Navigations starting at a {@link VecSpecification} or one of its sub types.
+ * <p>
+ * The steps of the sub types name the elements they lead to, which is what the {@code 2D} and {@code 3D} in
+ * their names refer to. Where a document version rather than a single specification is at hand,
+ * {@link DocumentVersions} offers the same targets from there.
+ */
+public final class Specifications {
+
+    private Specifications() {
+        // hide default constructor
+    }
+
+    /**
+     * Navigates to the {@link VecDocumentVersion} a specification belongs to, whether it is held by the
+     * document version directly or by one of its {@link VecSheetOrChapter}s.
+     *
+     * @return A navigation to the parent document version of a specification.
+     */
+    @RequiresBackReferences
+    public static SingleNavigation<VecSpecification, VecDocumentVersion> toParentDocumentVersion() {
+        return specification -> Optional.ofNullable(specification.getParentDocumentVersion())
+                .or(() -> Optional.ofNullable(specification.getParentSheetOrChapter())
+                        .map(VecSheetOrChapter::getParentDocumentVersion));
+    }
+
+    /**
+     * Navigates to the document number of the {@link VecDocumentVersion} a specification belongs to.
+     *
+     * @return A navigation to the parent document number of a specification.
+     * @see #toParentDocumentVersion()
+     */
+    @RequiresBackReferences
+    public static SingleNavigation<VecSpecification, String> toParentDocumentNumber() {
+        return toParentDocumentVersion().then(Navigations.nullable(VecDocumentVersion::getDocumentNumber));
+    }
+
+    /**
+     * Navigates to the components of a {@link VecCompositionSpecification}.
+     *
+     * @return A navigation to the components of a composition specification.
+     */
+    public static MultiNavigation<VecCompositionSpecification, VecPartOccurrence> toComponents() {
+        return Navigations.collection(VecCompositionSpecification::getComponents);
+    }
+
+    /**
+     * Navigates to the part usages of a {@link VecPartUsageSpecification}.
+     *
+     * @return A navigation to the part usages of a part usage specification.
+     */
+    public static MultiNavigation<VecPartUsageSpecification, VecPartUsage> toPartUsages() {
+        return Navigations.collection(VecPartUsageSpecification::getPartUsages);
+    }
+
+    /**
+     * Navigates to the placements of a {@link VecPlacementSpecification}.
+     *
+     * @return A navigation to the placements of a placement specification.
+     */
+    public static MultiNavigation<VecPlacementSpecification, VecPlacement> toPlacements() {
+        return Navigations.collection(VecPlacementSpecification::getPlacements);
+    }
+
+    /**
+     * Navigates to the geometry nodes of a {@link VecBuildingBlockSpecification2D}.
+     *
+     * @return A navigation to the 2D geometry nodes of a building block.
+     */
+    public static MultiNavigation<VecBuildingBlockSpecification2D, VecGeometryNode2D> toGeometryNodes2D() {
+        return Navigations.collection(VecBuildingBlockSpecification2D::getGeometryNodes);
+    }
+
+    /**
+     * Navigates to the geometry nodes of a {@link VecBuildingBlockSpecification3D}.
+     *
+     * @return A navigation to the 3D geometry nodes of a building block.
+     */
+    public static MultiNavigation<VecBuildingBlockSpecification3D, VecGeometryNode3D> toGeometryNodes3D() {
+        return Navigations.collection(VecBuildingBlockSpecification3D::getGeometryNodes);
+    }
+
+    /**
+     * Navigates to the geometry segments of a {@link VecBuildingBlockSpecification2D}.
+     *
+     * @return A navigation to the 2D geometry segments of a building block.
+     */
+    public static MultiNavigation<VecBuildingBlockSpecification2D, VecGeometrySegment2D> toGeometrySegments2D() {
+        return Navigations.collection(VecBuildingBlockSpecification2D::getGeometrySegments);
+    }
+
+    /**
+     * Navigates to the geometry segments of a {@link VecBuildingBlockSpecification3D}.
+     *
+     * @return A navigation to the 3D geometry segments of a building block.
+     */
+    public static MultiNavigation<VecBuildingBlockSpecification3D, VecGeometrySegment3D> toGeometrySegments3D() {
+        return Navigations.collection(VecBuildingBlockSpecification3D::getGeometrySegments);
+    }
+
+    /**
+     * Navigates to the view items of a {@link VecBuildingBlockSpecification2D}.
+     *
+     * @return A navigation to the 2D view items of a building block.
+     */
+    public static MultiNavigation<VecBuildingBlockSpecification2D, VecOccurrenceOrUsageViewItem2D> toViewItems2D() {
+        return Navigations.collection(VecBuildingBlockSpecification2D::getPlacedElementViewItems);
+    }
+
+    /**
+     * Navigates to the view items of a {@link VecBuildingBlockSpecification3D}.
+     *
+     * @return A navigation to the 3D view items of a building block.
+     */
+    public static MultiNavigation<VecBuildingBlockSpecification3D, VecOccurrenceOrUsageViewItem3D> toViewItems3D() {
+        return Navigations.collection(VecBuildingBlockSpecification3D::getPlacedElementViewItem3Ds);
+    }
+
+    /**
+     * Navigates to the building block positionings of a {@link VecHarnessDrawingSpecification2D}.
+     *
+     * @return A navigation to the 2D building block positionings of a harness drawing.
+     */
+    public static MultiNavigation<VecHarnessDrawingSpecification2D, VecBuildingBlockPositioning2D>
+    toBuildingBlockPositionings2D() {
+        return Navigations.collection(VecHarnessDrawingSpecification2D::getBuildingBlockPositionings);
+    }
+
+    /**
+     * Navigates to the building block positionings of a {@link VecHarnessGeometrySpecification3D}.
+     *
+     * @return A navigation to the 3D building block positionings of a harness geometry.
+     */
+    public static MultiNavigation<VecHarnessGeometrySpecification3D, VecBuildingBlockPositioning3D>
+    toBuildingBlockPositionings3D() {
+        return Navigations.collection(VecHarnessGeometrySpecification3D::getBuildingBlockPositionings);
+    }
+
+    /**
+     * Navigates to the geometry node of a {@link VecBuildingBlockSpecification2D} with the given identification.
+     *
+     * @param nodeId Identification of the geometry node to navigate to.
+     * @return A navigation to the identified 2D geometry node.
+     */
+    public static SingleNavigation<VecBuildingBlockSpecification2D, VecGeometryNode2D> geometryNode2dBy(
+            final String nodeId) {
+        return toGeometryNodes2D().filter(identifiedBy(nodeId)).atMostOne();
+    }
+
+    /**
+     * Navigates to the geometry node of a {@link VecBuildingBlockSpecification3D} with the given identification.
+     *
+     * @param nodeId Identification of the geometry node to navigate to.
+     * @return A navigation to the identified 3D geometry node.
+     */
+    public static SingleNavigation<VecBuildingBlockSpecification3D, VecGeometryNode3D> geometryNode3dBy(
+            final String nodeId) {
+        return toGeometryNodes3D().filter(identifiedBy(nodeId)).atMostOne();
+    }
+
+    /**
+     * Navigates to the geometry segment of a {@link VecBuildingBlockSpecification2D} with the given
+     * identification.
+     *
+     * @param segmentId Identification of the geometry segment to navigate to.
+     * @return A navigation to the identified 2D geometry segment.
+     */
+    public static SingleNavigation<VecBuildingBlockSpecification2D, VecGeometrySegment2D> geometrySegment2dBy(
+            final String segmentId) {
+        return toGeometrySegments2D().filter(identifiedBy(segmentId)).atMostOne();
+    }
+
+    /**
+     * Navigates to the geometry segment of a {@link VecBuildingBlockSpecification3D} with the given
+     * identification.
+     *
+     * @param segmentId Identification of the geometry segment to navigate to.
+     * @return A navigation to the identified 3D geometry segment.
+     */
+    public static SingleNavigation<VecBuildingBlockSpecification3D, VecGeometrySegment3D> geometrySegment3dBy(
+            final String segmentId) {
+        return toGeometrySegments3D().filter(identifiedBy(segmentId)).atMostOne();
+    }
+
+    private static Predicate<HasIdentification> identifiedBy(final String identification) {
+        return element -> element.getIdentification().equals(identification);
+    }
+
+}

--- a/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/traversal/TopologySegments.java
+++ b/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/traversal/TopologySegments.java
@@ -1,0 +1,113 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 1.2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v12x.traversal;
+
+import com.foursoft.harness.vec.common.annotations.RequiresBackReferences;
+import com.foursoft.harness.vec.common.traversal.MultiNavigation;
+import com.foursoft.harness.vec.common.traversal.Navigations;
+import com.foursoft.harness.vec.common.traversal.SingleNavigation;
+import com.foursoft.harness.vec.v12x.VecNumericalValue;
+import com.foursoft.harness.vec.v12x.VecSegmentCrossSectionArea;
+import com.foursoft.harness.vec.v12x.VecSegmentLength;
+import com.foursoft.harness.vec.v12x.VecTopologySegment;
+import com.foursoft.harness.vec.v12x.VecTopologySpecification;
+
+import java.util.Objects;
+
+/**
+ * Navigations starting at a {@link VecTopologySegment}.
+ * <p>
+ * A segment carries its length and cross section area several times over, once per classification, which is
+ * why the navigations to them are named after the value they select rather than after a plain step.
+ */
+public final class TopologySegments {
+
+    private TopologySegments() {
+        // hide default constructor
+    }
+
+    /**
+     * Navigates to the document number of the {@link com.foursoft.harness.vec.v12x.VecDocumentVersion} the
+     * {@link VecTopologySpecification} of a segment belongs to.
+     *
+     * @return A navigation to the parent document number of a segment.
+     */
+    @RequiresBackReferences
+    public static SingleNavigation<VecTopologySegment, String> toParentDocumentNumber() {
+        return Navigations.nullable(VecTopologySegment::getParentTopologySpecification)
+                .then(Specifications.toParentDocumentNumber());
+    }
+
+    /**
+     * Navigates to the length informations of a segment.
+     *
+     * @return A navigation to the length informations of a segment.
+     */
+    public static MultiNavigation<VecTopologySegment, VecSegmentLength> toLengthInformations() {
+        return Navigations.collection(VecTopologySegment::getLengthInformations)
+                .filter(Objects::nonNull);
+    }
+
+    /**
+     * Navigates to the cross section area informations of a segment.
+     *
+     * @return A navigation to the cross section area informations of a segment.
+     */
+    public static MultiNavigation<VecTopologySegment, VecSegmentCrossSectionArea> toCrossSectionAreaInformations() {
+        return Navigations.collection(
+                        VecTopologySegment::getCrossSectionAreaInformations)
+                .filter(Objects::nonNull);
+    }
+
+    /**
+     * Navigates to the length of a segment with the given classification.
+     *
+     * @param segmentLengthClassification Classification of the length to navigate to.
+     * @return A navigation to the length value of the given classification.
+     */
+    public static SingleNavigation<VecTopologySegment, Double> lengthBy(final String segmentLengthClassification) {
+        return toLengthInformations()
+                .filter(length -> segmentLengthClassification.equals(length.getClassification()))
+                .atMostOne()
+                .then(Navigations.nullable(VecSegmentLength::getLength))
+                .then(Navigations.nullable(VecNumericalValue::getValueComponent));
+    }
+
+    /**
+     * Navigates to the cross section area of a segment of the given type.
+     *
+     * @param areaType Type of the cross section area to navigate to, which may be {@code null}.
+     * @return A navigation to the cross section area value of the given type.
+     */
+    public static SingleNavigation<VecTopologySegment, Double> crossSectionAreaBy(final String areaType) {
+        return toCrossSectionAreaInformations()
+                .filter(area -> Objects.equals(areaType, area.getCrossSectionAreaType()))
+                .atMostOne()
+                .then(Navigations.nullable(VecSegmentCrossSectionArea::getArea))
+                .then(Navigations.nullable(VecNumericalValue::getValueComponent));
+    }
+
+}

--- a/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/traversal/ViewItems.java
+++ b/vec/vec-v12x/src/main/java/com/foursoft/harness/vec/v12x/traversal/ViewItems.java
@@ -1,0 +1,82 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 1.2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v12x.traversal;
+
+import com.foursoft.harness.vec.common.traversal.MultiNavigation;
+import com.foursoft.harness.vec.common.traversal.Navigations;
+import com.foursoft.harness.vec.common.traversal.SingleNavigation;
+import com.foursoft.harness.vec.v12x.HasOccurrenceOrUsages;
+import com.foursoft.harness.vec.v12x.VecOccurrenceOrUsage;
+import com.foursoft.harness.vec.v12x.VecOccurrenceOrUsageViewItem2D;
+import com.foursoft.harness.vec.v12x.VecOccurrenceOrUsageViewItem3D;
+import com.foursoft.harness.vec.v12x.VecPartOccurrence;
+import com.foursoft.harness.vec.v12x.VecPlaceableElementRole;
+
+/**
+ * Navigations starting at a {@link HasOccurrenceOrUsages}, that is a {@link VecOccurrenceOrUsageViewItem2D}
+ * or {@link VecOccurrenceOrUsageViewItem3D}.
+ * <p>
+ * To reach the locations of a view item, continue this navigation at the call site, for example
+ * <pre>
+ * {@code
+ * ViewItems.toPlaceableElementRole()
+ *         .then(PlaceableElementRoles.toOnWayPlacements())
+ *         .then(Placements.toLocations());
+ * }
+ * </pre>
+ */
+public final class ViewItems {
+
+    private ViewItems() {
+        // hide default constructor
+    }
+
+    /**
+     * Navigates to the occurrences or usages a view item shows.
+     *
+     * @return A navigation to the occurrences or usages of a view item.
+     */
+    public static MultiNavigation<HasOccurrenceOrUsages, VecOccurrenceOrUsage> toOccurrenceOrUsages() {
+        return Navigations.collection(HasOccurrenceOrUsages::getOccurrenceOrUsage);
+    }
+
+    /**
+     * Navigates to the {@link VecPlaceableElementRole} of a view item.
+     * <p>
+     * A view item is expected to reference at most one placeable element role. If there are several ones, the
+     * first is chosen, see {@link MultiNavigation#atMostOne()}.
+     *
+     * @return A navigation to the placeable element role of a view item.
+     */
+    public static SingleNavigation<HasOccurrenceOrUsages, VecPlaceableElementRole> toPlaceableElementRole() {
+        return toOccurrenceOrUsages()
+                .ofType(VecPartOccurrence.class)
+                .then(Navigations.collection(VecOccurrenceOrUsage::getRoles))
+                .ofType(VecPlaceableElementRole.class)
+                .atMostOne();
+    }
+
+}

--- a/vec/vec-v12x/src/main/java/module-info.java
+++ b/vec/vec-v12x/src/main/java/module-info.java
@@ -35,5 +35,6 @@ open module com.foursoft.harness.vec.v12x {
     exports com.foursoft.harness.vec.v12x.visitor;
     exports com.foursoft.harness.vec.v12x.navigations;
     exports com.foursoft.harness.vec.v12x.predicates;
+    exports com.foursoft.harness.vec.v12x.traversal;
     exports com.foursoft.harness.vec.v12x.validation;
 }

--- a/vec/vec-v12x/src/test/java/com/foursoft/harness/vec/v12x/traversal/ConfigurableElementsTest.java
+++ b/vec/vec-v12x/src/test/java/com/foursoft/harness/vec/v12x/traversal/ConfigurableElementsTest.java
@@ -1,0 +1,112 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 1.2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v12x.traversal;
+
+import com.foursoft.harness.vec.v12x.VecConfigurableElement;
+import com.foursoft.harness.vec.v12x.VecPartOccurrence;
+import com.foursoft.harness.vec.v12x.VecVariantConfiguration;
+import com.foursoft.harness.vec.v12x.navigations.ConfigurableElementNavs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings({"deprecation", "removal"})
+class ConfigurableElementsTest {
+
+    private final VecConfigurableElement unconfigured = new VecPartOccurrence();
+
+    private VecVariantConfiguration configuration;
+    private VecConfigurableElement configured;
+
+    @BeforeEach
+    void setUp() {
+        configuration = new VecVariantConfiguration();
+        configuration.setLogisticControlString("A + B");
+        configuration.setLogisticControlExpression("A OR B");
+
+        final VecPartOccurrence occurrence = new VecPartOccurrence();
+        occurrence.setConfigInfo(configuration);
+        configured = occurrence;
+    }
+
+    @Test
+    void navigatesToTheVariantConfigurationOfAnElement() {
+        assertThat(ConfigurableElements.toVariantConfiguration().from(configured)).contains(configuration);
+    }
+
+    @Test
+    void navigatesToTheLogisticControlStringAndExpression() {
+        assertThat(ConfigurableElements.toLogisticControlString().from(configured)).contains("A + B");
+        assertThat(ConfigurableElements.toLogisticControlExpression().from(configured)).contains("A OR B");
+    }
+
+    @Test
+    void navigatesNowhereForAnUnconfiguredElement() {
+        assertThat(ConfigurableElements.toVariantConfiguration().from(unconfigured)).isEmpty();
+        assertThat(ConfigurableElements.toLogisticControlString().from(unconfigured)).isEmpty();
+        assertThat(ConfigurableElements.toLogisticControlExpression().from(unconfigured)).isEmpty();
+    }
+
+    @Test
+    void navigatesNowhereForAConfigurationWithoutControlInformation() {
+        configuration.setLogisticControlString(null);
+        configuration.setLogisticControlExpression(null);
+
+        assertThat(ConfigurableElements.toLogisticControlString().from(configured)).isEmpty();
+        assertThat(ConfigurableElements.toLogisticControlExpression().from(configured)).isEmpty();
+    }
+
+    /**
+     * Characterisation test for the deprecated {@link ConfigurableElementNavs}, which delegates to
+     * {@link ConfigurableElements}. Can be removed together with {@link ConfigurableElementNavs}.
+     */
+    @Test
+    void deprecatedNavigationsBehaveLikeTheirReplacement() {
+        for (final VecConfigurableElement element : List.of(configured, unconfigured)) {
+            assertThat(ConfigurableElementNavs.variantConfiguration().apply(element))
+                    .isEqualTo(ConfigurableElements.toVariantConfiguration().from(element));
+            assertThat(ConfigurableElementNavs.controlInformation().apply(element))
+                    .isEqualTo(ConfigurableElements.toLogisticControlString().from(element));
+            assertThat(ConfigurableElementNavs.controlExpression().apply(element))
+                    .isEqualTo(ConfigurableElements.toLogisticControlExpression().from(element));
+        }
+    }
+
+    /**
+     * The deprecated navigations accept a {@code null} element, which the replacement does not; a navigation
+     * starts at an element.
+     */
+    @Test
+    void deprecatedNavigationsTolerateANullElement() {
+        assertThat(ConfigurableElementNavs.variantConfiguration().apply(null)).isEmpty();
+        assertThat(ConfigurableElementNavs.controlInformation().apply(null)).isEmpty();
+        assertThat(ConfigurableElementNavs.controlExpression().apply(null)).isEmpty();
+    }
+
+}

--- a/vec/vec-v12x/src/test/java/com/foursoft/harness/vec/v12x/traversal/ContentsTest.java
+++ b/vec/vec-v12x/src/test/java/com/foursoft/harness/vec/v12x/traversal/ContentsTest.java
@@ -1,0 +1,99 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 1.2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v12x.traversal;
+
+import com.foursoft.harness.vec.v12x.VecContent;
+import com.foursoft.harness.vec.v12x.VecDocumentVersion;
+import com.foursoft.harness.vec.v12x.VecPlacementSpecification;
+import com.foursoft.harness.vec.v12x.VecSpecification;
+import com.foursoft.harness.vec.v12x.VecTopologySpecification;
+import com.foursoft.harness.vec.v12x.navigations.ContentNavs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ContentsTest {
+
+    private final VecContent content = new VecContent();
+    private final VecDocumentVersion harness = documentVersion("DOC-1");
+    private final VecDocumentVersion topology = documentVersion("DOC-2");
+
+    private final VecPlacementSpecification placements = new VecPlacementSpecification();
+    private final VecTopologySpecification topologySpecification = new VecTopologySpecification();
+
+    private static VecDocumentVersion documentVersion(final String documentNumber) {
+        final VecDocumentVersion documentVersion = new VecDocumentVersion();
+        documentVersion.setDocumentNumber(documentNumber);
+        return documentVersion;
+    }
+
+    @BeforeEach
+    void setUp() {
+        harness.getSpecifications().add(placements);
+        topology.getSpecifications().add(topologySpecification);
+        content.getDocumentVersions().add(harness);
+        content.getDocumentVersions().add(topology);
+    }
+
+    @Test
+    void navigatesToTheDocumentVersionsOfAContent() {
+        assertThat(Contents.toDocumentVersions().listFrom(content)).containsExactly(harness, topology);
+        assertThat(Contents.toDocumentVersions().listFrom(new VecContent())).isEmpty();
+    }
+
+    @Test
+    void navigatesToTheDocumentVersionWithTheGivenDocumentNumber() {
+        assertThat(Contents.documentVersionBy("DOC-1").from(content)).contains(harness);
+        assertThat(Contents.documentVersionBy("DOC-3").from(content)).isEmpty();
+    }
+
+    @Test
+    void navigatesToTheSpecificationsOfAllDocumentVersions() {
+        assertThat(Contents.toDocumentVersions()
+                           .then(SpecificationOwners.<VecDocumentVersion>toSpecifications())
+                           .listFrom(content))
+                .containsExactly(placements, topologySpecification);
+    }
+
+    /**
+     * Characterisation test for the deprecated {@link ContentNavs}, which delegates to {@link Contents}.
+     * Can be removed together with {@link ContentNavs}.
+     */
+    @Test
+    @SuppressWarnings({"deprecation", "removal"})
+    void deprecatedNavigationsBehaveLikeTheirReplacement() {
+        assertThat(ContentNavs.documentVersionBy("DOC-1").apply(content))
+                .isEqualTo(Contents.documentVersionBy("DOC-1").from(content));
+        assertThat(ContentNavs.documentVersionBy("DOC-3").apply(content))
+                .isEqualTo(Contents.documentVersionBy("DOC-3").from(content));
+        assertThat(ContentNavs.allSpecificationsOf(VecSpecification.class).apply(content))
+                .containsExactly(placements, topologySpecification);
+        assertThat(ContentNavs.allSpecificationsOf(VecPlacementSpecification.class).apply(content))
+                .containsExactly(placements);
+    }
+
+}

--- a/vec/vec-v12x/src/test/java/com/foursoft/harness/vec/v12x/traversal/CustomPropertiesTest.java
+++ b/vec/vec-v12x/src/test/java/com/foursoft/harness/vec/v12x/traversal/CustomPropertiesTest.java
@@ -1,0 +1,204 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 1.2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v12x.traversal;
+
+import com.foursoft.harness.vec.common.HasCustomProperties;
+import com.foursoft.harness.vec.v12x.VecBooleanValueProperty;
+import com.foursoft.harness.vec.v12x.VecComplexProperty;
+import com.foursoft.harness.vec.v12x.VecCustomProperty;
+import com.foursoft.harness.vec.v12x.VecDoubleValueProperty;
+import com.foursoft.harness.vec.v12x.VecIntegerValueProperty;
+import com.foursoft.harness.vec.v12x.VecLanguageCode;
+import com.foursoft.harness.vec.v12x.VecLocalizedString;
+import com.foursoft.harness.vec.v12x.VecLocalizedStringProperty;
+import com.foursoft.harness.vec.v12x.VecPartOccurrence;
+import com.foursoft.harness.vec.v12x.VecSimpleValueProperty;
+import com.foursoft.harness.vec.v12x.VecValueRange;
+import com.foursoft.harness.vec.v12x.VecValueRangeProperty;
+import com.foursoft.harness.vec.v12x.navigations.CustomPropertyNavs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CustomPropertiesTest {
+
+    private static final String COLOUR = "Colour";
+    private static final String COUNT = "Count";
+    private static final String LENGTH = "Length";
+    private static final String RELEASED = "Released";
+    private static final String TOLERANCE = "Tolerance";
+    private static final String DIMENSIONS = "Dimensions";
+    private static final String LABEL = "Label";
+
+    private final VecPartOccurrence element = new VecPartOccurrence();
+
+    private VecValueRange tolerance;
+    private VecCustomProperty nested;
+
+    private static <T extends VecCustomProperty> T property(final T property, final String propertyType) {
+        property.setPropertyType(propertyType);
+        return property;
+    }
+
+    private void add(final VecCustomProperty property) {
+        element.getCustomProperties().add(property);
+    }
+
+    @BeforeEach
+    void setUp() {
+        final VecSimpleValueProperty colour = property(new VecSimpleValueProperty(), COLOUR);
+        colour.setValue("black");
+        final VecSimpleValueProperty secondColour = property(new VecSimpleValueProperty(), COLOUR);
+        secondColour.setValue("white");
+        final VecIntegerValueProperty count = property(new VecIntegerValueProperty(), COUNT);
+        count.setValue(BigInteger.valueOf(3));
+        final VecDoubleValueProperty length = property(new VecDoubleValueProperty(), LENGTH);
+        length.setValue(12.5);
+        final VecBooleanValueProperty released = property(new VecBooleanValueProperty(), RELEASED);
+        released.setValue(true);
+
+        tolerance = new VecValueRange();
+        final VecValueRangeProperty toleranceProperty = property(new VecValueRangeProperty(), TOLERANCE);
+        toleranceProperty.setValue(tolerance);
+
+        nested = property(new VecSimpleValueProperty(), "Width");
+        final VecComplexProperty dimensions = property(new VecComplexProperty(), DIMENSIONS);
+        dimensions.getCustomProperties().add(nested);
+
+        final VecLocalizedString german = new VecLocalizedString();
+        german.setLanguageCode(VecLanguageCode.DE);
+        german.setValue("Kabelbaum");
+        final VecLocalizedStringProperty label = property(new VecLocalizedStringProperty(), LABEL);
+        label.setValue(german);
+
+        add(colour);
+        add(secondColour);
+        add(count);
+        add(length);
+        add(released);
+        add(toleranceProperty);
+        add(dimensions);
+        add(label);
+    }
+
+    @Test
+    void navigatesToTheCustomPropertiesOfAnElement() {
+        assertThat(CustomProperties.toCustomProperties().listFrom(element)).hasSize(8);
+        assertThat(CustomProperties.toCustomProperties().listFrom(new VecPartOccurrence())).isEmpty();
+    }
+
+    @Test
+    void navigatesToTheValueOfTheRequestedProperty() {
+        assertThat(CustomProperties.stringValueOf(COLOUR).from(element)).contains("black");
+        assertThat(CustomProperties.integerValueOf(COUNT).from(element)).contains(BigInteger.valueOf(3));
+        assertThat(CustomProperties.doubleValueOf(LENGTH).from(element)).contains(12.5);
+        assertThat(CustomProperties.booleanValueOf(RELEASED).from(element)).contains(true);
+        assertThat(CustomProperties.valueRangeOf(TOLERANCE).from(element)).contains(tolerance);
+    }
+
+    @Test
+    void navigatesToAllValuesOfTheRequestedProperty() {
+        assertThat(CustomProperties.stringValuesOf(COLOUR).listFrom(element)).containsExactly("black", "white");
+    }
+
+    @Test
+    void navigatesToThePropertiesNestedInTheRequestedComplexProperty() {
+        assertThat(CustomProperties.nestedPropertiesOf(DIMENSIONS).listFrom(element)).containsExactly(nested);
+    }
+
+    @Test
+    void navigatesToTheLocalizedValueOfTheRequestedProperty() {
+        assertThat(CustomProperties.localizedValueOf(LABEL, VecLanguageCode.DE).from(element))
+                .contains("Kabelbaum");
+        assertThat(CustomProperties.localizedValueOf(LABEL, VecLanguageCode.EN).from(element)).isEmpty();
+    }
+
+    @Test
+    void navigatesNowhereForAnUnknownProperty() {
+        assertThat(CustomProperties.stringValueOf("Unknown").from(element)).isEmpty();
+        assertThat(CustomProperties.stringValuesOf("Unknown").listFrom(element)).isEmpty();
+        assertThat(CustomProperties.nestedPropertiesOf("Unknown").listFrom(element)).isEmpty();
+        assertThat(CustomProperties.localizedValueOf("Unknown", VecLanguageCode.DE).from(element)).isEmpty();
+    }
+
+    @Test
+    void navigatesNowhereForAPropertyOfAnotherKind() {
+        assertThat(CustomProperties.integerValueOf(COLOUR).from(element)).isEmpty();
+        assertThat(CustomProperties.stringValueOf(COUNT).from(element)).isEmpty();
+    }
+
+    /**
+     * Characterisation test for the deprecated {@link CustomPropertyNavs}, which delegates to
+     * {@link CustomProperties}. Can be removed together with {@link CustomPropertyNavs}.
+     */
+    @Test
+    @SuppressWarnings({"deprecation", "removal"})
+    void deprecatedNavigationsBehaveLikeTheirReplacement() {
+        final HasCustomProperties<VecCustomProperty> holder = element;
+
+        assertThat(CustomPropertyNavs.customPropertyValueStringOf(COLOUR).apply(holder))
+                .isEqualTo(CustomProperties.stringValueOf(COLOUR).from(element));
+        assertThat(CustomPropertyNavs.customPropertyValueStringsOf(COLOUR).apply(holder))
+                .isEqualTo(CustomProperties.stringValuesOf(COLOUR).listFrom(element));
+        assertThat(CustomPropertyNavs.customPropertyValueIntegerOf(COUNT).apply(holder))
+                .isEqualTo(CustomProperties.integerValueOf(COUNT).from(element));
+        assertThat(CustomPropertyNavs.customPropertyValueDoubleOf(LENGTH).apply(holder))
+                .isEqualTo(CustomProperties.doubleValueOf(LENGTH).from(element));
+        assertThat(CustomPropertyNavs.customPropertyValueBooleanOf(RELEASED).apply(holder))
+                .isEqualTo(CustomProperties.booleanValueOf(RELEASED).from(element));
+        assertThat(CustomPropertyNavs.customPropertyValueRangeOf(TOLERANCE).apply(holder))
+                .isEqualTo(CustomProperties.valueRangeOf(TOLERANCE).from(element));
+        assertThat(CustomPropertyNavs.customPropertyValuesOf(DIMENSIONS).apply(holder))
+                .isEqualTo(CustomProperties.nestedPropertiesOf(DIMENSIONS).listFrom(element));
+        assertThat(CustomPropertyNavs.customPropertyValueLocalizedString(LABEL, VecLanguageCode.DE).apply(holder))
+                .isEqualTo(CustomProperties.localizedValueOf(LABEL, VecLanguageCode.DE).from(element));
+    }
+
+    /**
+     * The deprecated lookup by property type takes the properties themselves and matches the type ignoring
+     * its case, which the replacing chain spells out at the call site.
+     */
+    @Test
+    @SuppressWarnings({"deprecation", "removal"})
+    void deprecatedLookupByPropertyTypeBehavesLikeItsReplacement() {
+        final List<VecCustomProperty> customProperties = element.getCustomProperties();
+
+        assertThat(CustomPropertyNavs.customPropertyOfType("colour", VecSimpleValueProperty.class)
+                           .apply(customProperties))
+                .isEqualTo(CustomProperties.toCustomProperties()
+                                   .filter(property -> "colour".equalsIgnoreCase(property.getPropertyType()))
+                                   .ofType(VecSimpleValueProperty.class)
+                                   .atMostOne()
+                                   .from(element));
+        assertThat(CustomPropertyNavs.customPropertyOfType(COUNT, VecSimpleValueProperty.class)
+                           .apply(customProperties)).isEmpty();
+    }
+
+}

--- a/vec/vec-v12x/src/test/java/com/foursoft/harness/vec/v12x/traversal/DescriptionsTest.java
+++ b/vec/vec-v12x/src/test/java/com/foursoft/harness/vec/v12x/traversal/DescriptionsTest.java
@@ -1,0 +1,118 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 1.2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v12x.traversal;
+
+import com.foursoft.harness.vec.common.HasDescription;
+import com.foursoft.harness.vec.v12x.VecAbstractLocalizedString;
+import com.foursoft.harness.vec.v12x.VecLanguageCode;
+import com.foursoft.harness.vec.v12x.navigations.DescriptionNavs;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static com.foursoft.harness.vec.v12x.traversal.LocalizedStringFixtures.LENGTH_TYPE;
+import static com.foursoft.harness.vec.v12x.traversal.LocalizedStringFixtures.localizedString;
+import static com.foursoft.harness.vec.v12x.traversal.LocalizedStringFixtures.typedString;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DescriptionsTest {
+
+    private static HasDescription<VecAbstractLocalizedString> holderOf(final VecAbstractLocalizedString... strings) {
+        final List<VecAbstractLocalizedString> descriptions = List.of(strings);
+        return () -> descriptions;
+    }
+
+    @Test
+    void navigatesToTheDescriptionsOfAnElement() {
+        final VecAbstractLocalizedString german = localizedString(VecLanguageCode.DE, "Leitung");
+        final VecAbstractLocalizedString english = localizedString(VecLanguageCode.EN, "Wire");
+
+        assertThat(Descriptions.toDescriptions().listFrom(holderOf(german, english)))
+                .containsExactly(german, english);
+        assertThat(Descriptions.toDescriptions().listFrom(holderOf())).isEmpty();
+    }
+
+    @Test
+    void navigatesToTheDescriptionOfTheRequestedLanguage() {
+        final HasDescription<VecAbstractLocalizedString> holder = holderOf(
+                localizedString(VecLanguageCode.DE, "Leitung"),
+                localizedString(VecLanguageCode.EN, "Wire"));
+
+        assertThat(Descriptions.germanDescription().from(holder)).contains("Leitung");
+        assertThat(Descriptions.englishDescription().from(holder)).contains("Wire");
+        assertThat(Descriptions.descriptionIn(VecLanguageCode.DE).from(holder)).contains("Leitung");
+    }
+
+    @Test
+    void navigatesToNoDescriptionForAnEmptyHolder() {
+        assertThat(Descriptions.germanDescription().from(holderOf())).isEmpty();
+    }
+
+    @Test
+    void navigatesToNoDescriptionForASingleTypedString() {
+        assertThat(Descriptions.germanDescription()
+                           .from(holderOf(typedString(VecLanguageCode.DE, LENGTH_TYPE, "100")))).isEmpty();
+    }
+
+    @Test
+    void navigatesToTheTypedStringOfTheRequestedTypeAndLanguage() {
+        final HasDescription<VecAbstractLocalizedString> holder = holderOf(
+                typedString(VecLanguageCode.DE, LENGTH_TYPE, "100"),
+                typedString(VecLanguageCode.EN, LENGTH_TYPE, "One hundred"),
+                typedString(VecLanguageCode.DE, "Width", "5"));
+
+        assertThat(Descriptions.germanTypedStringBy(LENGTH_TYPE).from(holder)).contains("100");
+        assertThat(Descriptions.englishTypedStringBy(LENGTH_TYPE).from(holder)).contains("One hundred");
+        assertThat(Descriptions.typedStringBy("Width", VecLanguageCode.DE).from(holder)).contains("5");
+        assertThat(Descriptions.typedStringBy("Height", VecLanguageCode.DE).from(holder)).isEmpty();
+    }
+
+    /**
+     * Characterisation test for the deprecated {@link DescriptionNavs}, which delegates to
+     * {@link Descriptions}. Can be removed together with {@link DescriptionNavs}.
+     */
+    @Test
+    @SuppressWarnings({"deprecation", "removal"})
+    void deprecatedNavigationsBehaveLikeTheirReplacement() {
+        for (final List<VecAbstractLocalizedString> descriptions : LocalizedStringFixtures.allVariants()) {
+            final HasDescription<VecAbstractLocalizedString> holder = () -> descriptions;
+
+            assertThat(DescriptionNavs.germanDescription().apply(holder))
+                    .isEqualTo(Descriptions.germanDescription().from(holder));
+            assertThat(DescriptionNavs.englishDescription().apply(holder))
+                    .isEqualTo(Descriptions.englishDescription().from(holder));
+            assertThat(DescriptionNavs.descriptionIn(VecLanguageCode.DE).apply(holder))
+                    .isEqualTo(Descriptions.descriptionIn(VecLanguageCode.DE).from(holder));
+            assertThat(DescriptionNavs.germanTypedStringBy(LENGTH_TYPE).apply(holder))
+                    .isEqualTo(Descriptions.germanTypedStringBy(LENGTH_TYPE).from(holder));
+            assertThat(DescriptionNavs.englishTypedStringBy(LENGTH_TYPE).apply(holder))
+                    .isEqualTo(Descriptions.englishTypedStringBy(LENGTH_TYPE).from(holder));
+            assertThat(DescriptionNavs.typedStringBy(LENGTH_TYPE, VecLanguageCode.DE).apply(holder))
+                    .isEqualTo(Descriptions.typedStringBy(LENGTH_TYPE, VecLanguageCode.DE).from(holder));
+        }
+    }
+
+}

--- a/vec/vec-v12x/src/test/java/com/foursoft/harness/vec/v12x/traversal/DocumentVersionsTest.java
+++ b/vec/vec-v12x/src/test/java/com/foursoft/harness/vec/v12x/traversal/DocumentVersionsTest.java
@@ -1,0 +1,255 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 1.2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v12x.traversal;
+
+import com.foursoft.harness.vec.v12x.VecBuildingBlockPositioning2D;
+import com.foursoft.harness.vec.v12x.VecBuildingBlockPositioning3D;
+import com.foursoft.harness.vec.v12x.VecBuildingBlockSpecification2D;
+import com.foursoft.harness.vec.v12x.VecBuildingBlockSpecification3D;
+import com.foursoft.harness.vec.v12x.VecCompositionSpecification;
+import com.foursoft.harness.vec.v12x.VecDocumentVersion;
+import com.foursoft.harness.vec.v12x.VecGeometryNode2D;
+import com.foursoft.harness.vec.v12x.VecGeometryNode3D;
+import com.foursoft.harness.vec.v12x.VecGeometrySegment2D;
+import com.foursoft.harness.vec.v12x.VecGeometrySegment3D;
+import com.foursoft.harness.vec.v12x.VecHarnessDrawingSpecification2D;
+import com.foursoft.harness.vec.v12x.VecHarnessGeometrySpecification3D;
+import com.foursoft.harness.vec.v12x.VecNodeLocation;
+import com.foursoft.harness.vec.v12x.VecOccurrenceOrUsageViewItem2D;
+import com.foursoft.harness.vec.v12x.VecOccurrenceOrUsageViewItem3D;
+import com.foursoft.harness.vec.v12x.VecOnPointPlacement;
+import com.foursoft.harness.vec.v12x.VecPartOccurrence;
+import com.foursoft.harness.vec.v12x.VecPlaceableElementRole;
+import com.foursoft.harness.vec.v12x.VecPlacementSpecification;
+import com.foursoft.harness.vec.v12x.VecTopologyNode;
+import com.foursoft.harness.vec.v12x.VecTopologySegment;
+import com.foursoft.harness.vec.v12x.navigations.DocumentVersionNavs;
+import com.foursoft.harness.vec.v12x.navigations.PartOccurrenceOrUsageNavs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DocumentVersionsTest {
+
+    private static final String COMPOSITION_ID = "COMP-1";
+    private static final String COMPONENT_ID = "OCC-1";
+
+    private final VecDocumentVersion documentVersion = new VecDocumentVersion();
+
+    private final VecBuildingBlockSpecification2D buildingBlock2D = new VecBuildingBlockSpecification2D();
+    private final VecBuildingBlockSpecification3D buildingBlock3D = new VecBuildingBlockSpecification3D();
+    private final VecPlacementSpecification placements = new VecPlacementSpecification();
+    private final VecCompositionSpecification composition = new VecCompositionSpecification();
+    private final VecHarnessDrawingSpecification2D drawing = new VecHarnessDrawingSpecification2D();
+    private final VecHarnessGeometrySpecification3D geometry = new VecHarnessGeometrySpecification3D();
+
+    private final VecTopologyNode topologyNode = new VecTopologyNode();
+    private final VecTopologySegment topologySegment = new VecTopologySegment();
+    private final VecGeometryNode2D node2D = new VecGeometryNode2D();
+    private final VecGeometryNode3D node3D = new VecGeometryNode3D();
+    private final VecGeometrySegment2D segment2D = new VecGeometrySegment2D();
+    private final VecGeometrySegment3D segment3D = new VecGeometrySegment3D();
+    private final VecNodeLocation location = new VecNodeLocation();
+    private final VecOnPointPlacement placement = new VecOnPointPlacement();
+    private final VecPlaceableElementRole placedElement = new VecPlaceableElementRole();
+    private final VecPartOccurrence component = new VecPartOccurrence();
+    private final VecOccurrenceOrUsageViewItem2D viewItem2D = new VecOccurrenceOrUsageViewItem2D();
+    private final VecOccurrenceOrUsageViewItem3D viewItem3D = new VecOccurrenceOrUsageViewItem3D();
+    private final VecBuildingBlockPositioning2D positioning2D = new VecBuildingBlockPositioning2D();
+    private final VecBuildingBlockPositioning3D positioning3D = new VecBuildingBlockPositioning3D();
+
+    @BeforeEach
+    void setUp() {
+        buildingBlock2D.setIdentification("BB-2D");
+        buildingBlock3D.setIdentification("BB-3D");
+        composition.setIdentification(COMPOSITION_ID);
+        component.setIdentification(COMPONENT_ID);
+
+        node2D.setReferenceNode(topologyNode);
+        node3D.setReferenceNode(topologyNode);
+        segment3D.setReferenceSegment(topologySegment);
+        location.setReferencedNode(topologyNode);
+
+        placement.getLocations().add(location);
+        placement.getPlacedElement().add(placedElement);
+        placedElement.getRefPlacement().add(placement);
+        component.getRoles().add(placedElement);
+
+        viewItem2D.getOccurrenceOrUsage().add(component);
+        viewItem3D.getOccurrenceOrUsage().add(component);
+
+        positioning2D.setReferenced2DBuildingBlock(buildingBlock2D);
+        positioning3D.setReferenced3DBuildingBlock(buildingBlock3D);
+
+        buildingBlock2D.getGeometryNodes().add(node2D);
+        buildingBlock2D.getGeometrySegments().add(segment2D);
+        buildingBlock2D.getPlacedElementViewItems().add(viewItem2D);
+        buildingBlock3D.getGeometryNodes().add(node3D);
+        buildingBlock3D.getGeometrySegments().add(segment3D);
+        buildingBlock3D.getPlacedElementViewItem3Ds().add(viewItem3D);
+        placements.getPlacements().add(placement);
+        composition.getComponents().add(component);
+        drawing.getBuildingBlockPositionings().add(positioning2D);
+        geometry.getBuildingBlockPositionings().add(positioning3D);
+
+        documentVersion.getSpecifications().add(buildingBlock2D);
+        documentVersion.getSpecifications().add(buildingBlock3D);
+        documentVersion.getSpecifications().add(placements);
+        documentVersion.getSpecifications().add(composition);
+        documentVersion.getSpecifications().add(drawing);
+        documentVersion.getSpecifications().add(geometry);
+    }
+
+    @Test
+    void navigatesToTheBuildingBlocksOfADocumentVersion() {
+        assertThat(DocumentVersions.toBuildingBlockSpecifications2D().listFrom(documentVersion))
+                .containsExactly(buildingBlock2D);
+        assertThat(DocumentVersions.toBuildingBlockSpecifications3D().listFrom(documentVersion))
+                .containsExactly(buildingBlock3D);
+        assertThat(DocumentVersions.buildingBlockSpecification2dBy("BB-2D").from(documentVersion))
+                .contains(buildingBlock2D);
+        assertThat(DocumentVersions.buildingBlockSpecification3dBy("BB-2D").from(documentVersion)).isEmpty();
+    }
+
+    @Test
+    void navigatesToTheGeometryOfAllBuildingBlocks() {
+        assertThat(DocumentVersions.toGeometryNodes2D().listFrom(documentVersion)).containsExactly(node2D);
+        assertThat(DocumentVersions.toGeometryNodes3D().listFrom(documentVersion)).containsExactly(node3D);
+        assertThat(DocumentVersions.toGeometrySegments3D().listFrom(documentVersion)).containsExactly(segment3D);
+        assertThat(DocumentVersions.toGeometrySegments2D().listFrom(documentVersion)).containsExactly(segment2D);
+    }
+
+    @Test
+    void navigatesToTheGeometryOfTheGivenTopologyElement() {
+        assertThat(DocumentVersions.geometryNodes3dBy(topologyNode).listFrom(documentVersion))
+                .containsExactly(node3D);
+        assertThat(DocumentVersions.geometryNodes3dBy(new VecTopologyNode()).listFrom(documentVersion)).isEmpty();
+        assertThat(DocumentVersions.geometrySegments3dBy(topologySegment).listFrom(documentVersion))
+                .containsExactly(segment3D);
+        assertThat(DocumentVersions.geometryNode2dBy(location).from(documentVersion)).contains(node2D);
+        assertThat(DocumentVersions.geometryNode3dBy(location).from(documentVersion)).contains(node3D);
+    }
+
+    @Test
+    void navigatesToTheViewItemsOfADocumentVersion() {
+        assertThat(DocumentVersions.toViewItems2D().listFrom(documentVersion)).containsExactly(viewItem2D);
+        assertThat(DocumentVersions.toViewItems3D().listFrom(documentVersion)).containsExactly(viewItem3D);
+        assertThat(DocumentVersions.viewItems3dBy(component).listFrom(documentVersion)).containsExactly(viewItem3D);
+        assertThat(DocumentVersions.viewItem2dBy(COMPONENT_ID).from(documentVersion)).contains(viewItem2D);
+        assertThat(DocumentVersions.viewItem3dBy(COMPONENT_ID).from(documentVersion)).contains(viewItem3D);
+        assertThat(DocumentVersions.viewItem2dBy("OCC-2").from(documentVersion)).isEmpty();
+    }
+
+    @Test
+    void navigatesToThePlacementsAndNodeLocationsOfADocumentVersion() {
+        assertThat(DocumentVersions.toPlacements().listFrom(documentVersion)).containsExactly(placement);
+        assertThat(DocumentVersions.toNodeLocations().listFrom(documentVersion)).containsExactly(location);
+        assertThat(DocumentVersions.placementsOf(placedElement).listFrom(documentVersion))
+                .containsExactly(placement);
+        assertThat(DocumentVersions.nodeLocationsOf(placedElement).listFrom(documentVersion))
+                .containsExactly(location);
+        assertThat(DocumentVersions.nodeLocationsOf(new VecPlaceableElementRole()).listFrom(documentVersion))
+                .isEmpty();
+    }
+
+    @Test
+    void navigatesToTheBuildingBlockPositionings() {
+        assertThat(DocumentVersions.toBuildingBlockPositionings2D().listFrom(documentVersion))
+                .containsExactly(positioning2D);
+        assertThat(DocumentVersions.toBuildingBlockPositionings3D().listFrom(documentVersion))
+                .containsExactly(positioning3D);
+        assertThat(DocumentVersions.positioning2dWith(buildingBlock2D).from(documentVersion))
+                .contains(positioning2D);
+        assertThat(DocumentVersions.positioning3dWith(buildingBlock3D).from(documentVersion))
+                .contains(positioning3D);
+        assertThat(DocumentVersions.positioning2dWith(new VecBuildingBlockSpecification2D())
+                           .from(documentVersion)).isEmpty();
+    }
+
+    @Test
+    void navigatesToTheRoleAndPlacementOfTheIdentifiedComponent() {
+        assertThat(DocumentVersions.placeableElementRoleBy(COMPOSITION_ID, COMPONENT_ID).from(documentVersion))
+                .contains(placedElement);
+        assertThat(DocumentVersions.placementBy(COMPOSITION_ID, COMPONENT_ID).from(documentVersion))
+                .contains(placement);
+        assertThat(DocumentVersions.placeableElementRoleBy(COMPOSITION_ID, "OCC-2").from(documentVersion))
+                .isEmpty();
+        assertThat(DocumentVersions.placementBy("COMP-2", COMPONENT_ID).from(documentVersion)).isEmpty();
+    }
+
+    @Test
+    void navigatesToTheTopologyNodeOfAComponent() {
+        assertThat(DocumentVersions.topologyNodeBy(COMPONENT_ID).from(documentVersion)).contains(topologyNode);
+        assertThat(DocumentVersions.topologyNodeBy("OCC-2").from(documentVersion)).isEmpty();
+        assertThat(DocumentVersions.topologyNodeOf(component).from(documentVersion)).contains(topologyNode);
+        assertThat(DocumentVersions.topologyNodeOf(new VecPartOccurrence()).from(documentVersion)).isEmpty();
+    }
+
+    /**
+     * Characterisation test for the deprecated {@link DocumentVersionNavs}, which delegates to
+     * {@link DocumentVersions}. Can be removed together with {@link DocumentVersionNavs}.
+     */
+    @Test
+    @SuppressWarnings({"deprecation", "removal"})
+    void deprecatedNavigationsBehaveLikeTheirReplacement() {
+        assertThat(DocumentVersionNavs.geometryNodes3dBy(topologyNode).apply(documentVersion))
+                .isEqualTo(DocumentVersions.geometryNodes3dBy(topologyNode).listFrom(documentVersion));
+        assertThat(DocumentVersionNavs.geometrySegments3dBy(topologySegment).apply(documentVersion))
+                .isEqualTo(DocumentVersions.geometrySegments3dBy(topologySegment).listFrom(documentVersion));
+        assertThat(DocumentVersionNavs.viewItems3dBy(component).apply(documentVersion))
+                .isEqualTo(DocumentVersions.viewItems3dBy(component).listFrom(documentVersion));
+        assertThat(DocumentVersionNavs.topologyNodeBy(COMPONENT_ID).apply(documentVersion))
+                .isEqualTo(DocumentVersions.topologyNodeBy(COMPONENT_ID).from(documentVersion));
+        assertThat(DocumentVersionNavs.nodeLocationsBy(placedElement).apply(documentVersion))
+                .isEqualTo(DocumentVersions.nodeLocationsOf(placedElement).listFrom(documentVersion));
+        assertThat(DocumentVersionNavs.nodeLocationsBy(null).apply(documentVersion))
+                .isEqualTo(DocumentVersions.toNodeLocations().listFrom(documentVersion));
+        assertThat(DocumentVersionNavs.placeableElementRoleBy(COMPOSITION_ID, COMPONENT_ID).apply(documentVersion))
+                .isEqualTo(placedElement);
+        assertThat(DocumentVersionNavs.placementBy(COMPOSITION_ID, COMPONENT_ID).apply(documentVersion))
+                .isEqualTo(placement);
+        assertThat(DocumentVersionNavs.placeableElementRoleBy(COMPOSITION_ID, "OCC-2").apply(documentVersion))
+                .isNull();
+        assertThat(DocumentVersionNavs.geometryNode2dBy(location).apply(documentVersion)).isEqualTo(node2D);
+        assertThat(DocumentVersionNavs.geometryNode3dBy(location).apply(documentVersion)).isEqualTo(node3D);
+        assertThat(DocumentVersionNavs.viewItem2dBy(COMPONENT_ID).apply(documentVersion))
+                .isEqualTo(DocumentVersions.viewItem2dBy(COMPONENT_ID).from(documentVersion));
+        assertThat(DocumentVersionNavs.viewItem3dBy(COMPONENT_ID).apply(documentVersion))
+                .isEqualTo(DocumentVersions.viewItem3dBy(COMPONENT_ID).from(documentVersion));
+        assertThat(DocumentVersionNavs.buildingBlockSpecification2dBy("BB-2D").apply(documentVersion))
+                .isEqualTo(DocumentVersions.buildingBlockSpecification2dBy("BB-2D").from(documentVersion));
+        assertThat(DocumentVersionNavs.buildingBlockSpecification3dBy("BB-3D").apply(documentVersion))
+                .isEqualTo(DocumentVersions.buildingBlockSpecification3dBy("BB-3D").from(documentVersion));
+        assertThat(DocumentVersionNavs.positioning2dWith(buildingBlock2D).apply(documentVersion))
+                .isEqualTo(DocumentVersions.positioning2dWith(buildingBlock2D).from(documentVersion));
+        assertThat(DocumentVersionNavs.positioning3dWith(buildingBlock3D).apply(documentVersion))
+                .isEqualTo(DocumentVersions.positioning3dWith(buildingBlock3D).from(documentVersion));
+        assertThat(PartOccurrenceOrUsageNavs.findNodeOfComponent().apply(component, documentVersion))
+                .isEqualTo(DocumentVersions.topologyNodeOf(component).from(documentVersion));
+    }
+
+}

--- a/vec/vec-v12x/src/test/java/com/foursoft/harness/vec/v12x/traversal/ExtendableElementsTest.java
+++ b/vec/vec-v12x/src/test/java/com/foursoft/harness/vec/v12x/traversal/ExtendableElementsTest.java
@@ -1,0 +1,73 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 1.2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v12x.traversal;
+
+import com.foursoft.harness.vec.v12x.VecDocumentVersion;
+import com.foursoft.harness.vec.v12x.VecExtendableElement;
+import com.foursoft.harness.vec.v12x.VecPartOccurrence;
+import com.foursoft.harness.vec.v12x.navigations.VecNavs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ExtendableElementsTest {
+
+    private final VecExtendableElement element = new VecPartOccurrence();
+    private final VecDocumentVersion drawing = new VecDocumentVersion();
+    private final VecDocumentVersion unnumbered = new VecDocumentVersion();
+
+    @BeforeEach
+    void setUp() {
+        drawing.setDocumentNumber("DRW-1");
+        element.getReferencedExternalDocuments().add(drawing);
+        element.getReferencedExternalDocuments().add(unnumbered);
+    }
+
+    @Test
+    void navigatesToTheReferencedExternalDocumentsOfAnElement() {
+        assertThat(ExtendableElements.toReferencedExternalDocuments().listFrom(element))
+                .containsExactly(drawing, unnumbered);
+        assertThat(ExtendableElements.toReferencedExternalDocuments().listFrom(new VecPartOccurrence())).isEmpty();
+    }
+
+    @Test
+    void navigatesToTheDocumentNumbersOfTheReferencedExternalDocuments() {
+        assertThat(ExtendableElements.toExternalDocumentNumbers().listFrom(element)).containsExactly("DRW-1");
+    }
+
+    /**
+     * Characterisation test for the deprecated {@link VecNavs}, which delegates to
+     * {@link ExtendableElements}. Can be removed together with {@link VecNavs}.
+     */
+    @Test
+    @SuppressWarnings({"deprecation", "removal"})
+    void deprecatedNavigationsBehaveLikeTheirReplacement() {
+        assertThat(VecNavs.externalDocumentNumbers().apply(element))
+                .isEqualTo(ExtendableElements.toExternalDocumentNumbers().listFrom(element));
+    }
+
+}

--- a/vec/vec-v12x/src/test/java/com/foursoft/harness/vec/v12x/traversal/ExtendableElementsTest.java
+++ b/vec/vec-v12x/src/test/java/com/foursoft/harness/vec/v12x/traversal/ExtendableElementsTest.java
@@ -62,12 +62,21 @@ class ExtendableElementsTest {
     /**
      * Characterisation test for the deprecated {@link VecNavs}, which delegates to
      * {@link ExtendableElements}. Can be removed together with {@link VecNavs}.
+     * <p>
+     * The two agree on every model the schema admits, which is what this pins. They deviate on an
+     * unnumbered document: the deprecated navigation maps each referenced document and so yields a
+     * {@code null} element, while the replacement treats a missing number as an absent target and
+     * omits it. Since {@code DocumentNumber} is mandatory, only an incomplete model can tell them
+     * apart, and the fixture below therefore references numbered documents only.
      */
     @Test
     @SuppressWarnings({"deprecation", "removal"})
     void deprecatedNavigationsBehaveLikeTheirReplacement() {
-        assertThat(VecNavs.externalDocumentNumbers().apply(element))
-                .isEqualTo(ExtendableElements.toExternalDocumentNumbers().listFrom(element));
+        final VecExtendableElement numbered = new VecPartOccurrence();
+        numbered.getReferencedExternalDocuments().add(drawing);
+
+        assertThat(VecNavs.externalDocumentNumbers().apply(numbered))
+                .isEqualTo(ExtendableElements.toExternalDocumentNumbers().listFrom(numbered));
     }
 
 }

--- a/vec/vec-v12x/src/test/java/com/foursoft/harness/vec/v12x/traversal/LocalizedStringFixtures.java
+++ b/vec/vec-v12x/src/test/java/com/foursoft/harness/vec/v12x/traversal/LocalizedStringFixtures.java
@@ -1,0 +1,80 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 1.2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v12x.traversal;
+
+import com.foursoft.harness.vec.v12x.VecAbstractLocalizedString;
+import com.foursoft.harness.vec.v12x.VecLanguageCode;
+import com.foursoft.harness.vec.v12x.VecLocalizedString;
+import com.foursoft.harness.vec.v12x.VecLocalizedTypedString;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Localized string fixtures shared by {@link LocalizedStringsTest} and {@link DescriptionsTest}.
+ */
+final class LocalizedStringFixtures {
+
+    static final String LENGTH_TYPE = "Length";
+
+    private LocalizedStringFixtures() {
+        // hide default constructor
+    }
+
+    static VecLocalizedString localizedString(final VecLanguageCode languageCode, final String value) {
+        final VecLocalizedString localizedString = new VecLocalizedString();
+        localizedString.setLanguageCode(languageCode);
+        localizedString.setValue(value);
+        return localizedString;
+    }
+
+    static VecLocalizedTypedString typedString(final VecLanguageCode languageCode, final String type,
+                                               final String value) {
+        final VecLocalizedTypedString typedString = new VecLocalizedTypedString();
+        typedString.setLanguageCode(languageCode);
+        typedString.setType(type);
+        typedString.setValue(value);
+        return typedString;
+    }
+
+    /**
+     * The description list shapes the navigations treat differently, for exhaustive comparisons of the
+     * deprecated navigations against their replacements.
+     */
+    static List<List<VecAbstractLocalizedString>> allVariants() {
+        return List.of(
+                Collections.emptyList(),
+                List.of(localizedString(VecLanguageCode.EN, "Wire")),
+                List.of(typedString(VecLanguageCode.DE, LENGTH_TYPE, "100")),
+                List.of(typedString(VecLanguageCode.DE, null, "Leitung")),
+                List.of(typedString(VecLanguageCode.DE, LENGTH_TYPE, ""),
+                        localizedString(VecLanguageCode.DE, "Leitung")),
+                List.of(localizedString(VecLanguageCode.DE, "Leitung"),
+                        localizedString(VecLanguageCode.EN, "Wire"),
+                        typedString(VecLanguageCode.DE, LENGTH_TYPE, "100")));
+    }
+
+}

--- a/vec/vec-v12x/src/test/java/com/foursoft/harness/vec/v12x/traversal/LocalizedStringPropertiesTest.java
+++ b/vec/vec-v12x/src/test/java/com/foursoft/harness/vec/v12x/traversal/LocalizedStringPropertiesTest.java
@@ -1,0 +1,79 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 1.2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v12x.traversal;
+
+import com.foursoft.harness.vec.v12x.VecLanguageCode;
+import com.foursoft.harness.vec.v12x.VecLocalizedString;
+import com.foursoft.harness.vec.v12x.VecLocalizedStringProperty;
+import com.foursoft.harness.vec.v12x.navigations.CustomPropertyNavs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LocalizedStringPropertiesTest {
+
+    private final VecLocalizedStringProperty property = new VecLocalizedStringProperty();
+
+    @BeforeEach
+    void setUp() {
+        final VecLocalizedString german = new VecLocalizedString();
+        german.setLanguageCode(VecLanguageCode.DE);
+        german.setValue("Kabelbaum");
+        property.setValue(german);
+    }
+
+    @Test
+    void navigatesToTheValueOfTheRequestedLanguage() {
+        assertThat(LocalizedStringProperties.valueIn(VecLanguageCode.DE).from(property)).contains("Kabelbaum");
+    }
+
+    @Test
+    void navigatesNowhereForAnotherLanguage() {
+        assertThat(LocalizedStringProperties.valueIn(VecLanguageCode.EN).from(property)).isEmpty();
+    }
+
+    @Test
+    void navigatesNowhereForAPropertyWithoutValue() {
+        assertThat(LocalizedStringProperties.valueIn(VecLanguageCode.DE).from(new VecLocalizedStringProperty()))
+                .isEmpty();
+    }
+
+    /**
+     * Characterisation test for the deprecated {@link CustomPropertyNavs}, which delegates to
+     * {@link LocalizedStringProperties}. Can be removed together with {@link CustomPropertyNavs}.
+     */
+    @Test
+    @SuppressWarnings({"deprecation", "removal"})
+    void deprecatedNavigationsBehaveLikeTheirReplacement() {
+        assertThat(CustomPropertyNavs.convertLocalizedStringProperty(VecLanguageCode.DE).apply(property))
+                .isEqualTo(LocalizedStringProperties.valueIn(VecLanguageCode.DE).from(property));
+        assertThat(CustomPropertyNavs.convertLocalizedStringProperty(VecLanguageCode.EN).apply(property))
+                .isEqualTo(LocalizedStringProperties.valueIn(VecLanguageCode.EN).from(property));
+        assertThat(CustomPropertyNavs.convertLocalizedStringProperty(VecLanguageCode.DE).apply(null)).isEmpty();
+    }
+
+}

--- a/vec/vec-v12x/src/test/java/com/foursoft/harness/vec/v12x/traversal/LocalizedStringsTest.java
+++ b/vec/vec-v12x/src/test/java/com/foursoft/harness/vec/v12x/traversal/LocalizedStringsTest.java
@@ -1,0 +1,141 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 1.2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v12x.traversal;
+
+import com.foursoft.harness.vec.v12x.VecAbstractLocalizedString;
+import com.foursoft.harness.vec.v12x.VecLanguageCode;
+import com.foursoft.harness.vec.v12x.navigations.DescriptionNavs;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collector;
+
+import static com.foursoft.harness.vec.v12x.traversal.LocalizedStringFixtures.LENGTH_TYPE;
+import static com.foursoft.harness.vec.v12x.traversal.LocalizedStringFixtures.localizedString;
+import static com.foursoft.harness.vec.v12x.traversal.LocalizedStringFixtures.typedString;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LocalizedStringsTest {
+
+    private static Optional<String> reduce(final List<VecAbstractLocalizedString> localizedStrings,
+                                           final Collector<VecAbstractLocalizedString, ?, Optional<String>>
+                                                   reduction) {
+        return localizedStrings.stream().collect(reduction);
+    }
+
+    @Test
+    void reducesToTheValueOfTheRequestedLanguage() {
+        final List<VecAbstractLocalizedString> localizedStrings = List.of(
+                localizedString(VecLanguageCode.DE, "Leitung"),
+                localizedString(VecLanguageCode.EN, "Wire"));
+
+        assertThat(reduce(localizedStrings, LocalizedStrings.valueIn(VecLanguageCode.DE))).contains("Leitung");
+        assertThat(reduce(localizedStrings, LocalizedStrings.valueIn(VecLanguageCode.EN))).contains("Wire");
+    }
+
+    @Test
+    void reducesToTheOnlyValueRegardlessOfItsLanguage() {
+        final List<VecAbstractLocalizedString> localizedStrings =
+                List.of(localizedString(VecLanguageCode.EN, "Wire"));
+
+        assertThat(reduce(localizedStrings, LocalizedStrings.valueIn(VecLanguageCode.DE))).contains("Wire");
+    }
+
+    @Test
+    void reducesToNoValueForNoLocalizedString() {
+        assertThat(reduce(Collections.emptyList(), LocalizedStrings.valueIn(VecLanguageCode.DE))).isEmpty();
+    }
+
+    @Test
+    void reducesToNoValueForASingleTypedString() {
+        final List<VecAbstractLocalizedString> localizedStrings =
+                List.of(typedString(VecLanguageCode.DE, LENGTH_TYPE, "100"));
+
+        assertThat(reduce(localizedStrings, LocalizedStrings.valueIn(VecLanguageCode.DE))).isEmpty();
+    }
+
+    @Test
+    void reducesToASingleTypedStringWithoutAType() {
+        final List<VecAbstractLocalizedString> localizedStrings =
+                List.of(typedString(VecLanguageCode.DE, null, "Leitung"));
+
+        assertThat(reduce(localizedStrings, LocalizedStrings.valueIn(VecLanguageCode.DE))).contains("Leitung");
+    }
+
+    @Test
+    void ignoresTypedStringsWhenSeveralValuesArePresent() {
+        final List<VecAbstractLocalizedString> localizedStrings = List.of(
+                typedString(VecLanguageCode.DE, LENGTH_TYPE, "100"),
+                localizedString(VecLanguageCode.DE, "Leitung"));
+
+        assertThat(reduce(localizedStrings, LocalizedStrings.valueIn(VecLanguageCode.DE))).contains("Leitung");
+    }
+
+    @Test
+    void reducesToTheTypedValueOfTheRequestedTypeAndLanguage() {
+        final List<VecAbstractLocalizedString> localizedStrings = List.of(
+                typedString(VecLanguageCode.DE, LENGTH_TYPE, "100"),
+                typedString(VecLanguageCode.EN, LENGTH_TYPE, "One hundred"),
+                typedString(VecLanguageCode.DE, "Width", "5"));
+
+        assertThat(reduce(localizedStrings, LocalizedStrings.typedValueBy(LENGTH_TYPE, VecLanguageCode.DE)))
+                .contains("100");
+        assertThat(reduce(localizedStrings, LocalizedStrings.typedValueBy(LENGTH_TYPE, VecLanguageCode.EN)))
+                .contains("One hundred");
+        assertThat(reduce(localizedStrings, LocalizedStrings.typedValueBy("Height", VecLanguageCode.DE)))
+                .isEmpty();
+    }
+
+    @Test
+    void reducesToNoTypedValueForAnEmptyValue() {
+        final List<VecAbstractLocalizedString> localizedStrings = List.of(
+                typedString(VecLanguageCode.DE, LENGTH_TYPE, ""),
+                localizedString(VecLanguageCode.DE, "Leitung"));
+
+        assertThat(reduce(localizedStrings, LocalizedStrings.typedValueBy(LENGTH_TYPE, VecLanguageCode.DE)))
+                .isEmpty();
+    }
+
+    /**
+     * Characterisation test for the list based navigations of the deprecated {@link DescriptionNavs}, which
+     * now apply these reductions. Can be removed together with {@link DescriptionNavs}.
+     */
+    @Test
+    @SuppressWarnings({"deprecation", "removal"})
+    void deprecatedNavigationsBehaveLikeTheirReplacement() {
+        for (final List<VecAbstractLocalizedString> localizedStrings : LocalizedStringFixtures.allVariants()) {
+            assertThat(DescriptionNavs.germanString().apply(localizedStrings))
+                    .isEqualTo(reduce(localizedStrings, LocalizedStrings.valueIn(VecLanguageCode.DE)));
+            assertThat(DescriptionNavs.englishString().apply(localizedStrings))
+                    .isEqualTo(reduce(localizedStrings, LocalizedStrings.valueIn(VecLanguageCode.EN)));
+            assertThat(DescriptionNavs.stringIn(VecLanguageCode.EN).apply(localizedStrings))
+                    .isEqualTo(reduce(localizedStrings, LocalizedStrings.valueIn(VecLanguageCode.EN)));
+        }
+    }
+
+}

--- a/vec/vec-v12x/src/test/java/com/foursoft/harness/vec/v12x/traversal/OccurrenceOrUsagesTest.java
+++ b/vec/vec-v12x/src/test/java/com/foursoft/harness/vec/v12x/traversal/OccurrenceOrUsagesTest.java
@@ -1,0 +1,213 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 1.2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v12x.traversal;
+
+import com.foursoft.harness.vec.v12x.VecCompositionSpecification;
+import com.foursoft.harness.vec.v12x.VecDocumentVersion;
+import com.foursoft.harness.vec.v12x.VecModuleFamily;
+import com.foursoft.harness.vec.v12x.VecNodeLocation;
+import com.foursoft.harness.vec.v12x.VecOnPointPlacement;
+import com.foursoft.harness.vec.v12x.VecPartOccurrence;
+import com.foursoft.harness.vec.v12x.VecPartOrUsageRelatedSpecification;
+import com.foursoft.harness.vec.v12x.VecPartUsage;
+import com.foursoft.harness.vec.v12x.VecPartUsageSpecification;
+import com.foursoft.harness.vec.v12x.VecPartVersion;
+import com.foursoft.harness.vec.v12x.VecPartWithSubComponentsRole;
+import com.foursoft.harness.vec.v12x.VecPlaceableElementRole;
+import com.foursoft.harness.vec.v12x.VecPrimaryPartType;
+import com.foursoft.harness.vec.v12x.VecTopologyNode;
+import com.foursoft.harness.vec.v12x.VecWireRole;
+import com.foursoft.harness.vec.v12x.VecWireSpecification;
+import com.foursoft.harness.vec.v12x.navigations.PartOccurrenceOrUsageNavs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OccurrenceOrUsagesTest {
+
+    private final VecDocumentVersion harness = new VecDocumentVersion();
+    private final VecDocumentVersion partMaster = new VecDocumentVersion();
+
+    private final VecPartOccurrence occurrence = new VecPartOccurrence();
+    private final VecPartUsage usage = new VecPartUsage();
+    private final VecPartVersion part = new VecPartVersion();
+    private final VecPlaceableElementRole placeableElementRole = new VecPlaceableElementRole();
+    private final VecWireRole wireRole = new VecWireRole();
+
+    @BeforeEach
+    void setUp() {
+        harness.setDocumentNumber("HARNESS-1");
+        partMaster.setDocumentNumber("PART-MASTER-1");
+
+        part.setPartNumber("  12  34  ");
+        part.setPartVersion("  01 ");
+        part.setPrimaryPartType(VecPrimaryPartType.WIRE);
+        occurrence.setPart(part);
+        occurrence.getRoles().add(wireRole);
+        occurrence.getRoles().add(placeableElementRole);
+
+        final VecCompositionSpecification composition = new VecCompositionSpecification();
+        composition.setParentDocumentVersion(harness);
+        occurrence.setParentCompositionSpecification(composition);
+
+        usage.setPrimaryPartUsageType(VecPrimaryPartType.CONNECTOR_HOUSING);
+        final VecPartUsageSpecification partUsages = new VecPartUsageSpecification();
+        partUsages.setParentDocumentVersion(partMaster);
+        usage.setParentPartUsageSpecification(partUsages);
+    }
+
+    @Test
+    void navigatesToTheRolesOfAnOccurrenceOrUsage() {
+        assertThat(OccurrenceOrUsages.toRoles().listFrom(occurrence))
+                .containsExactly(wireRole, placeableElementRole);
+        assertThat(OccurrenceOrUsages.toRoles().listFrom(usage)).isEmpty();
+    }
+
+    @Test
+    void navigatesToThePlaceableElementRoleOfAnOccurrenceOrUsage() {
+        assertThat(OccurrenceOrUsages.toPlaceableElementRole().from(occurrence)).contains(placeableElementRole);
+        assertThat(OccurrenceOrUsages.toPlaceableElementRole().from(usage)).isEmpty();
+    }
+
+    @Test
+    void navigatesToTheParentDocumentVersionOfAnOccurrenceAndOfAUsage() {
+        assertThat(OccurrenceOrUsages.toParentDocumentVersion().from(occurrence)).contains(harness);
+        assertThat(OccurrenceOrUsages.toParentDocumentVersion().from(usage)).contains(partMaster);
+        assertThat(OccurrenceOrUsages.toParentDocumentNumber().from(occurrence)).contains("HARNESS-1");
+        assertThat(OccurrenceOrUsages.toParentDocumentNumber().from(usage)).contains("PART-MASTER-1");
+    }
+
+    @Test
+    void navigatesToNoParentDocumentVersionForAnUnattachedOccurrence() {
+        assertThat(OccurrenceOrUsages.toParentDocumentVersion().from(new VecPartOccurrence())).isEmpty();
+    }
+
+    @Test
+    void navigatesToThePartOfAnOccurrenceWithItsWhitespacesCollapsed() {
+        assertThat(OccurrenceOrUsages.toPart().from(occurrence)).contains(part);
+        assertThat(OccurrenceOrUsages.toPartNumber().from(occurrence)).contains("12 34");
+        assertThat(OccurrenceOrUsages.toPartVersion().from(occurrence)).contains("01");
+    }
+
+    @Test
+    void navigatesToNoPartForAnOccurrenceWithoutOne() {
+        assertThat(OccurrenceOrUsages.toPart().from(new VecPartOccurrence())).isEmpty();
+        assertThat(OccurrenceOrUsages.toPartNumber().from(new VecPartOccurrence())).isEmpty();
+    }
+
+    @Test
+    void navigatesToThePrimaryPartTypeOfAnOccurrenceAndOfAUsage() {
+        assertThat(OccurrenceOrUsages.toPrimaryPartType().from(occurrence)).contains(VecPrimaryPartType.WIRE);
+        assertThat(OccurrenceOrUsages.toPrimaryPartType().from(usage))
+                .contains(VecPrimaryPartType.CONNECTOR_HOUSING);
+    }
+
+    @Test
+    void navigatesToThePrimaryPartTypeOfTheRealizedUsageForAnOccurrenceWithoutAPart() {
+        final VecPartOccurrence realizing = new VecPartOccurrence();
+        realizing.getRealizedPartUsage().add(usage);
+
+        assertThat(OccurrenceOrUsages.toPrimaryPartType().from(realizing))
+                .contains(VecPrimaryPartType.CONNECTOR_HOUSING);
+        assertThat(OccurrenceOrUsages.toPrimaryPartType().from(new VecPartOccurrence()))
+                .contains(VecPrimaryPartType.OTHER);
+    }
+
+    @Test
+    void navigatesToThePartOrUsageRelatedSpecifications() {
+        final VecPartOrUsageRelatedSpecification specification = new VecWireSpecification();
+        part.getRefPartOrUsageRelatedSpecification().add(specification);
+        usage.getPartOrUsageRelatedSpecification().add(specification);
+
+        assertThat(OccurrenceOrUsages.toPartOrUsageRelatedSpecifications().listFrom(occurrence))
+                .containsExactly(specification);
+        assertThat(OccurrenceOrUsages.toPartOrUsageRelatedSpecifications().listFrom(usage))
+                .containsExactly(specification);
+        assertThat(OccurrenceOrUsages.toPartOrUsageRelatedSpecifications().listFrom(new VecPartOccurrence()))
+                .isEmpty();
+    }
+
+    @Test
+    void navigatesToTheTopologyNodeAnOccurrenceIsPlacedOn() {
+        final VecTopologyNode topologyNode = new VecTopologyNode();
+        final VecNodeLocation location = new VecNodeLocation();
+        location.setReferencedNode(topologyNode);
+        final VecOnPointPlacement placement = new VecOnPointPlacement();
+        placement.getLocations().add(location);
+        placeableElementRole.getRefPlacement().add(placement);
+
+        assertThat(OccurrenceOrUsages.toReferencedTopologyNode().from(occurrence)).contains(topologyNode);
+        assertThat(OccurrenceOrUsages.toReferencedTopologyNode().from(new VecPartOccurrence())).isEmpty();
+    }
+
+    @Test
+    void navigatesToTheModuleFamilyOfAModule() {
+        final VecModuleFamily moduleFamily = new VecModuleFamily();
+        final VecPartWithSubComponentsRole moduleRole = new VecPartWithSubComponentsRole();
+        moduleRole.getRefModuleFamily().add(moduleFamily);
+        occurrence.getRoles().add(moduleRole);
+
+        assertThat(OccurrenceOrUsages.toModuleFamily().from(occurrence)).isEmpty();
+
+        part.setPrimaryPartType(VecPrimaryPartType.PART_STRUCTURE);
+
+        assertThat(OccurrenceOrUsages.toModuleFamily().from(occurrence)).contains(moduleFamily);
+    }
+
+    /**
+     * Characterisation test for the deprecated {@link PartOccurrenceOrUsageNavs}, which delegates to
+     * {@link OccurrenceOrUsages}. Can be removed together with {@link PartOccurrenceOrUsageNavs}.
+     */
+    @Test
+    @SuppressWarnings({"deprecation", "removal"})
+    void deprecatedNavigationsBehaveLikeTheirReplacement() {
+        assertThat(PartOccurrenceOrUsageNavs.parentDocumentVersionOfOccurrence().apply(occurrence))
+                .isEqualTo(harness);
+        assertThat(PartOccurrenceOrUsageNavs.parentDocumentVersionOfUsage().apply(usage)).isEqualTo(partMaster);
+        assertThat(PartOccurrenceOrUsageNavs.parentDocumentVersion().apply(occurrence)).isEqualTo(harness);
+        assertThat(PartOccurrenceOrUsageNavs.parentDocumentNumberOfOccurrence().apply(occurrence))
+                .isEqualTo("HARNESS-1");
+        assertThat(PartOccurrenceOrUsageNavs.parentDocumentNumberOfUsage().apply(usage))
+                .isEqualTo("PART-MASTER-1");
+        assertThat(PartOccurrenceOrUsageNavs.parentDocumentNumber().apply(usage)).isEqualTo("PART-MASTER-1");
+        assertThat(PartOccurrenceOrUsageNavs.partNumber().apply(occurrence))
+                .isEqualTo(OccurrenceOrUsages.toPartNumber().from(occurrence));
+        assertThat(PartOccurrenceOrUsageNavs.partVersion().apply(occurrence))
+                .isEqualTo(OccurrenceOrUsages.toPartVersion().from(occurrence));
+        assertThat(PartOccurrenceOrUsageNavs.primaryPartTypeOfOccurrence().apply(occurrence))
+                .isEqualTo(VecPrimaryPartType.WIRE);
+        assertThat(PartOccurrenceOrUsageNavs.primaryPartType().apply(usage))
+                .isEqualTo(VecPrimaryPartType.CONNECTOR_HOUSING);
+        assertThat(PartOccurrenceOrUsageNavs.moduleFamily().apply(occurrence))
+                .isEqualTo(OccurrenceOrUsages.toModuleFamily().from(occurrence));
+        assertThat(PartOccurrenceOrUsageNavs.topologyNodeByOccurrenceOrUsage().apply(occurrence))
+                .isEqualTo(OccurrenceOrUsages.toReferencedTopologyNode().from(occurrence));
+        assertThat(PartOccurrenceOrUsageNavs.occurrence().apply(occurrence)).contains(occurrence);
+        assertThat(PartOccurrenceOrUsageNavs.usage().apply(usage)).contains(usage);
+    }
+
+}

--- a/vec/vec-v12x/src/test/java/com/foursoft/harness/vec/v12x/traversal/PlaceableElementRolesTest.java
+++ b/vec/vec-v12x/src/test/java/com/foursoft/harness/vec/v12x/traversal/PlaceableElementRolesTest.java
@@ -1,0 +1,83 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 1.2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v12x.traversal;
+
+import com.foursoft.harness.vec.v12x.VecOnPointPlacement;
+import com.foursoft.harness.vec.v12x.VecOnWayPlacement;
+import com.foursoft.harness.vec.v12x.VecPlaceableElementRole;
+import com.foursoft.harness.vec.v12x.navigations.PlacementNavs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PlaceableElementRolesTest {
+
+    private final VecOnPointPlacement onPointPlacement = new VecOnPointPlacement();
+    private final VecOnWayPlacement onWayPlacement = new VecOnWayPlacement();
+
+    private VecPlaceableElementRole role;
+
+    @BeforeEach
+    void setUp() {
+        role = new VecPlaceableElementRole();
+        role.getRefPlacement().add(onPointPlacement);
+        role.getRefPlacement().add(onWayPlacement);
+    }
+
+    @Test
+    void navigatesToAllPlacementsOfARole() {
+        assertThat(PlaceableElementRoles.toPlacements().listFrom(role))
+                .containsExactlyInAnyOrder(onPointPlacement, onWayPlacement);
+    }
+
+    @Test
+    void navigatesToThePlacementsOfTheRequestedKind() {
+        assertThat(PlaceableElementRoles.toOnPointPlacements().listFrom(role))
+                .containsExactly(onPointPlacement);
+        assertThat(PlaceableElementRoles.toOnWayPlacements().listFrom(role))
+                .containsExactly(onWayPlacement);
+    }
+
+    @Test
+    void navigatesToNoPlacementForARoleWithoutPlacements() {
+        assertThat(PlaceableElementRoles.toPlacements().listFrom(new VecPlaceableElementRole())).isEmpty();
+    }
+
+    /**
+     * Characterisation test for the deprecated {@link PlacementNavs}, which delegates to
+     * {@link PlaceableElementRoles}. Can be removed together with {@link PlacementNavs}.
+     */
+    @Test
+    @SuppressWarnings({"deprecation", "removal"})
+    void deprecatedNavigationsBehaveLikeTheirReplacement() {
+        assertThat(PlacementNavs.onPointPlacement().apply(role))
+                .containsExactlyElementsOf(PlaceableElementRoles.toOnPointPlacements().listFrom(role));
+        assertThat(PlacementNavs.onWayPlacement().apply(role))
+                .containsExactlyElementsOf(PlaceableElementRoles.toOnWayPlacements().listFrom(role));
+    }
+
+}

--- a/vec/vec-v12x/src/test/java/com/foursoft/harness/vec/v12x/traversal/PlacementsTest.java
+++ b/vec/vec-v12x/src/test/java/com/foursoft/harness/vec/v12x/traversal/PlacementsTest.java
@@ -1,0 +1,108 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 1.2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v12x.traversal;
+
+import com.foursoft.harness.vec.v12x.VecNodeLocation;
+import com.foursoft.harness.vec.v12x.VecOnPointPlacement;
+import com.foursoft.harness.vec.v12x.VecOnWayPlacement;
+import com.foursoft.harness.vec.v12x.VecSegmentLocation;
+import com.foursoft.harness.vec.v12x.navigations.PlacementNavs;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PlacementsTest {
+
+    private final VecNodeLocation nodeLocation = new VecNodeLocation();
+    private final VecSegmentLocation segmentLocation = new VecSegmentLocation();
+
+    private VecOnPointPlacement onPointPlacement(final VecNodeLocation... locations) {
+        final VecOnPointPlacement placement = new VecOnPointPlacement();
+        for (final VecNodeLocation location : locations) {
+            placement.getLocations().add(location);
+        }
+        return placement;
+    }
+
+    private VecOnWayPlacement onWayPlacement() {
+        final VecOnWayPlacement placement = new VecOnWayPlacement();
+        placement.setStartLocation(segmentLocation);
+        placement.setEndLocation(nodeLocation);
+        return placement;
+    }
+
+    @Test
+    void navigatesToTheLocationsOfAnOnPointPlacement() {
+        assertThat(Placements.toLocations().listFrom(onPointPlacement(nodeLocation)))
+                .containsExactly(nodeLocation);
+    }
+
+    @Test
+    void navigatesToTheStartAndEndLocationOfAnOnWayPlacement() {
+        assertThat(Placements.toLocations().listFrom(onWayPlacement()))
+                .containsExactly(segmentLocation, nodeLocation);
+    }
+
+    @Test
+    void navigatesToNoLocationForAPlacementWithoutLocations() {
+        assertThat(Placements.toLocations().listFrom(onPointPlacement())).isEmpty();
+        assertThat(Placements.toLocations().listFrom(new VecOnWayPlacement())).isEmpty();
+    }
+
+    @Test
+    void skipsAnUnsetStartOrEndLocation() {
+        final VecOnWayPlacement placement = onWayPlacement();
+        placement.setStartLocation(null);
+
+        assertThat(Placements.toLocations().listFrom(placement)).containsExactly(nodeLocation);
+    }
+
+    @Test
+    void navigatesToTheLocationsOfTheRequestedType() {
+        final VecOnWayPlacement placement = onWayPlacement();
+
+        assertThat(Placements.toLocations().ofType(VecNodeLocation.class).listFrom(placement))
+                .containsExactly(nodeLocation);
+        assertThat(Placements.toLocations().ofType(VecSegmentLocation.class).listFrom(placement))
+                .containsExactly(segmentLocation);
+    }
+
+    /**
+     * Characterisation test for the deprecated {@link PlacementNavs}, which delegates to {@link Placements}.
+     * Can be removed together with {@link PlacementNavs}.
+     */
+    @Test
+    @SuppressWarnings({"deprecation", "removal"})
+    void deprecatedNavigationsBehaveLikeTheirReplacement() {
+        final VecOnWayPlacement placement = onWayPlacement();
+
+        assertThat(PlacementNavs.locationsWith(VecNodeLocation.class).apply(placement))
+                .isEqualTo(Placements.toLocations().ofType(VecNodeLocation.class).listFrom(placement));
+        assertThat(PlacementNavs.locationsWith(VecSegmentLocation.class).apply(placement))
+                .isEqualTo(Placements.toLocations().ofType(VecSegmentLocation.class).listFrom(placement));
+    }
+
+}

--- a/vec/vec-v12x/src/test/java/com/foursoft/harness/vec/v12x/traversal/RolesTest.java
+++ b/vec/vec-v12x/src/test/java/com/foursoft/harness/vec/v12x/traversal/RolesTest.java
@@ -1,0 +1,80 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 1.2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v12x.traversal;
+
+import com.foursoft.harness.vec.v12x.VecCompositionSpecification;
+import com.foursoft.harness.vec.v12x.VecDocumentVersion;
+import com.foursoft.harness.vec.v12x.VecPartOccurrence;
+import com.foursoft.harness.vec.v12x.VecPlaceableElementRole;
+import com.foursoft.harness.vec.v12x.VecRole;
+import com.foursoft.harness.vec.v12x.navigations.VecNavs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RolesTest {
+
+    private final VecDocumentVersion documentVersion = new VecDocumentVersion();
+    private final VecPartOccurrence occurrence = new VecPartOccurrence();
+    private final VecRole role = new VecPlaceableElementRole();
+
+    @BeforeEach
+    void setUp() {
+        final VecCompositionSpecification composition = new VecCompositionSpecification();
+        composition.setParentDocumentVersion(documentVersion);
+        occurrence.setParentCompositionSpecification(composition);
+        role.setParentOccurrenceOrUsage(occurrence);
+    }
+
+    @Test
+    void navigatesToTheOccurrenceOrUsageOfARole() {
+        assertThat(Roles.toParentOccurrenceOrUsage().from(role)).contains(occurrence);
+    }
+
+    @Test
+    void navigatesToTheParentDocumentVersionOfARole() {
+        assertThat(Roles.toParentDocumentVersion().from(role)).contains(documentVersion);
+    }
+
+    @Test
+    void navigatesNowhereForAnUnattachedRole() {
+        assertThat(Roles.toParentOccurrenceOrUsage().from(new VecPlaceableElementRole())).isEmpty();
+        assertThat(Roles.toParentDocumentVersion().from(new VecPlaceableElementRole())).isEmpty();
+    }
+
+    /**
+     * Characterisation test for the deprecated {@link VecNavs}, which delegates to {@link Roles}.
+     * Can be removed together with {@link VecNavs}.
+     */
+    @Test
+    @SuppressWarnings({"deprecation", "removal"})
+    void deprecatedNavigationsBehaveLikeTheirReplacement() {
+        assertThat(VecNavs.parentDocumentVersion().apply(role))
+                .isEqualTo(Roles.toParentDocumentVersion().orElseNull(role));
+    }
+
+}

--- a/vec/vec-v12x/src/test/java/com/foursoft/harness/vec/v12x/traversal/SpecificationOwnersTest.java
+++ b/vec/vec-v12x/src/test/java/com/foursoft/harness/vec/v12x/traversal/SpecificationOwnersTest.java
@@ -1,0 +1,114 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 1.2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v12x.traversal;
+
+import com.foursoft.harness.vec.common.HasSpecifications;
+import com.foursoft.harness.vec.v12x.VecCompositionSpecification;
+import com.foursoft.harness.vec.v12x.VecPartOccurrence;
+import com.foursoft.harness.vec.v12x.VecPartUsage;
+import com.foursoft.harness.vec.v12x.VecPartUsageSpecification;
+import com.foursoft.harness.vec.v12x.VecSpecification;
+import com.foursoft.harness.vec.v12x.navigations.SpecificationNavs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SpecificationOwnersTest {
+
+    private final List<VecSpecification> specifications = new ArrayList<>();
+    private final HasSpecifications<VecSpecification> owner = () -> specifications;
+
+    private final VecPartOccurrence firstComponent = new VecPartOccurrence();
+    private final VecPartOccurrence secondComponent = new VecPartOccurrence();
+    private final VecPartUsage partUsage = new VecPartUsage();
+
+    private final VecCompositionSpecification firstComposition = new VecCompositionSpecification();
+    private final VecCompositionSpecification secondComposition = new VecCompositionSpecification();
+    private final VecPartUsageSpecification partUsages = new VecPartUsageSpecification();
+
+    @BeforeEach
+    void setUp() {
+        firstComposition.setIdentification("COMP-1");
+        firstComposition.getComponents().add(firstComponent);
+        secondComposition.setIdentification("COMP-2");
+        secondComposition.getComponents().add(secondComponent);
+        partUsages.getPartUsages().add(partUsage);
+
+        specifications.add(firstComposition);
+        specifications.add(secondComposition);
+        specifications.add(partUsages);
+    }
+
+    @Test
+    void navigatesToTheSpecificationsOfTheirHolder() {
+        assertThat(SpecificationOwners.toSpecifications().listFrom(owner))
+                .containsExactly(firstComposition, secondComposition, partUsages);
+        assertThat(SpecificationOwners.toSpecifications().listFrom(List::of)).isEmpty();
+    }
+
+    @Test
+    void navigatesToTheComponentsOfAllCompositionSpecifications() {
+        assertThat(SpecificationOwners.toComponents().listFrom(owner))
+                .containsExactly(firstComponent, secondComponent);
+    }
+
+    @Test
+    void navigatesToThePartUsagesOfAllPartUsageSpecifications() {
+        assertThat(SpecificationOwners.toPartUsages().listFrom(owner)).containsExactly(partUsage);
+    }
+
+    @Test
+    void navigatesToTheComponentsFollowedByThePartUsages() {
+        assertThat(SpecificationOwners.toOccurrenceOrUsages().listFrom(owner))
+                .containsExactly(firstComponent, secondComponent, partUsage);
+    }
+
+    @Test
+    void navigatesToTheComponentsOfTheIdentifiedCompositionSpecification() {
+        assertThat(SpecificationOwners.componentsBy("COMP-2").listFrom(owner)).containsExactly(secondComponent);
+        assertThat(SpecificationOwners.componentsBy("COMP-3").listFrom(owner)).isEmpty();
+    }
+
+    /**
+     * Characterisation test for the deprecated {@link SpecificationNavs}, which delegates to
+     * {@link SpecificationOwners}. Can be removed together with {@link SpecificationNavs}.
+     */
+    @Test
+    @SuppressWarnings({"deprecation", "removal"})
+    void deprecatedNavigationsBehaveLikeTheirReplacement() {
+        assertThat(SpecificationNavs.components().apply(owner))
+                .isEqualTo(SpecificationOwners.toComponents().listFrom(owner));
+        assertThat(SpecificationNavs.componentsBy("COMP-2").apply(owner))
+                .isEqualTo(SpecificationOwners.componentsBy("COMP-2").listFrom(owner));
+        assertThat(SpecificationNavs.allOccurrenceOrUsages().apply(owner))
+                .isEqualTo(SpecificationOwners.toOccurrenceOrUsages().listFrom(owner));
+    }
+
+}

--- a/vec/vec-v12x/src/test/java/com/foursoft/harness/vec/v12x/traversal/SpecificationsTest.java
+++ b/vec/vec-v12x/src/test/java/com/foursoft/harness/vec/v12x/traversal/SpecificationsTest.java
@@ -1,0 +1,155 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 1.2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v12x.traversal;
+
+import com.foursoft.harness.vec.common.HasModifiableIdentification;
+import com.foursoft.harness.vec.v12x.VecBuildingBlockSpecification2D;
+import com.foursoft.harness.vec.v12x.VecBuildingBlockSpecification3D;
+import com.foursoft.harness.vec.v12x.VecCompositionSpecification;
+import com.foursoft.harness.vec.v12x.VecDocumentVersion;
+import com.foursoft.harness.vec.v12x.VecGeometryNode2D;
+import com.foursoft.harness.vec.v12x.VecGeometryNode3D;
+import com.foursoft.harness.vec.v12x.VecGeometrySegment2D;
+import com.foursoft.harness.vec.v12x.VecGeometrySegment3D;
+import com.foursoft.harness.vec.v12x.VecPartOccurrence;
+import com.foursoft.harness.vec.v12x.VecPartUsage;
+import com.foursoft.harness.vec.v12x.VecPartUsageSpecification;
+import com.foursoft.harness.vec.v12x.VecPlacementSpecification;
+import com.foursoft.harness.vec.v12x.VecSheetOrChapter;
+import com.foursoft.harness.vec.v12x.VecSpecification;
+import com.foursoft.harness.vec.v12x.navigations.SpecificationNavs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SpecificationsTest {
+
+    private final VecDocumentVersion documentVersion = new VecDocumentVersion();
+    private final VecBuildingBlockSpecification2D buildingBlock2D = new VecBuildingBlockSpecification2D();
+    private final VecBuildingBlockSpecification3D buildingBlock3D = new VecBuildingBlockSpecification3D();
+
+    private final VecGeometryNode2D node2D = identified(new VecGeometryNode2D(), "N-1");
+    private final VecGeometryNode3D node3D = identified(new VecGeometryNode3D(), "N-1");
+    private final VecGeometrySegment2D segment2D = identified(new VecGeometrySegment2D(), "S-1");
+    private final VecGeometrySegment3D segment3D = identified(new VecGeometrySegment3D(), "S-1");
+
+    private static <T extends HasModifiableIdentification> T identified(
+            final T element, final String identification) {
+        element.setIdentification(identification);
+        return element;
+    }
+
+    @BeforeEach
+    void setUp() {
+        documentVersion.setDocumentNumber("DOC-1");
+        buildingBlock2D.getGeometryNodes().add(node2D);
+        buildingBlock2D.getGeometrySegments().add(segment2D);
+        buildingBlock3D.getGeometryNodes().add(node3D);
+        buildingBlock3D.getGeometrySegments().add(segment3D);
+    }
+
+    @Test
+    void navigatesToTheParentDocumentVersionHeldByTheSpecificationItself() {
+        final VecSpecification specification = new VecPlacementSpecification();
+        specification.setParentDocumentVersion(documentVersion);
+
+        assertThat(Specifications.toParentDocumentVersion().from(specification)).contains(documentVersion);
+        assertThat(Specifications.toParentDocumentNumber().from(specification)).contains("DOC-1");
+    }
+
+    @Test
+    void navigatesToTheParentDocumentVersionThroughTheSheetOrChapter() {
+        final VecSheetOrChapter sheet = new VecSheetOrChapter();
+        sheet.setParentDocumentVersion(documentVersion);
+        final VecSpecification specification = new VecPlacementSpecification();
+        specification.setParentSheetOrChapter(sheet);
+
+        assertThat(Specifications.toParentDocumentVersion().from(specification)).contains(documentVersion);
+    }
+
+    @Test
+    void navigatesToNoParentDocumentVersionForAnUnattachedSpecification() {
+        assertThat(Specifications.toParentDocumentVersion().from(new VecPlacementSpecification())).isEmpty();
+        assertThat(Specifications.toParentDocumentNumber().from(new VecPlacementSpecification())).isEmpty();
+    }
+
+    @Test
+    void navigatesToTheComponentsAndPartUsagesOfASpecification() {
+        final VecPartOccurrence component = new VecPartOccurrence();
+        final VecCompositionSpecification composition = new VecCompositionSpecification();
+        composition.getComponents().add(component);
+
+        final VecPartUsage partUsage = new VecPartUsage();
+        final VecPartUsageSpecification partUsages = new VecPartUsageSpecification();
+        partUsages.getPartUsages().add(partUsage);
+
+        assertThat(Specifications.toComponents().listFrom(composition)).containsExactly(component);
+        assertThat(Specifications.toPartUsages().listFrom(partUsages)).containsExactly(partUsage);
+    }
+
+    @Test
+    void navigatesToTheGeometryOfABuildingBlock() {
+        assertThat(Specifications.toGeometryNodes2D().listFrom(buildingBlock2D)).containsExactly(node2D);
+        assertThat(Specifications.toGeometryNodes3D().listFrom(buildingBlock3D)).containsExactly(node3D);
+        assertThat(Specifications.toGeometrySegments2D().listFrom(buildingBlock2D)).containsExactly(segment2D);
+        assertThat(Specifications.toGeometrySegments3D().listFrom(buildingBlock3D)).containsExactly(segment3D);
+    }
+
+    @Test
+    void navigatesToTheGeometryWithTheGivenIdentification() {
+        assertThat(Specifications.geometryNode2dBy("N-1").from(buildingBlock2D)).contains(node2D);
+        assertThat(Specifications.geometryNode3dBy("N-1").from(buildingBlock3D)).contains(node3D);
+        assertThat(Specifications.geometrySegment2dBy("S-1").from(buildingBlock2D)).contains(segment2D);
+        assertThat(Specifications.geometrySegment3dBy("S-1").from(buildingBlock3D)).contains(segment3D);
+    }
+
+    @Test
+    void navigatesToNoGeometryForAnUnknownIdentification() {
+        assertThat(Specifications.geometryNode2dBy("N-2").from(buildingBlock2D)).isEmpty();
+        assertThat(Specifications.geometrySegment3dBy("S-2").from(buildingBlock3D)).isEmpty();
+    }
+
+    /**
+     * Characterisation test for the deprecated {@link SpecificationNavs}, which delegates to
+     * {@link Specifications}. Can be removed together with {@link SpecificationNavs}.
+     */
+    @Test
+    @SuppressWarnings({"deprecation", "removal"})
+    void deprecatedNavigationsBehaveLikeTheirReplacement() {
+        final VecSpecification specification = new VecPlacementSpecification();
+        specification.setParentDocumentVersion(documentVersion);
+
+        assertThat(SpecificationNavs.parentDocumentVersion().apply(specification)).isEqualTo(documentVersion);
+        assertThat(SpecificationNavs.parentDocumentNumber().apply(specification)).isEqualTo("DOC-1");
+        assertThat(SpecificationNavs.geometryNode2dBy("N-1").apply(buildingBlock2D)).isEqualTo(node2D);
+        assertThat(SpecificationNavs.geometryNode3dBy("N-1").apply(buildingBlock3D)).isEqualTo(node3D);
+        assertThat(SpecificationNavs.geometrySegment2dBy("S-1").apply(buildingBlock2D)).isEqualTo(segment2D);
+        assertThat(SpecificationNavs.geometrySegment3dBy("S-1").apply(buildingBlock3D)).isEqualTo(segment3D);
+        assertThat(SpecificationNavs.geometryNode2dBy("N-2").apply(buildingBlock2D)).isNull();
+    }
+
+}

--- a/vec/vec-v12x/src/test/java/com/foursoft/harness/vec/v12x/traversal/TopologySegmentsTest.java
+++ b/vec/vec-v12x/src/test/java/com/foursoft/harness/vec/v12x/traversal/TopologySegmentsTest.java
@@ -1,0 +1,121 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 1.2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v12x.traversal;
+
+import com.foursoft.harness.vec.v12x.VecDocumentVersion;
+import com.foursoft.harness.vec.v12x.VecNumericalValue;
+import com.foursoft.harness.vec.v12x.VecSegmentCrossSectionArea;
+import com.foursoft.harness.vec.v12x.VecSegmentLength;
+import com.foursoft.harness.vec.v12x.VecTopologySegment;
+import com.foursoft.harness.vec.v12x.VecTopologySpecification;
+import com.foursoft.harness.vec.v12x.navigations.SegmentNavs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TopologySegmentsTest {
+
+    private static final String DESIGNED = "Designed";
+    private static final String RESERVED = "Reserved";
+
+    private final VecTopologySegment segment = new VecTopologySegment();
+    private final VecDocumentVersion documentVersion = new VecDocumentVersion();
+
+    private static VecNumericalValue value(final double valueComponent) {
+        final VecNumericalValue numericalValue = new VecNumericalValue();
+        numericalValue.setValueComponent(valueComponent);
+        return numericalValue;
+    }
+
+    @BeforeEach
+    void setUp() {
+        documentVersion.setDocumentNumber("DOC-1");
+        final VecTopologySpecification topology = new VecTopologySpecification();
+        topology.setParentDocumentVersion(documentVersion);
+        segment.setParentTopologySpecification(topology);
+
+        final VecSegmentLength length = new VecSegmentLength();
+        length.setClassification(DESIGNED);
+        length.setLength(value(1500.0));
+        segment.getLengthInformations().add(length);
+
+        final VecSegmentCrossSectionArea area = new VecSegmentCrossSectionArea();
+        area.setCrossSectionAreaType(RESERVED);
+        area.setArea(value(2.5));
+        segment.getCrossSectionAreaInformations().add(area);
+    }
+
+    @Test
+    void navigatesToTheParentDocumentNumberOfASegment() {
+        assertThat(TopologySegments.toParentDocumentNumber().from(segment)).contains("DOC-1");
+        assertThat(TopologySegments.toParentDocumentNumber().from(new VecTopologySegment())).isEmpty();
+    }
+
+    @Test
+    void navigatesToTheLengthAndCrossSectionAreaInformations() {
+        assertThat(TopologySegments.toLengthInformations().listFrom(segment)).hasSize(1);
+        assertThat(TopologySegments.toCrossSectionAreaInformations().listFrom(segment)).hasSize(1);
+    }
+
+    @Test
+    void navigatesToTheLengthOfTheRequestedClassification() {
+        assertThat(TopologySegments.lengthBy(DESIGNED).from(segment)).contains(1500.0);
+        assertThat(TopologySegments.lengthBy("Adapted").from(segment)).isEmpty();
+    }
+
+    @Test
+    void navigatesToTheCrossSectionAreaOfTheRequestedType() {
+        assertThat(TopologySegments.crossSectionAreaBy(RESERVED).from(segment)).contains(2.5);
+        assertThat(TopologySegments.crossSectionAreaBy("Real").from(segment)).isEmpty();
+    }
+
+    @Test
+    void navigatesToTheCrossSectionAreaWithoutAType() {
+        final VecSegmentCrossSectionArea untyped = new VecSegmentCrossSectionArea();
+        untyped.setArea(value(4.0));
+        final VecTopologySegment untypedSegment = new VecTopologySegment();
+        untypedSegment.getCrossSectionAreaInformations().add(untyped);
+
+        assertThat(TopologySegments.crossSectionAreaBy(null).from(untypedSegment)).contains(4.0);
+    }
+
+    /**
+     * Characterisation test for the deprecated {@link SegmentNavs}, which delegates to
+     * {@link TopologySegments}. Can be removed together with {@link SegmentNavs}.
+     */
+    @Test
+    @SuppressWarnings({"deprecation", "removal"})
+    void deprecatedNavigationsBehaveLikeTheirReplacement() {
+        assertThat(SegmentNavs.parentDocumentNumber().apply(segment))
+                .isEqualTo(TopologySegments.toParentDocumentNumber().orElseNull(segment));
+        assertThat(SegmentNavs.lengthBy(DESIGNED).apply(segment))
+                .isEqualTo(TopologySegments.lengthBy(DESIGNED).from(segment));
+        assertThat(SegmentNavs.crossSectionAreaBy(RESERVED).apply(segment))
+                .isEqualTo(TopologySegments.crossSectionAreaBy(RESERVED).from(segment));
+    }
+
+}

--- a/vec/vec-v12x/src/test/java/com/foursoft/harness/vec/v12x/traversal/ViewItemsTest.java
+++ b/vec/vec-v12x/src/test/java/com/foursoft/harness/vec/v12x/traversal/ViewItemsTest.java
@@ -1,0 +1,152 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 1.2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v12x.traversal;
+
+import com.foursoft.harness.vec.common.traversal.MultiNavigation;
+import com.foursoft.harness.vec.v12x.HasOccurrenceOrUsages;
+import com.foursoft.harness.vec.v12x.VecLocation;
+import com.foursoft.harness.vec.v12x.VecNodeLocation;
+import com.foursoft.harness.vec.v12x.VecOccurrenceOrUsage;
+import com.foursoft.harness.vec.v12x.VecOnPointPlacement;
+import com.foursoft.harness.vec.v12x.VecOnWayPlacement;
+import com.foursoft.harness.vec.v12x.VecPartOccurrence;
+import com.foursoft.harness.vec.v12x.VecPlaceableElementRole;
+import com.foursoft.harness.vec.v12x.VecSegmentLocation;
+import com.foursoft.harness.vec.v12x.navigations.PlacementNavs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ViewItemsTest {
+
+    private static final MultiNavigation<HasOccurrenceOrUsages, VecLocation> ON_POINT_LOCATIONS =
+            ViewItems.toPlaceableElementRole()
+                    .then(PlaceableElementRoles.toOnPointPlacements())
+                    .then(Placements.toLocations());
+    private static final MultiNavigation<HasOccurrenceOrUsages, VecLocation> ON_WAY_LOCATIONS =
+            ViewItems.toPlaceableElementRole()
+                    .then(PlaceableElementRoles.toOnWayPlacements())
+                    .then(Placements.toLocations());
+
+    private final VecNodeLocation nodeLocation = new VecNodeLocation();
+    private final VecSegmentLocation segmentLocation = new VecSegmentLocation();
+
+    private VecPlaceableElementRole role;
+    private VecPartOccurrence partOccurrence;
+    private HasOccurrenceOrUsages viewItem;
+
+    @BeforeEach
+    void setUp() {
+        final VecOnPointPlacement onPointPlacement = new VecOnPointPlacement();
+        onPointPlacement.getLocations().add(nodeLocation);
+
+        final VecOnWayPlacement onWayPlacement = new VecOnWayPlacement();
+        onWayPlacement.setStartLocation(segmentLocation);
+        onWayPlacement.setEndLocation(nodeLocation);
+
+        role = new VecPlaceableElementRole();
+        role.getRefPlacement().add(onPointPlacement);
+        role.getRefPlacement().add(onWayPlacement);
+
+        partOccurrence = new VecPartOccurrence();
+        partOccurrence.getRoles().add(role);
+
+        final List<VecOccurrenceOrUsage> occurrences = List.of(partOccurrence);
+        viewItem = () -> occurrences;
+    }
+
+    @Test
+    void navigatesToTheOccurrencesOrUsagesOfAViewItem() {
+        assertThat(ViewItems.toOccurrenceOrUsages().listFrom(viewItem)).containsExactly(partOccurrence);
+        assertThat(ViewItems.toOccurrenceOrUsages().listFrom(Collections::emptyList)).isEmpty();
+    }
+
+    @Test
+    void navigatesToThePlaceableElementRoleOfAViewItem() {
+        assertThat(ViewItems.toPlaceableElementRole().from(viewItem)).contains(role);
+    }
+
+    @Test
+    void navigatesToNoPlaceableElementRoleForAnOccurrenceWithoutSuchARole() {
+        partOccurrence.getRoles().clear();
+
+        assertThat(ViewItems.toPlaceableElementRole().from(viewItem)).isEmpty();
+    }
+
+    @Test
+    void navigatesToNoPlaceableElementRoleForAnEmptyViewItem() {
+        assertThat(ViewItems.toPlaceableElementRole().from(Collections::emptyList)).isEmpty();
+    }
+
+    @Test
+    void navigatesToTheOnPointLocationsOfAViewItem() {
+        assertThat(ON_POINT_LOCATIONS.listFrom(viewItem)).containsExactly(nodeLocation);
+    }
+
+    /**
+     * Since the way to the locations is composed at the call site, on way placements work just as well. The
+     * deprecated {@link PlacementNavs#locationsOf(java.util.function.Function)} documented this, but its
+     * parameter type only allowed on point placements.
+     */
+    @Test
+    void navigatesToTheOnWayLocationsOfAViewItem() {
+        assertThat(ON_WAY_LOCATIONS.listFrom(viewItem)).containsExactly(segmentLocation, nodeLocation);
+    }
+
+    @Test
+    void navigatesToTheLocationsOfEveryPlacementKindAtOnce() {
+        final MultiNavigation<HasOccurrenceOrUsages, VecLocation> allLocations =
+                ViewItems.toPlaceableElementRole()
+                        .then(PlaceableElementRoles.toPlacements())
+                        .then(Placements.toLocations());
+
+        assertThat(allLocations.listFrom(viewItem))
+                .containsExactlyInAnyOrder(nodeLocation, segmentLocation, nodeLocation);
+    }
+
+    @Test
+    void navigatesToNoLocationForAnEmptyViewItem() {
+        assertThat(ON_POINT_LOCATIONS.listFrom(Collections::emptyList)).isEmpty();
+    }
+
+    /**
+     * Characterisation test for the deprecated {@link PlacementNavs}, which delegates to {@link ViewItems}.
+     * Can be removed together with {@link PlacementNavs}.
+     */
+    @Test
+    @SuppressWarnings({"deprecation", "removal"})
+    void deprecatedNavigationsBehaveLikeTheirReplacement() {
+        assertThat(PlacementNavs.locationsOf(PlacementNavs.onPointPlacement()).apply(viewItem))
+                .isEqualTo(ON_POINT_LOCATIONS.listFrom(viewItem));
+        assertThat(PlacementNavs.locationsOf(PlacementNavs.onPointPlacement()).apply(Collections::emptyList))
+                .isEmpty();
+    }
+
+}

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/navigations/ConfigurableElementNavs.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/navigations/ConfigurableElementNavs.java
@@ -2,7 +2,7 @@
  * ========================LICENSE_START=================================
  * VEC 2.X
  * %%
- * Copyright (C) 2020 - 2023 4Soft GmbH
+ * Copyright (C) 2020 - 2026 4Soft GmbH
  * %%
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -10,10 +10,10 @@
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * 
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -27,34 +27,48 @@ package com.foursoft.harness.vec.v2x.navigations;
 
 import com.foursoft.harness.vec.v2x.VecConfigurableElement;
 import com.foursoft.harness.vec.v2x.VecVariantConfiguration;
+import com.foursoft.harness.vec.v2x.traversal.ConfigurableElements;
 
 import java.util.Optional;
 import java.util.function.Function;
 
 /**
  * Navigation methods for the {@link VecConfigurableElement}.
+ *
+ * @deprecated Use {@link ConfigurableElements} instead.
  */
+@Deprecated(forRemoval = true)
 public final class ConfigurableElementNavs {
 
     private ConfigurableElementNavs() {
         // hide default constructor
     }
 
+    /**
+     * @deprecated Use {@link ConfigurableElements#toVariantConfiguration()} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecConfigurableElement, Optional<VecVariantConfiguration>> variantConfiguration() {
         return configurableElement -> Optional.ofNullable(configurableElement)
-                .map(VecConfigurableElement::getConfigInfo);
+                .flatMap(ConfigurableElements.toVariantConfiguration());
     }
 
+    /**
+     * @deprecated Use {@link ConfigurableElements#toLogisticControlString()} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecConfigurableElement, Optional<String>> controlInformation() {
         return configurableElement -> Optional.ofNullable(configurableElement)
-                .map(VecConfigurableElement::getConfigInfo)
-                .map(VecVariantConfiguration::getLogisticControlString);
+                .flatMap(ConfigurableElements.toLogisticControlString());
     }
 
+    /**
+     * @deprecated Use {@link ConfigurableElements#toLogisticControlExpression()} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecConfigurableElement, Optional<String>> controlExpression() {
         return configurableElement -> Optional.ofNullable(configurableElement)
-                .map(VecConfigurableElement::getConfigInfo)
-                .map(VecVariantConfiguration::getLogisticControlExpression);
+                .flatMap(ConfigurableElements.toLogisticControlExpression());
     }
 
 }

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/navigations/ContentNavs.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/navigations/ContentNavs.java
@@ -2,7 +2,7 @@
  * ========================LICENSE_START=================================
  * VEC 2.X
  * %%
- * Copyright (C) 2020 - 2023 4Soft GmbH
+ * Copyright (C) 2020 - 2026 4Soft GmbH
  * %%
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -10,10 +10,10 @@
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * 
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -25,10 +25,12 @@
  */
 package com.foursoft.harness.vec.v2x.navigations;
 
-import com.foursoft.harness.vec.common.util.StreamUtils;
+import com.foursoft.harness.vec.common.traversal.MultiNavigation;
 import com.foursoft.harness.vec.v2x.VecContent;
 import com.foursoft.harness.vec.v2x.VecDocumentVersion;
 import com.foursoft.harness.vec.v2x.VecSpecification;
+import com.foursoft.harness.vec.v2x.traversal.Contents;
+import com.foursoft.harness.vec.v2x.traversal.SpecificationOwners;
 
 import java.util.List;
 import java.util.Optional;
@@ -36,25 +38,34 @@ import java.util.function.Function;
 
 /**
  * Navigation methods for the {@link VecContent}.
+ *
+ * @deprecated Use {@link Contents} instead.
  */
+@Deprecated(forRemoval = true)
 public final class ContentNavs {
 
     private ContentNavs() {
         // hide default constructor
     }
 
+    /**
+     * @deprecated Compose the navigation at the call site instead:
+     * {@code Contents.toDocumentVersions().then(SpecificationOwners.toSpecifications()).ofType(clazz)}.
+     */
+    @Deprecated(forRemoval = true)
     public static <T extends VecSpecification> Function<VecContent, List<T>> allSpecificationsOf(final Class<T> clazz) {
-        return vecContent -> vecContent.getDocumentVersions()
-                .stream()
-                .flatMap(StreamUtils.toStream(documentVersion -> documentVersion.getSpecificationsWithType(clazz)))
-                .toList();
+        final MultiNavigation<VecContent, T> specifications = Contents.toDocumentVersions()
+                .then(SpecificationOwners.<VecDocumentVersion>toSpecifications())
+                .ofType(clazz);
+        return specifications::listFrom;
     }
 
-    public static Function<VecContent, Optional<VecDocumentVersion>> documentVersionBy(
-            final String documentNumber) {
-        return content -> content.getDocumentVersions().stream()
-                .filter(documentVersion -> documentVersion.getDocumentNumber().equals(documentNumber))
-                .collect(StreamUtils.findOneOrNone());
+    /**
+     * @deprecated Use {@link Contents#documentVersionBy(String)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    public static Function<VecContent, Optional<VecDocumentVersion>> documentVersionBy(final String documentNumber) {
+        return Contents.documentVersionBy(documentNumber);
     }
 
 }

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/navigations/ContentNavs.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/navigations/ContentNavs.java
@@ -33,7 +33,6 @@ import com.foursoft.harness.vec.v2x.VecSpecification;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 /**
  * Navigation methods for the {@link VecContent}.

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/navigations/CustomPropertyNavs.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/navigations/CustomPropertyNavs.java
@@ -2,7 +2,7 @@
  * ========================LICENSE_START=================================
  * VEC 2.X
  * %%
- * Copyright (C) 2020 - 2023 4Soft GmbH
+ * Copyright (C) 2020 - 2026 4Soft GmbH
  * %%
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -10,10 +10,10 @@
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * 
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,85 +26,112 @@
 package com.foursoft.harness.vec.v2x.navigations;
 
 import com.foursoft.harness.vec.common.HasCustomProperties;
-import com.foursoft.harness.vec.common.util.StreamUtils;
-import com.foursoft.harness.vec.v2x.*;
-import com.foursoft.harness.vec.v2x.predicates.VecPredicates;
+import com.foursoft.harness.vec.v2x.VecCustomProperty;
+import com.foursoft.harness.vec.v2x.VecExtendableElement;
+import com.foursoft.harness.vec.v2x.VecLanguageCode;
+import com.foursoft.harness.vec.v2x.VecLocalizedStringProperty;
+import com.foursoft.harness.vec.v2x.VecValueRange;
+import com.foursoft.harness.vec.v2x.traversal.CustomProperties;
+import com.foursoft.harness.vec.v2x.traversal.LocalizedStringProperties;
 
 import java.math.BigInteger;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 
 /**
  * Navigation methods for custom properties of a {@link VecExtendableElement}.
+ *
+ * @deprecated Use {@link CustomProperties} instead, and {@link LocalizedStringProperties} for the navigations
+ * starting at a {@link VecLocalizedStringProperty}.
  */
+@Deprecated(forRemoval = true)
 public final class CustomPropertyNavs {
 
     private CustomPropertyNavs() {
         // hide default constructor
     }
 
+    /**
+     * @deprecated Use {@link CustomProperties#stringValueOf(String)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<HasCustomProperties<VecCustomProperty>, Optional<String>> customPropertyValueStringOf(
             final String customProperty) {
-        return element -> element.getCustomProperty(VecSimpleValueProperty.class, customProperty)
-                .map(VecSimpleValueProperty::getValue);
+        return CustomProperties.stringValueOf(customProperty);
     }
 
+    /**
+     * @deprecated Use {@link CustomProperties#integerValueOf(String)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<HasCustomProperties<VecCustomProperty>, Optional<BigInteger>> customPropertyValueIntegerOf(
             final String customProperty) {
-        return element -> element.getCustomProperty(VecIntegerValueProperty.class, customProperty)
-                .map(VecIntegerValueProperty::getValue);
+        return CustomProperties.integerValueOf(customProperty);
     }
 
+    /**
+     * @deprecated Use {@link CustomProperties#stringValuesOf(String)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<HasCustomProperties<VecCustomProperty>, List<String>> customPropertyValueStringsOf(
             final String customProperty) {
-        return element -> element.getCustomPropertiesWithType(VecSimpleValueProperty.class).stream()
-                .filter(c -> c.getPropertyType().equals(customProperty))
-                .map(VecSimpleValueProperty::getValue)
-                .toList();
+        return CustomProperties.stringValuesOf(customProperty)::listFrom;
     }
 
+    /**
+     * @deprecated Use {@link CustomProperties#doubleValueOf(String)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<HasCustomProperties<VecCustomProperty>, Optional<Double>> customPropertyValueDoubleOf(
             final String customProperty) {
-        return element -> element.getCustomProperty(VecDoubleValueProperty.class, customProperty)
-                .map(VecDoubleValueProperty::getValue);
+        return CustomProperties.doubleValueOf(customProperty);
     }
 
+    /**
+     * @deprecated Use {@link CustomProperties#valueRangeOf(String)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<HasCustomProperties<VecCustomProperty>, Optional<VecValueRange>> customPropertyValueRangeOf(
             final String customProperty) {
-        return element -> element.getCustomProperty(VecValueRangeProperty.class, customProperty)
-                .map(VecValueRangeProperty::getValue);
+        return CustomProperties.valueRangeOf(customProperty);
     }
 
+    /**
+     * @deprecated Use {@link CustomProperties#booleanValueOf(String)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<HasCustomProperties<VecCustomProperty>, Optional<Boolean>> customPropertyValueBooleanOf(
             final String customProperty) {
-        return element -> element.getCustomProperty(VecBooleanValueProperty.class, customProperty)
-                .map(VecBooleanValueProperty::isValue);
+        return CustomProperties.booleanValueOf(customProperty);
     }
 
+    /**
+     * @deprecated Use {@link CustomProperties#nestedPropertiesOf(String)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<HasCustomProperties<VecCustomProperty>, List<VecCustomProperty>> customPropertyValuesOf(
             final String customProperty) {
-        return element -> element.getCustomProperty(VecComplexProperty.class, customProperty)
-                .map(VecComplexProperty::getCustomProperties)
-                .orElseGet(Collections::emptyList);
+        return CustomProperties.nestedPropertiesOf(customProperty)::listFrom;
     }
 
+    /**
+     * @deprecated Use {@link CustomProperties#localizedValueOf(String, VecLanguageCode)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<HasCustomProperties<VecCustomProperty>, Optional<String>> customPropertyValueLocalizedString(
             final String customProperty, final VecLanguageCode languageCode) {
-        return element -> element.getCustomProperty(VecLocalizedStringProperty.class, customProperty)
-                .stream()
-                .map(convertLocalizedStringProperty(languageCode))
-                .flatMap(StreamUtils.unwrapOptional())
-                .collect(StreamUtils.findOneOrNone());
+        return CustomProperties.localizedValueOf(customProperty, languageCode);
     }
 
+    /**
+     * @deprecated Use {@link LocalizedStringProperties#valueIn(VecLanguageCode)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecLocalizedStringProperty, Optional<String>> convertLocalizedStringProperty(
             final VecLanguageCode languageCode) {
         return localizedString -> Optional.ofNullable(localizedString)
-                .map(VecLocalizedStringProperty::getValue)
-                .filter(VecPredicates.languageCode(languageCode))
-                .map(VecLocalizedString::getValue);
+                .flatMap(LocalizedStringProperties.valueIn(languageCode));
     }
 
 }

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/navigations/DescriptionNavs.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/navigations/DescriptionNavs.java
@@ -75,7 +75,7 @@ public final class DescriptionNavs {
     /**
      * @deprecated Reduce the localized strings with {@link LocalizedStrings#valueIn(VecLanguageCode)}
      * instead, which composes onto any navigation leading to them, for example
-     * {@link Descriptions#descriptions()}.
+     * {@link Descriptions#toDescriptions()}.
      */
     @Deprecated(forRemoval = true)
     public static Function<List<? extends VecAbstractLocalizedString>, Optional<String>> germanString() {
@@ -85,7 +85,7 @@ public final class DescriptionNavs {
     /**
      * @deprecated Reduce the localized strings with {@link LocalizedStrings#valueIn(VecLanguageCode)}
      * instead, which composes onto any navigation leading to them, for example
-     * {@link Descriptions#descriptions()}.
+     * {@link Descriptions#toDescriptions()}.
      */
     @Deprecated(forRemoval = true)
     public static Function<List<? extends VecAbstractLocalizedString>, Optional<String>> englishString() {
@@ -95,7 +95,7 @@ public final class DescriptionNavs {
     /**
      * @deprecated Reduce the localized strings with {@link LocalizedStrings#valueIn(VecLanguageCode)}
      * instead, which composes onto any navigation leading to them, for example
-     * {@link Descriptions#descriptions()}.
+     * {@link Descriptions#toDescriptions()}.
      */
     @Deprecated(forRemoval = true)
     public static Function<List<? extends VecAbstractLocalizedString>, Optional<String>> stringIn(

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/navigations/DescriptionNavs.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/navigations/DescriptionNavs.java
@@ -29,6 +29,7 @@ import com.foursoft.harness.vec.common.HasDescription;
 import com.foursoft.harness.vec.v2x.VecAbstractLocalizedString;
 import com.foursoft.harness.vec.v2x.VecLanguageCode;
 import com.foursoft.harness.vec.v2x.traversal.Descriptions;
+import com.foursoft.harness.vec.v2x.traversal.LocalizedStrings;
 
 import java.util.List;
 import java.util.Optional;
@@ -72,28 +73,28 @@ public final class DescriptionNavs {
     }
 
     /**
-     * @deprecated Use {@link Descriptions#germanString()} instead.
+     * @deprecated Use {@link LocalizedStrings#germanString()} instead.
      */
     @Deprecated(forRemoval = true)
     public static Function<List<? extends VecAbstractLocalizedString>, Optional<String>> germanString() {
-        return Descriptions.germanString();
+        return LocalizedStrings.germanString();
     }
 
     /**
-     * @deprecated Use {@link Descriptions#englishString()} instead.
+     * @deprecated Use {@link LocalizedStrings#englishString()} instead.
      */
     @Deprecated(forRemoval = true)
     public static Function<List<? extends VecAbstractLocalizedString>, Optional<String>> englishString() {
-        return Descriptions.englishString();
+        return LocalizedStrings.englishString();
     }
 
     /**
-     * @deprecated Use {@link Descriptions#stringIn(VecLanguageCode)} instead.
+     * @deprecated Use {@link LocalizedStrings#stringIn(VecLanguageCode)} instead.
      */
     @Deprecated(forRemoval = true)
     public static Function<List<? extends VecAbstractLocalizedString>, Optional<String>> stringIn(
             final VecLanguageCode vecLanguageCode) {
-        return Descriptions.stringIn(vecLanguageCode);
+        return LocalizedStrings.stringIn(vecLanguageCode);
     }
 
     /**

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/navigations/DescriptionNavs.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/navigations/DescriptionNavs.java
@@ -73,28 +73,36 @@ public final class DescriptionNavs {
     }
 
     /**
-     * @deprecated Use {@link LocalizedStrings#germanString()} instead.
+     * @deprecated Reduce the localized strings with {@link LocalizedStrings#valueIn(VecLanguageCode)}
+     * instead, which composes onto any navigation leading to them, for example
+     * {@link Descriptions#descriptions()}.
      */
     @Deprecated(forRemoval = true)
     public static Function<List<? extends VecAbstractLocalizedString>, Optional<String>> germanString() {
-        return LocalizedStrings.germanString();
+        return stringIn(VecLanguageCode.DE);
     }
 
     /**
-     * @deprecated Use {@link LocalizedStrings#englishString()} instead.
+     * @deprecated Reduce the localized strings with {@link LocalizedStrings#valueIn(VecLanguageCode)}
+     * instead, which composes onto any navigation leading to them, for example
+     * {@link Descriptions#descriptions()}.
      */
     @Deprecated(forRemoval = true)
     public static Function<List<? extends VecAbstractLocalizedString>, Optional<String>> englishString() {
-        return LocalizedStrings.englishString();
+        return stringIn(VecLanguageCode.EN);
     }
 
     /**
-     * @deprecated Use {@link LocalizedStrings#stringIn(VecLanguageCode)} instead.
+     * @deprecated Reduce the localized strings with {@link LocalizedStrings#valueIn(VecLanguageCode)}
+     * instead, which composes onto any navigation leading to them, for example
+     * {@link Descriptions#descriptions()}.
      */
     @Deprecated(forRemoval = true)
     public static Function<List<? extends VecAbstractLocalizedString>, Optional<String>> stringIn(
             final VecLanguageCode vecLanguageCode) {
-        return LocalizedStrings.stringIn(vecLanguageCode);
+        return localizedStrings -> localizedStrings.stream()
+                .map(VecAbstractLocalizedString.class::cast)
+                .collect(LocalizedStrings.valueIn(vecLanguageCode));
     }
 
     /**

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/navigations/DescriptionNavs.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/navigations/DescriptionNavs.java
@@ -26,95 +26,101 @@
 package com.foursoft.harness.vec.v2x.navigations;
 
 import com.foursoft.harness.vec.common.HasDescription;
-import com.foursoft.harness.vec.common.util.StreamUtils;
-import com.foursoft.harness.vec.common.util.StringUtils;
 import com.foursoft.harness.vec.v2x.VecAbstractLocalizedString;
 import com.foursoft.harness.vec.v2x.VecLanguageCode;
-import com.foursoft.harness.vec.v2x.VecLocalizedTypedString;
-import com.foursoft.harness.vec.v2x.predicates.VecPredicates;
+import com.foursoft.harness.vec.v2x.traversal.Descriptions;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 
 /**
  * Navigation methods for {@link HasDescription} with {@link VecAbstractLocalizedString}s.
+ *
+ * @deprecated Use {@link Descriptions} instead.
  */
+@Deprecated(forRemoval = true)
 public final class DescriptionNavs {
 
     private DescriptionNavs() {
         // hide default constructor
     }
 
+    /**
+     * @deprecated Use {@link Descriptions#germanDescription()} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<HasDescription<? extends VecAbstractLocalizedString>, Optional<String>> germanDescription() {
-        return descriptionIn(VecLanguageCode.DE);
+        return Descriptions.germanDescription();
     }
 
+    /**
+     * @deprecated Use {@link Descriptions#englishDescription()} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<HasDescription<? extends VecAbstractLocalizedString>, Optional<String>> englishDescription() {
-        return descriptionIn(VecLanguageCode.EN);
+        return Descriptions.englishDescription();
     }
 
+    /**
+     * @deprecated Use {@link Descriptions#descriptionIn(VecLanguageCode)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<HasDescription<? extends VecAbstractLocalizedString>, Optional<String>> descriptionIn(
             final VecLanguageCode vecLanguageCode) {
-        return descHolder -> {
-            final List<? extends VecAbstractLocalizedString> localizedStrings = descHolder.getDescriptions();
-            return stringIn(vecLanguageCode).apply(localizedStrings);
-        };
+        return Descriptions.descriptionIn(vecLanguageCode);
     }
 
+    /**
+     * @deprecated Use {@link Descriptions#germanString()} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<List<? extends VecAbstractLocalizedString>, Optional<String>> germanString() {
-        return stringIn(VecLanguageCode.DE);
+        return Descriptions.germanString();
     }
 
+    /**
+     * @deprecated Use {@link Descriptions#englishString()} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<List<? extends VecAbstractLocalizedString>, Optional<String>> englishString() {
-        return stringIn(VecLanguageCode.EN);
+        return Descriptions.englishString();
     }
 
+    /**
+     * @deprecated Use {@link Descriptions#stringIn(VecLanguageCode)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<List<? extends VecAbstractLocalizedString>, Optional<String>> stringIn(
             final VecLanguageCode vecLanguageCode) {
-        return localizedStrings -> {
-            if (localizedStrings.isEmpty()) {
-                return Optional.empty();
-            }
-            if (localizedStrings.size() == 1) {
-                final VecAbstractLocalizedString localizedString = localizedStrings.get(0);
-                if (localizedString instanceof VecLocalizedTypedString &&
-                        !StringUtils.isEmpty(((VecLocalizedTypedString) localizedString).getType())) {
-                    return Optional.empty();
-                }
-                return Optional.ofNullable(localizedString).map(VecAbstractLocalizedString::getValue);
-            }
-
-            return localizedStrings.stream()
-                    .filter(Objects::nonNull)
-                    .filter(d -> !(d instanceof VecLocalizedTypedString))
-                    .filter(VecPredicates.languageCode(vecLanguageCode))
-                    .map(VecAbstractLocalizedString::getValue)
-                    .filter(Objects::nonNull)
-                    .collect(StreamUtils.findOneOrNone());
-        };
+        return Descriptions.stringIn(vecLanguageCode);
     }
 
+    /**
+     * @deprecated Use {@link Descriptions#germanTypedStringBy(String)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<HasDescription<? extends VecAbstractLocalizedString>, Optional<String>> germanTypedStringBy(
             final String descriptionType) {
-        return typedStringBy(descriptionType, VecLanguageCode.DE);
+        return Descriptions.germanTypedStringBy(descriptionType);
     }
 
+    /**
+     * @deprecated Use {@link Descriptions#englishTypedStringBy(String)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<HasDescription<? extends VecAbstractLocalizedString>, Optional<String>> englishTypedStringBy(
             final String descriptionType) {
-        return typedStringBy(descriptionType, VecLanguageCode.EN);
+        return Descriptions.englishTypedStringBy(descriptionType);
     }
 
+    /**
+     * @deprecated Use {@link Descriptions#typedStringBy(String, VecLanguageCode)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<HasDescription<? extends VecAbstractLocalizedString>, Optional<String>> typedStringBy(
             final String descriptionType, final VecLanguageCode vecLanguageCode) {
-        return hasDescription -> hasDescription.getDescriptions().stream()
-                .filter(VecPredicates.languageCode(vecLanguageCode))
-                .flatMap(StreamUtils.ofClass(VecLocalizedTypedString.class))
-                .filter(typedString -> descriptionType.equals(typedString.getType()))
-                .collect(StreamUtils.findOneOrNone())
-                .map(VecLocalizedTypedString::getValue)
-                .filter(StringUtils::isNotEmpty);
+        return Descriptions.typedStringBy(descriptionType, vecLanguageCode);
     }
 
 }

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/navigations/DocumentVersionNavs.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/navigations/DocumentVersionNavs.java
@@ -2,7 +2,7 @@
  * ========================LICENSE_START=================================
  * VEC 2.X
  * %%
- * Copyright (C) 2020 - 2023 4Soft GmbH
+ * Copyright (C) 2020 - 2026 4Soft GmbH
  * %%
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -10,10 +10,10 @@
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * 
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -25,65 +25,75 @@
  */
 package com.foursoft.harness.vec.v2x.navigations;
 
-import com.foursoft.harness.vec.common.util.StreamUtils;
-import com.foursoft.harness.vec.v2x.*;
+import com.foursoft.harness.vec.v2x.VecBuildingBlockPositioning2D;
+import com.foursoft.harness.vec.v2x.VecBuildingBlockPositioning3D;
+import com.foursoft.harness.vec.v2x.VecBuildingBlockSpecification2D;
+import com.foursoft.harness.vec.v2x.VecBuildingBlockSpecification3D;
+import com.foursoft.harness.vec.v2x.VecDocumentVersion;
+import com.foursoft.harness.vec.v2x.VecGeometryNode2D;
+import com.foursoft.harness.vec.v2x.VecGeometryNode3D;
+import com.foursoft.harness.vec.v2x.VecGeometrySegment3D;
+import com.foursoft.harness.vec.v2x.VecNodeLocation;
+import com.foursoft.harness.vec.v2x.VecOccurrenceOrUsage;
+import com.foursoft.harness.vec.v2x.VecOccurrenceOrUsageViewItem2D;
+import com.foursoft.harness.vec.v2x.VecOccurrenceOrUsageViewItem3D;
+import com.foursoft.harness.vec.v2x.VecOnPointPlacement;
+import com.foursoft.harness.vec.v2x.VecPlaceableElementRole;
+import com.foursoft.harness.vec.v2x.VecPlacement;
+import com.foursoft.harness.vec.v2x.VecTopologyNode;
+import com.foursoft.harness.vec.v2x.VecTopologySegment;
+import com.foursoft.harness.vec.v2x.traversal.DocumentVersions;
 
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
-import java.util.stream.Stream;
 
 /**
  * Navigation methods for the {@link VecDocumentVersion}.
+ *
+ * @deprecated Use {@link DocumentVersions} instead.
  */
+@Deprecated(forRemoval = true)
 public final class DocumentVersionNavs {
 
     private DocumentVersionNavs() {
         // hide default constructor
     }
 
+    /**
+     * @deprecated Use {@link DocumentVersions#geometryNodes3dBy(VecTopologyNode)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecDocumentVersion, List<VecGeometryNode3D>> geometryNodes3dBy(
             final VecTopologyNode topologyNode) {
-        return documentVersion -> documentVersion.getSpecificationsWithType(VecBuildingBlockSpecification3D.class)
-                .stream()
-                .map(VecBuildingBlockSpecification3D::getGeometryNodes)
-                .flatMap(Collection::stream)
-                .filter(node3d -> node3d.getReferenceNode().equals(topologyNode))
-                .toList();
+        return DocumentVersions.geometryNodes3dBy(topologyNode)::listFrom;
     }
 
+    /**
+     * @deprecated Use {@link DocumentVersions#geometrySegments3dBy(VecTopologySegment)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecDocumentVersion, List<VecGeometrySegment3D>> geometrySegments3dBy(
             final VecTopologySegment topologySegment) {
-        return documentVersion -> documentVersion.getSpecificationsWithType(VecBuildingBlockSpecification3D.class)
-                .stream()
-                .map(VecBuildingBlockSpecification3D::getGeometrySegments)
-                .flatMap(Collection::stream)
-                .filter(segment3d -> segment3d.getReferenceSegment().equals(topologySegment))
-                .toList();
+        return DocumentVersions.geometrySegments3dBy(topologySegment)::listFrom;
     }
 
+    /**
+     * @deprecated Use {@link DocumentVersions#viewItems3dBy(VecOccurrenceOrUsage)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecDocumentVersion, List<VecOccurrenceOrUsageViewItem3D>> viewItems3dBy(
             final VecOccurrenceOrUsage occurrence) {
-        return documentVersion -> documentVersion.getSpecificationsWithType(VecBuildingBlockSpecification3D.class)
-                .stream()
-                .map(specification -> specification
-                        .getPlacedElementViewItem3Ds().stream()
-                        .filter(viewItem -> viewItem.getOccurrenceOrUsage().contains(occurrence))
-                        .toList())
-                .flatMap(Collection::stream)
-                .toList();
+        return DocumentVersions.viewItems3dBy(occurrence)::listFrom;
     }
 
+    /**
+     * @deprecated Use {@link DocumentVersions#topologyNodeBy(String)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecDocumentVersion, Optional<VecTopologyNode>> topologyNodeBy(
             final String occurrenceIdentification) {
-        return documentVersion -> SpecificationNavs.components().apply(documentVersion)
-                .stream()
-                .filter(occurrence -> occurrence.getIdentification().equals(occurrenceIdentification))
-                .map(PartOccurrenceOrUsageNavs.topologyNodeByOccurrenceOrUsage())
-                .flatMap(StreamUtils.unwrapOptional())
-                .collect(StreamUtils.findOneOrNone());
+        return DocumentVersions.topologyNodeBy(occurrenceIdentification);
     }
 
     /**
@@ -92,142 +102,107 @@ public final class DocumentVersionNavs {
      * @param placedElement Placed Element the {@link VecOnPointPlacement} needs to contain.
      *                      May be {@code null} to not filter for this.
      * @return A possibly-empty list of VecNodeLocations.
+     * @deprecated Use {@link DocumentVersions#nodeLocationsOf(VecPlaceableElementRole)} instead, or
+     * {@link DocumentVersions#toNodeLocations()} for the unfiltered navigation which passing {@code null}
+     * stood for.
      */
+    @Deprecated(forRemoval = true)
     public static Function<VecDocumentVersion, List<VecNodeLocation>> nodeLocationsBy(
             final VecPlaceableElementRole placedElement) {
-        return documentVersion -> documentVersion
-                .getSpecificationsWithType(VecPlacementSpecification.class).stream()
-                .map(VecPlacementSpecification::getPlacements)
-                .flatMap(Collection::stream)
-                .filter(VecOnPointPlacement.class::isInstance)
-                .map(VecOnPointPlacement.class::cast)
-                .filter(c -> placedElement == null || c.getPlacedElement().contains(placedElement))
-                .map(VecOnPointPlacement::getLocations)
-                .flatMap(Collection::stream)
-                .filter(VecNodeLocation.class::isInstance)
-                .map(VecNodeLocation.class::cast)
-                .toList();
+        return placedElement == null
+                ? DocumentVersions.toNodeLocations()::listFrom
+                : DocumentVersions.nodeLocationsOf(placedElement)::listFrom;
     }
 
+    /**
+     * @deprecated Use {@link DocumentVersions#placeableElementRoleBy(String, String)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecDocumentVersion, VecPlaceableElementRole> placeableElementRoleBy(
             final String compositionSpecificationId,
             final String occurrenceOrUsageId) {
-        return documentVersion -> SpecificationNavs.componentsBy(compositionSpecificationId).apply(documentVersion)
-                .stream()
-                .filter(c -> c.getIdentification().equals(occurrenceOrUsageId))
-                .map(VecPartOccurrence::getRoles)
-                .flatMap(Collection::stream)
-                .filter(VecPlaceableElementRole.class::isInstance)
-                .map(VecPlaceableElementRole.class::cast)
-                .collect(StreamUtils.findOneOrNone()).orElse(null);
+        return DocumentVersions.placeableElementRoleBy(compositionSpecificationId, occurrenceOrUsageId)::orElseNull;
     }
 
+    /**
+     * @deprecated Use {@link DocumentVersions#placementBy(String, String)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecDocumentVersion, VecPlacement> placementBy(final String compositionSpecificationId,
-                                                                         final String occurrenceOrUsageId) {
-        return documentVersion -> {
-            final VecPlaceableElementRole role =
-                    placeableElementRoleBy(compositionSpecificationId, occurrenceOrUsageId).apply(documentVersion);
-
-            return documentVersion.getSpecificationsWithType(VecPlacementSpecification.class).stream()
-                    .map(VecPlacementSpecification::getPlacements)
-                    .flatMap(Collection::stream)
-                    .filter(p -> p.getPlacedElement().stream().anyMatch(r -> r.equals(role)))
-                    .collect(StreamUtils.findOneOrNone()).orElse(null);
-        };
+                                                                        final String occurrenceOrUsageId) {
+        return DocumentVersions.placementBy(compositionSpecificationId, occurrenceOrUsageId)::orElseNull;
     }
 
+    /**
+     * @deprecated Use {@link DocumentVersions#geometryNode2dBy(VecNodeLocation)} instead, which searches all
+     * {@link VecBuildingBlockSpecification2D}s of the document version rather than only the first one.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecDocumentVersion, VecGeometryNode2D> geometryNode2dBy(final VecNodeLocation location) {
-        return documentVersion -> {
-            final List<VecGeometryNode2D> nodes = documentVersion
-                    .getSpecificationWithType(VecBuildingBlockSpecification2D.class)
-                    .map(VecBuildingBlockSpecification2D::getGeometryNodes)
-                    .orElseGet(Collections::emptyList);
-            return getGeometryNode(nodes, location);
-        };
+        return DocumentVersions.geometryNode2dBy(location)::orElseNull;
     }
 
+    /**
+     * @deprecated Use {@link DocumentVersions#geometryNode3dBy(VecNodeLocation)} instead, which searches all
+     * {@link VecBuildingBlockSpecification3D}s of the document version rather than only the first one.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecDocumentVersion, VecGeometryNode3D> geometryNode3dBy(final VecNodeLocation location) {
-        return documentVersion -> {
-            final List<VecGeometryNode3D> nodes = documentVersion
-                    .getSpecificationWithType(VecBuildingBlockSpecification3D.class)
-                    .map(VecBuildingBlockSpecification3D::getGeometryNodes)
-                    .orElseGet(Collections::emptyList);
-            return getGeometryNode(nodes, location);
-        };
+        return DocumentVersions.geometryNode3dBy(location)::orElseNull;
     }
 
+    /**
+     * @deprecated Use {@link DocumentVersions#viewItem2dBy(String)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecDocumentVersion, Optional<VecOccurrenceOrUsageViewItem2D>> viewItem2dBy(
             final String occurrenceOrUsageId) {
-        return documentVersion -> {
-            final Stream<VecOccurrenceOrUsageViewItem2D> stream = documentVersion
-                    .getSpecificationsWithType(VecBuildingBlockSpecification2D.class)
-                    .stream()
-                    .map(VecBuildingBlockSpecification2D::getPlacedElementViewItems)
-                    .flatMap(Collection::stream);
-            return getViewItem(stream, occurrenceOrUsageId);
-        };
+        return DocumentVersions.viewItem2dBy(occurrenceOrUsageId);
     }
 
+    /**
+     * @deprecated Use {@link DocumentVersions#viewItem3dBy(String)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecDocumentVersion, Optional<VecOccurrenceOrUsageViewItem3D>> viewItem3dBy(
             final String occurrenceOrUsageId) {
-        return documentVersion -> {
-            final Stream<VecOccurrenceOrUsageViewItem3D> stream = documentVersion
-                    .getSpecificationsWithType(VecBuildingBlockSpecification3D.class)
-                    .stream()
-                    .map(VecBuildingBlockSpecification3D::getPlacedElementViewItem3Ds)
-                    .flatMap(Collection::stream);
-            return getViewItem(stream, occurrenceOrUsageId);
-        };
+        return DocumentVersions.viewItem3dBy(occurrenceOrUsageId);
     }
 
+    /**
+     * @deprecated Use {@link DocumentVersions#buildingBlockSpecification2dBy(String)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecDocumentVersion, Optional<VecBuildingBlockSpecification2D>> buildingBlockSpecification2dBy(
             final String specificationId) {
-        return documentVersion -> documentVersion
-                .getSpecificationWith(VecBuildingBlockSpecification2D.class, specificationId);
+        return DocumentVersions.buildingBlockSpecification2dBy(specificationId);
     }
 
+    /**
+     * @deprecated Use {@link DocumentVersions#buildingBlockSpecification3dBy(String)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecDocumentVersion, Optional<VecBuildingBlockSpecification3D>> buildingBlockSpecification3dBy(
             final String specificationId) {
-        return documentVersion -> documentVersion
-                .getSpecificationWith(VecBuildingBlockSpecification3D.class, specificationId);
+        return DocumentVersions.buildingBlockSpecification3dBy(specificationId);
     }
 
+    /**
+     * @deprecated Use {@link DocumentVersions#positioning2dWith(VecBuildingBlockSpecification2D)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecDocumentVersion, Optional<VecBuildingBlockPositioning2D>> positioning2dWith(
             final VecBuildingBlockSpecification2D buildingBlock) {
-        return documentVersion -> documentVersion
-                .getSpecificationsWithType(VecHarnessDrawingSpecification2D.class).stream()
-                .map(VecHarnessDrawingSpecification2D::getBuildingBlockPositionings)
-                .flatMap(Collection::stream)
-                .filter(positioning -> buildingBlock.equals(positioning.getReferenced2DBuildingBlock()))
-                .collect(StreamUtils.findOneOrNone());
+        return DocumentVersions.positioning2dWith(buildingBlock);
     }
 
+    /**
+     * @deprecated Use {@link DocumentVersions#positioning3dWith(VecBuildingBlockSpecification3D)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecDocumentVersion, Optional<VecBuildingBlockPositioning3D>> positioning3dWith(
             final VecBuildingBlockSpecification3D buildingBlock) {
-        return documentVersion -> documentVersion
-                .getSpecificationsWithType(VecHarnessGeometrySpecification3D.class).stream()
-                .map(VecHarnessGeometrySpecification3D::getBuildingBlockPositionings)
-                .flatMap(Collection::stream)
-                .filter(positioning -> buildingBlock.equals(positioning.getReferenced3DBuildingBlock()))
-                .collect(StreamUtils.findOneOrNone());
-    }
-
-    private static <T extends VecGeometryNode> T getGeometryNode(final List<T> nodes,
-                                                                 final VecNodeLocation location) {
-        return nodes.stream()
-                .filter(node -> node.getReferenceNode().equals(location.getReferencedNode()))
-                .collect(StreamUtils.findOneOrNone()).orElse(null);
-    }
-
-    private static <T extends HasOccurrenceOrUsages> Optional<T> getViewItem(final Stream<T> stream,
-                                                                             final String occurrenceOrUsageId) {
-        return stream
-                .filter(item -> item.getOccurrenceOrUsage().stream()
-                        .collect(StreamUtils.findOneOrNone())
-                        .map(VecOccurrenceOrUsage::getIdentification)
-                        .map(id -> id.equals(occurrenceOrUsageId))
-                        .orElse(false))
-                .collect(StreamUtils.findOneOrNone());
+        return DocumentVersions.positioning3dWith(buildingBlock);
     }
 
 }

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/navigations/DocumentVersionNavs.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/navigations/DocumentVersionNavs.java
@@ -33,7 +33,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/navigations/PartOccurrenceOrUsageNavs.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/navigations/PartOccurrenceOrUsageNavs.java
@@ -2,7 +2,7 @@
  * ========================LICENSE_START=================================
  * VEC 2.X
  * %%
- * Copyright (C) 2020 - 2023 4Soft GmbH
+ * Copyright (C) 2020 - 2026 4Soft GmbH
  * %%
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -10,10 +10,10 @@
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * 
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,13 +26,19 @@
 package com.foursoft.harness.vec.v2x.navigations;
 
 import com.foursoft.harness.vec.common.annotations.RequiresBackReferences;
-import com.foursoft.harness.vec.common.util.StreamUtils;
-import com.foursoft.harness.vec.common.util.StringUtils;
-import com.foursoft.harness.vec.v2x.*;
-import com.foursoft.harness.vec.v2x.visitor.ReferencedNodeLocationVisitor;
+import com.foursoft.harness.vec.common.traversal.MultiNavigation;
+import com.foursoft.harness.vec.v2x.VecDocumentVersion;
+import com.foursoft.harness.vec.v2x.VecModuleFamily;
+import com.foursoft.harness.vec.v2x.VecOccurrenceOrUsage;
+import com.foursoft.harness.vec.v2x.VecPartOccurrence;
+import com.foursoft.harness.vec.v2x.VecPartOrUsageRelatedSpecification;
+import com.foursoft.harness.vec.v2x.VecPartUsage;
+import com.foursoft.harness.vec.v2x.VecPrimaryPartType;
+import com.foursoft.harness.vec.v2x.VecTopologyNode;
+import com.foursoft.harness.vec.v2x.traversal.DocumentVersions;
+import com.foursoft.harness.vec.v2x.traversal.OccurrenceOrUsages;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.BiFunction;
@@ -40,7 +46,11 @@ import java.util.function.Function;
 
 /**
  * Navigation methods for the {@link VecOccurrenceOrUsage} including {@link VecPartOccurrence} and {@link VecPartUsage}.
+ *
+ * @deprecated Use {@link OccurrenceOrUsages} instead, which starts at the family wherever both sub types lead
+ * to the same target and therefore needs no {@code OfOccurrence} and {@code OfUsage} suffixes.
  */
+@Deprecated(forRemoval = true)
 public final class PartOccurrenceOrUsageNavs {
 
     private PartOccurrenceOrUsageNavs() {
@@ -49,57 +59,67 @@ public final class PartOccurrenceOrUsageNavs {
 
     // VecPartUsage
 
+    /**
+     * @deprecated Use {@link OccurrenceOrUsages#toParentDocumentNumber()} instead.
+     */
+    @Deprecated(forRemoval = true)
     @RequiresBackReferences
     public static Function<VecPartUsage, String> parentDocumentNumberOfUsage() {
-        return usage -> parentDocumentVersionOfUsage().apply(usage).getDocumentNumber();
+        return OccurrenceOrUsages.toParentDocumentNumber()::orElseNull;
     }
 
+    /**
+     * @deprecated Use {@link OccurrenceOrUsages#toParentDocumentVersion()} instead.
+     */
+    @Deprecated(forRemoval = true)
     @RequiresBackReferences
     public static Function<VecPartUsage, VecDocumentVersion> parentDocumentVersionOfUsage() {
-        return usage -> {
-            final VecPartUsageSpecification partUsageSpec = usage.getParentPartUsageSpecification();
-            return SpecificationNavs.parentDocumentVersion().apply(partUsageSpec);
-        };
+        return OccurrenceOrUsages.toParentDocumentVersion()::orElseNull;
     }
 
     // VecPartOccurrence
 
+    /**
+     * @deprecated Use {@link OccurrenceOrUsages#toParentDocumentNumber()} instead.
+     */
+    @Deprecated(forRemoval = true)
     @RequiresBackReferences
     public static Function<VecPartOccurrence, String> parentDocumentNumberOfOccurrence() {
-        return occurrence -> parentDocumentVersionOfOccurrence().apply(occurrence).getDocumentNumber();
+        return OccurrenceOrUsages.toParentDocumentNumber()::orElseNull;
     }
 
+    /**
+     * @deprecated Use {@link OccurrenceOrUsages#toPartNumber()} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecPartOccurrence, Optional<String>> partNumber() {
-        return occurrence -> Optional.of(occurrence)
-                .map(VecPartOccurrence::getPart)
-                .map(VecPartVersion::getPartNumber)
-                .map(StringUtils::collapseMultipleWhitespaces);
+        return OccurrenceOrUsages.toPartNumber();
     }
 
+    /**
+     * @deprecated Use {@link OccurrenceOrUsages#toPartVersion()} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecPartOccurrence, Optional<String>> partVersion() {
-        return occurrence -> Optional.of(occurrence)
-                .map(VecPartOccurrence::getPart)
-                .map(VecPartVersion::getPartVersion)
-                .map(StringUtils::collapseMultipleWhitespaces);
+        return OccurrenceOrUsages.toPartVersion();
     }
 
+    /**
+     * @deprecated Use {@link OccurrenceOrUsages#toPrimaryPartType()} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecPartOccurrence, VecPrimaryPartType> primaryPartTypeOfOccurrence() {
-        return occurrence -> {
-            final VecPartVersion partVersion = occurrence.getPart();
-            return partVersion != null
-                    ? partVersion.getPrimaryPartType()
-                    :
-                    occurrence.getRealizedPartUsage()
-                            .stream()
-                            .collect(StreamUtils.findOneOrNone())
-                            .map(VecPartUsage::getPrimaryPartUsageType)
-                            .orElse(VecPrimaryPartType.OTHER);
-        };
+        return OccurrenceOrUsages.toPrimaryPartType()::orElseNull;
     }
 
+    /**
+     * @deprecated Use {@link OccurrenceOrUsages#toPartOrUsageRelatedSpecifications()} instead.
+     */
+    @Deprecated(forRemoval = true)
     @RequiresBackReferences
     public static Function<VecPartOccurrence, List<VecPartOrUsageRelatedSpecification>> partOrUsageRelatedSpecificationsOfOccurrence() {
-        return occurrence -> new ArrayList<>(occurrence.getPart().getRefPartOrUsageRelatedSpecification());
+        return occurrence -> new ArrayList<>(
+                OccurrenceOrUsages.toPartOrUsageRelatedSpecifications().listFrom(occurrence));
     }
 
     /**
@@ -108,16 +128,12 @@ public final class PartOccurrenceOrUsageNavs {
      * <b>Warning: This uses {@link RequiresBackReferences back references}!</b>
      *
      * @return The parent VecDocumentVersion of a VecPartOccurrence.
+     * @deprecated Use {@link OccurrenceOrUsages#toParentDocumentVersion()} instead.
      */
+    @Deprecated(forRemoval = true)
     @RequiresBackReferences
     public static Function<VecPartOccurrence, VecDocumentVersion> parentDocumentVersionOfOccurrence() {
-        return occurrence -> {
-
-            final VecCompositionSpecification parentCompositionSpecification =
-                    occurrence.getParentCompositionSpecification();
-
-            return SpecificationNavs.parentDocumentVersion().apply(parentCompositionSpecification);
-        };
+        return OccurrenceOrUsages.toParentDocumentVersion()::orElseNull;
     }
 
     /**
@@ -125,86 +141,86 @@ public final class PartOccurrenceOrUsageNavs {
      * Note that the PartOccurrence has to be a module in order to be checked.
      *
      * @return An empty optional if the tested PartOccurrence is not a module or if no family was found.
+     * @deprecated Use {@link OccurrenceOrUsages#toModuleFamily()} instead.
      */
+    @Deprecated(forRemoval = true)
     public static Function<VecPartOccurrence, Optional<VecModuleFamily>> moduleFamily() {
-        return occurrence -> {
-            // Can also be an assembly though!
-            final boolean isModule = occurrence.getPart().getPrimaryPartType() == VecPrimaryPartType.PART_STRUCTURE;
-
-            return !isModule
-                    ? Optional.empty()
-                    :
-                    occurrence.getRolesWithType(VecPartWithSubComponentsRole.class).stream()
-                            .flatMap(StreamUtils.toStream(VecPartWithSubComponentsRole::getRefModuleFamily))
-                            .collect(StreamUtils.findOneOrNone());
-        };
+        return OccurrenceOrUsages.toModuleFamily();
     }
 
     // VecOccurrenceOrUsage
 
+    /**
+     * @deprecated Use {@link OccurrenceOrUsages#toParentDocumentNumber()} instead.
+     */
+    @Deprecated(forRemoval = true)
     @RequiresBackReferences
     public static Function<VecOccurrenceOrUsage, String> parentDocumentNumber() {
-        return occurrenceOrUsage -> parentDocumentVersion().apply(occurrenceOrUsage).getDocumentNumber();
+        return OccurrenceOrUsages.toParentDocumentNumber()::orElseNull;
     }
 
+    /**
+     * @deprecated Use {@link OccurrenceOrUsages#toParentDocumentVersion()} instead.
+     */
+    @Deprecated(forRemoval = true)
     @RequiresBackReferences
     public static Function<VecOccurrenceOrUsage, VecDocumentVersion> parentDocumentVersion() {
-        return occurrenceOrUsage -> {
-            if (occurrenceOrUsage instanceof VecPartOccurrence) {
-                return parentDocumentVersionOfOccurrence().apply((VecPartOccurrence) occurrenceOrUsage);
-            }
-            return parentDocumentVersionOfUsage().apply((VecPartUsage) occurrenceOrUsage);
-        };
+        return OccurrenceOrUsages.toParentDocumentVersion()::orElseNull;
     }
 
+    /**
+     * @deprecated Use {@link DocumentVersions#topologyNodeOf(VecOccurrenceOrUsage)} instead, which is a
+     * navigation from the document version rather than a function of two arguments.
+     */
+    @Deprecated(forRemoval = true)
     public static BiFunction<VecOccurrenceOrUsage, VecDocumentVersion, Optional<VecTopologyNode>> findNodeOfComponent() {
-        return (component, documentVersion) -> component.getRoleWithType(VecPlaceableElementRole.class)
-                .flatMap(placedElement -> DocumentVersionNavs
-                        .nodeLocationsBy(placedElement)
-                        .apply(documentVersion)
-                        .stream()
-                        .collect(StreamUtils.findOneOrNone()))
-                .map(VecNodeLocation::getReferencedNode);
+        return (component, documentVersion) -> DocumentVersions.topologyNodeOf(component).from(documentVersion);
     }
 
+    /**
+     * @deprecated Use {@link OccurrenceOrUsages#toReferencedTopologyNode()} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecOccurrenceOrUsage, Optional<VecTopologyNode>> topologyNodeByOccurrenceOrUsage() {
-        final ReferencedNodeLocationVisitor visitor = new ReferencedNodeLocationVisitor();
-        return occurrence -> occurrence.getRolesWithType(VecPlaceableElementRole.class).stream()
-                .map(VecPlaceableElementRole::getRefPlacement)
-                .flatMap(Collection::stream)
-                .filter(VecOnPointPlacement.class::isInstance)
-                .map(VecOnPointPlacement.class::cast)
-                .map(VecOnPointPlacement::getLocations)
-                .flatMap(Collection::stream)
-                .map(location -> location.accept(visitor))
-                .collect(StreamUtils.findOneOrNone());
+        return OccurrenceOrUsages.toReferencedTopologyNode();
     }
 
+    /**
+     * @deprecated Use {@link OccurrenceOrUsages#toPrimaryPartType()} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecOccurrenceOrUsage, VecPrimaryPartType> primaryPartType() {
-        return occurrenceOrUsage -> {
-            if (occurrenceOrUsage instanceof VecPartOccurrence) {
-                return primaryPartTypeOfOccurrence().apply((VecPartOccurrence) occurrenceOrUsage);
-            }
-            return ((VecPartUsage) occurrenceOrUsage).getPrimaryPartUsageType();
-        };
+        return OccurrenceOrUsages.toPrimaryPartType()::orElseNull;
     }
 
+    /**
+     * @deprecated Use {@link OccurrenceOrUsages#toPartOrUsageRelatedSpecifications()} instead.
+     */
+    @Deprecated(forRemoval = true)
     @RequiresBackReferences
     public static Function<VecOccurrenceOrUsage, List<VecPartOrUsageRelatedSpecification>> partOrUsageRelatedSpecifications() {
-        return occurrenceOrUsage -> {
-            if (occurrenceOrUsage instanceof VecPartOccurrence) {
-                return partOrUsageRelatedSpecificationsOfOccurrence().apply((VecPartOccurrence) occurrenceOrUsage);
-            }
-            return ((VecPartUsage) occurrenceOrUsage).getPartOrUsageRelatedSpecification();
-        };
+        return occurrenceOrUsage -> new ArrayList<>(
+                OccurrenceOrUsages.toPartOrUsageRelatedSpecifications().listFrom(occurrenceOrUsage));
     }
 
+    /**
+     * @deprecated Narrow the navigation leading to the occurrences or usages with
+     * {@link MultiNavigation#ofType(Class)} instead, for example
+     * {@code SpecificationOwners.toOccurrenceOrUsages().ofType(VecPartOccurrence.class)}.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecOccurrenceOrUsage, Optional<VecPartOccurrence>> occurrence() {
         return occurrenceOrUsage -> Optional.of(occurrenceOrUsage)
                 .filter(VecPartOccurrence.class::isInstance)
                 .map(VecPartOccurrence.class::cast);
     }
 
+    /**
+     * @deprecated Narrow the navigation leading to the occurrences or usages with
+     * {@link MultiNavigation#ofType(Class)} instead, for example
+     * {@code SpecificationOwners.toOccurrenceOrUsages().ofType(VecPartUsage.class)}.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecOccurrenceOrUsage, Optional<VecPartUsage>> usage() {
         return occurrenceOrUsage -> Optional.of(occurrenceOrUsage)
                 .filter(VecPartUsage.class::isInstance)

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/navigations/PlacementNavs.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/navigations/PlacementNavs.java
@@ -50,19 +50,19 @@ public final class PlacementNavs {
     }
 
     /**
-     * @deprecated Use {@link PlaceableElementRoles#onPointPlacements()} instead.
+     * @deprecated Use {@link PlaceableElementRoles#toOnPointPlacements()} instead.
      */
     @Deprecated(forRemoval = true)
     public static Function<VecPlaceableElementRole, Stream<VecOnPointPlacement>> onPointPlacement() {
-        return PlaceableElementRoles.onPointPlacements();
+        return PlaceableElementRoles.toOnPointPlacements();
     }
 
     /**
-     * @deprecated Use {@link PlaceableElementRoles#onWayPlacements()} instead.
+     * @deprecated Use {@link PlaceableElementRoles#toOnWayPlacements()} instead.
      */
     @Deprecated(forRemoval = true)
     public static Function<VecPlaceableElementRole, Stream<VecOnWayPlacement>> onWayPlacement() {
-        return PlaceableElementRoles.onWayPlacements();
+        return PlaceableElementRoles.toOnWayPlacements();
     }
 
     /**
@@ -73,26 +73,26 @@ public final class PlacementNavs {
      * {@link VecOccurrenceOrUsageViewItem3D} or {@link VecOccurrenceOrUsageViewItem2D}.
      * @see #onPointPlacement()
      * @deprecated Compose the navigation at the call site instead, which also works for
-     * {@link PlaceableElementRoles#onWayPlacements()}:
-     * {@code ViewItems.placeableElementRole().then(PlaceableElementRoles.onPointPlacements())
-     * .then(Placements.locations())}.
+     * {@link PlaceableElementRoles#toOnWayPlacements()}:
+     * {@code ViewItems.toPlaceableElementRole().then(PlaceableElementRoles.toOnPointPlacements())
+     * .then(Placements.toLocations())}.
      */
     @Deprecated(forRemoval = true)
     public static Function<HasOccurrenceOrUsages, List<VecLocation>> locationsOf(
             final Function<VecPlaceableElementRole, Stream<VecOnPointPlacement>> placement) {
-        final MultiNavigation<HasOccurrenceOrUsages, VecLocation> locations = ViewItems.placeableElementRole()
+        final MultiNavigation<HasOccurrenceOrUsages, VecLocation> locations = ViewItems.toPlaceableElementRole()
                 .then(Navigations.stream(placement))
-                .then(Placements.locations());
+                .then(Placements.toLocations());
         return locations::listFrom;
     }
 
     /**
-     * @deprecated Use {@code Placements.locations().ofType(locationType)} instead.
+     * @deprecated Use {@code Placements.toLocations().ofType(locationType)} instead.
      */
     @Deprecated(forRemoval = true)
     public static <T extends VecLocation> Function<VecOnWayPlacement, List<T>> locationsWith(
             final Class<T> locationType) {
-        final MultiNavigation<VecPlacement, T> locations = Placements.locations().ofType(locationType);
+        final MultiNavigation<VecPlacement, T> locations = Placements.toLocations().ofType(locationType);
         return locations::listFrom;
     }
 

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/navigations/PlacementNavs.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/navigations/PlacementNavs.java
@@ -74,15 +74,15 @@ public final class PlacementNavs {
      * @see #onPointPlacement()
      * @deprecated Compose the navigation at the call site instead, which also works for
      * {@link PlaceableElementRoles#onWayPlacements()}:
-     * {@code ViewItems.placeableElementRole().thenEach(PlaceableElementRoles.onPointPlacements())
-     * .thenEach(Placements.locations())}.
+     * {@code ViewItems.placeableElementRole().then(PlaceableElementRoles.onPointPlacements())
+     * .then(Placements.locations())}.
      */
     @Deprecated(forRemoval = true)
     public static Function<HasOccurrenceOrUsages, List<VecLocation>> locationsOf(
             final Function<VecPlaceableElementRole, Stream<VecOnPointPlacement>> placement) {
         final MultiNavigation<HasOccurrenceOrUsages, VecLocation> locations = ViewItems.placeableElementRole()
-                .thenEach(Navigations.stream(placement))
-                .thenEach(Placements.locations());
+                .then(Navigations.stream(placement))
+                .then(Placements.locations());
         return locations::listFrom;
     }
 

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/navigations/PlacementNavs.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/navigations/PlacementNavs.java
@@ -25,34 +25,40 @@
  */
 package com.foursoft.harness.vec.v2x.navigations;
 
-import com.foursoft.harness.vec.common.util.StreamUtils;
+import com.foursoft.harness.vec.common.traversal.Navigations;
 import com.foursoft.harness.vec.v2x.*;
+import com.foursoft.harness.vec.v2x.traversal.Placements;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
  * Navigation methods for getting {@link VecPlacement}s.
+ *
+ * @deprecated Use {@link Placements} instead.
  */
+@Deprecated(forRemoval = true)
 public final class PlacementNavs {
 
     private PlacementNavs() {
         // hide default constructor
     }
 
+    /**
+     * @deprecated Use {@link Placements#onPointPlacement()} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecPlaceableElementRole, Stream<VecOnPointPlacement>> onPointPlacement() {
-        return role -> role.getRefPlacement().stream()
-                .filter(VecOnPointPlacement.class::isInstance)
-                .map(VecOnPointPlacement.class::cast);
+        return Placements.onPointPlacement();
     }
 
+    /**
+     * @deprecated Use {@link Placements#onWayPlacement()} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecPlaceableElementRole, Stream<VecOnWayPlacement>> onWayPlacement() {
-        return role -> role.getRefPlacement().stream()
-                .filter(VecOnWayPlacement.class::isInstance)
-                .map(VecOnWayPlacement.class::cast);
+        return Placements.onWayPlacement();
     }
 
     /**
@@ -61,35 +67,28 @@ public final class PlacementNavs {
      * @param placement Placement Navigation method.
      * @return A function to get the locations from a
      * {@link VecOccurrenceOrUsageViewItem3D} or {@link VecOccurrenceOrUsageViewItem2D}.
-     * @see #onWayPlacement()
      * @see #onPointPlacement()
+     * @deprecated Use {@link Placements#locationsOf(com.foursoft.harness.vec.common.traversal.MultiNavigation)}
+     * instead, which accepts the way from the role to the locations and therefore also supports
+     * {@link Placements#onWayPlacement()}.
      */
+    @Deprecated(forRemoval = true)
     public static Function<HasOccurrenceOrUsages, List<VecLocation>> locationsOf(
             final Function<VecPlaceableElementRole, Stream<VecOnPointPlacement>> placement) {
-        return viewItem -> viewItem.getOccurrenceOrUsage().stream()
-                .filter(VecPartOccurrence.class::isInstance)
-                .map(VecPartOccurrence.class::cast)
-                .flatMap(StreamUtils.toStream(c -> c.getRolesWithType(VecPlaceableElementRole.class)))
-                .collect(StreamUtils.findOneOrNone())
-                .map(role -> placement.apply(role)
-                        .map(VecOnPointPlacement::getLocations)
-                        .flatMap(List::stream)
-                        .toList())
-                .orElseGet(Collections::emptyList);
+        return viewItem -> Placements
+                .locationsOf(Navigations.stream(placement)
+                                     .thenEach(Placements.onPointLocations()))
+                .listFrom(viewItem);
     }
 
+    /**
+     * @deprecated Use {@link Placements#onWayLocationsWith(Class)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static <T extends VecLocation> Function<VecOnWayPlacement, List<T>> locationsWith(
             final Class<T> locationType) {
-        return placement ->
-                getLocationsByType(Stream.of(placement.getStartLocation(), placement.getEndLocation()), locationType)
-                        .toList();
-    }
-
-    private static <T extends VecLocation> Stream<T> getLocationsByType(final Stream<VecLocation> locations,
-                                                                        final Class<T> locationType) {
-        return locations
-                .filter(locationType::isInstance)
-                .map(locationType::cast);
+        return placement -> Placements.onWayLocationsWith(locationType)
+                .listFrom(placement);
     }
 
 }

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/navigations/PlacementNavs.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/navigations/PlacementNavs.java
@@ -25,6 +25,7 @@
  */
 package com.foursoft.harness.vec.v2x.navigations;
 
+import com.foursoft.harness.vec.common.traversal.MultiNavigation;
 import com.foursoft.harness.vec.common.traversal.Navigations;
 import com.foursoft.harness.vec.v2x.*;
 import com.foursoft.harness.vec.v2x.traversal.PlaceableElementRoles;
@@ -71,27 +72,28 @@ public final class PlacementNavs {
      * @return A function to get the locations from a
      * {@link VecOccurrenceOrUsageViewItem3D} or {@link VecOccurrenceOrUsageViewItem2D}.
      * @see #onPointPlacement()
-     * @deprecated Use {@link ViewItems#locations(com.foursoft.harness.vec.common.traversal.MultiNavigation)}
-     * instead, which accepts the way from the role to the locations and therefore also supports
-     * {@link PlaceableElementRoles#onWayPlacements()}.
+     * @deprecated Compose the navigation at the call site instead, which also works for
+     * {@link PlaceableElementRoles#onWayPlacements()}:
+     * {@code ViewItems.placeableElementRole().thenEach(PlaceableElementRoles.onPointPlacements())
+     * .thenEach(Placements.locations())}.
      */
     @Deprecated(forRemoval = true)
     public static Function<HasOccurrenceOrUsages, List<VecLocation>> locationsOf(
             final Function<VecPlaceableElementRole, Stream<VecOnPointPlacement>> placement) {
-        return viewItem -> ViewItems
-                .locations(Navigations.stream(placement)
-                                   .thenEach(Placements.locations()))
-                .listFrom(viewItem);
+        final MultiNavigation<HasOccurrenceOrUsages, VecLocation> locations = ViewItems.placeableElementRole()
+                .thenEach(Navigations.stream(placement))
+                .thenEach(Placements.locations());
+        return locations::listFrom;
     }
 
     /**
-     * @deprecated Use {@link Placements#locationsWith(Class)} instead.
+     * @deprecated Use {@code Placements.locations().ofType(locationType)} instead.
      */
     @Deprecated(forRemoval = true)
     public static <T extends VecLocation> Function<VecOnWayPlacement, List<T>> locationsWith(
             final Class<T> locationType) {
-        return placement -> Placements.locationsWith(locationType)
-                .listFrom(placement);
+        final MultiNavigation<VecPlacement, T> locations = Placements.locations().ofType(locationType);
+        return locations::listFrom;
     }
 
 }

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/navigations/PlacementNavs.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/navigations/PlacementNavs.java
@@ -27,7 +27,9 @@ package com.foursoft.harness.vec.v2x.navigations;
 
 import com.foursoft.harness.vec.common.traversal.Navigations;
 import com.foursoft.harness.vec.v2x.*;
+import com.foursoft.harness.vec.v2x.traversal.PlaceableElementRoles;
 import com.foursoft.harness.vec.v2x.traversal.Placements;
+import com.foursoft.harness.vec.v2x.traversal.ViewItems;
 
 import java.util.List;
 import java.util.function.Function;
@@ -36,7 +38,8 @@ import java.util.stream.Stream;
 /**
  * Navigation methods for getting {@link VecPlacement}s.
  *
- * @deprecated Use {@link Placements} instead.
+ * @deprecated These navigations start at three different source types and are therefore spread over the
+ * catalogs of those types: {@link PlaceableElementRoles}, {@link Placements} and {@link ViewItems}.
  */
 @Deprecated(forRemoval = true)
 public final class PlacementNavs {
@@ -46,19 +49,19 @@ public final class PlacementNavs {
     }
 
     /**
-     * @deprecated Use {@link Placements#onPointPlacement()} instead.
+     * @deprecated Use {@link PlaceableElementRoles#onPointPlacements()} instead.
      */
     @Deprecated(forRemoval = true)
     public static Function<VecPlaceableElementRole, Stream<VecOnPointPlacement>> onPointPlacement() {
-        return Placements.onPointPlacement();
+        return PlaceableElementRoles.onPointPlacements();
     }
 
     /**
-     * @deprecated Use {@link Placements#onWayPlacement()} instead.
+     * @deprecated Use {@link PlaceableElementRoles#onWayPlacements()} instead.
      */
     @Deprecated(forRemoval = true)
     public static Function<VecPlaceableElementRole, Stream<VecOnWayPlacement>> onWayPlacement() {
-        return Placements.onWayPlacement();
+        return PlaceableElementRoles.onWayPlacements();
     }
 
     /**
@@ -68,26 +71,26 @@ public final class PlacementNavs {
      * @return A function to get the locations from a
      * {@link VecOccurrenceOrUsageViewItem3D} or {@link VecOccurrenceOrUsageViewItem2D}.
      * @see #onPointPlacement()
-     * @deprecated Use {@link Placements#locationsOf(com.foursoft.harness.vec.common.traversal.MultiNavigation)}
+     * @deprecated Use {@link ViewItems#locations(com.foursoft.harness.vec.common.traversal.MultiNavigation)}
      * instead, which accepts the way from the role to the locations and therefore also supports
-     * {@link Placements#onWayPlacement()}.
+     * {@link PlaceableElementRoles#onWayPlacements()}.
      */
     @Deprecated(forRemoval = true)
     public static Function<HasOccurrenceOrUsages, List<VecLocation>> locationsOf(
             final Function<VecPlaceableElementRole, Stream<VecOnPointPlacement>> placement) {
-        return viewItem -> Placements
-                .locationsOf(Navigations.stream(placement)
-                                     .thenEach(Placements.onPointLocations()))
+        return viewItem -> ViewItems
+                .locations(Navigations.stream(placement)
+                                   .thenEach(Placements.locations()))
                 .listFrom(viewItem);
     }
 
     /**
-     * @deprecated Use {@link Placements#onWayLocationsWith(Class)} instead.
+     * @deprecated Use {@link Placements#locationsWith(Class)} instead.
      */
     @Deprecated(forRemoval = true)
     public static <T extends VecLocation> Function<VecOnWayPlacement, List<T>> locationsWith(
             final Class<T> locationType) {
-        return placement -> Placements.onWayLocationsWith(locationType)
+        return placement -> Placements.locationsWith(locationType)
                 .listFrom(placement);
     }
 

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/navigations/SegmentNavs.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/navigations/SegmentNavs.java
@@ -2,7 +2,7 @@
  * ========================LICENSE_START=================================
  * VEC 2.X
  * %%
- * Copyright (C) 2020 - 2023 4Soft GmbH
+ * Copyright (C) 2020 - 2026 4Soft GmbH
  * %%
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -10,10 +10,10 @@
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * 
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,44 +26,47 @@
 package com.foursoft.harness.vec.v2x.navigations;
 
 import com.foursoft.harness.vec.common.annotations.RequiresBackReferences;
-import com.foursoft.harness.vec.common.util.StreamUtils;
-import com.foursoft.harness.vec.v2x.VecNumericalValue;
-import com.foursoft.harness.vec.v2x.VecSegmentCrossSectionArea;
-import com.foursoft.harness.vec.v2x.VecSegmentLength;
 import com.foursoft.harness.vec.v2x.VecTopologySegment;
+import com.foursoft.harness.vec.v2x.traversal.TopologySegments;
 
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 
 /**
  * Navigation methods for segments such as the {@link VecTopologySegment}.
+ *
+ * @deprecated Use {@link TopologySegments} instead.
  */
+@Deprecated(forRemoval = true)
 public final class SegmentNavs {
 
     private SegmentNavs() {
         // hide default constructor
     }
 
+    /**
+     * @deprecated Use {@link TopologySegments#toParentDocumentNumber()} instead.
+     */
+    @Deprecated(forRemoval = true)
     @RequiresBackReferences
     public static Function<VecTopologySegment, String> parentDocumentNumber() {
-        return segment -> segment.getParentTopologySpecification().getParentDocumentVersion().getDocumentNumber();
+        return TopologySegments.toParentDocumentNumber()::orElseNull;
     }
 
+    /**
+     * @deprecated Use {@link TopologySegments#lengthBy(String)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecTopologySegment, Optional<Double>> lengthBy(final String segmentLengthClassification) {
-        return segment -> StreamUtils.nonNullStream(segment.getLengthInformations())
-                .filter(segmentLength -> segmentLength.getClassification().equals(segmentLengthClassification))
-                .collect(StreamUtils.findOneOrNone())
-                .map(VecSegmentLength::getLength)
-                .map(VecNumericalValue::getValueComponent);
+        return TopologySegments.lengthBy(segmentLengthClassification);
     }
 
+    /**
+     * @deprecated Use {@link TopologySegments#crossSectionAreaBy(String)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecTopologySegment, Optional<Double>> crossSectionAreaBy(final String areaType) {
-        return segment -> StreamUtils.nonNullStream(segment.getCrossSectionAreaInformations())
-                .filter(seg -> Objects.equals(areaType, seg.getCrossSectionAreaType()))  // is nullable
-                .collect(StreamUtils.findOneOrNone())
-                .map(VecSegmentCrossSectionArea::getArea)
-                .map(VecNumericalValue::getValueComponent);
+        return TopologySegments.crossSectionAreaBy(areaType);
     }
 
 }

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/navigations/SpecificationNavs.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/navigations/SpecificationNavs.java
@@ -2,7 +2,7 @@
  * ========================LICENSE_START=================================
  * VEC 2.X
  * %%
- * Copyright (C) 2020 - 2023 4Soft GmbH
+ * Copyright (C) 2020 - 2026 4Soft GmbH
  * %%
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -10,10 +10,10 @@
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * 
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -25,53 +25,62 @@
  */
 package com.foursoft.harness.vec.v2x.navigations;
 
-import com.foursoft.harness.vec.common.HasIdentification;
 import com.foursoft.harness.vec.common.HasSpecifications;
 import com.foursoft.harness.vec.common.annotations.RequiresBackReferences;
-import com.foursoft.harness.vec.common.util.StreamUtils;
-import com.foursoft.harness.vec.v2x.*;
+import com.foursoft.harness.vec.v2x.VecBuildingBlockSpecification2D;
+import com.foursoft.harness.vec.v2x.VecBuildingBlockSpecification3D;
+import com.foursoft.harness.vec.v2x.VecCompositionSpecification;
+import com.foursoft.harness.vec.v2x.VecDocumentVersion;
+import com.foursoft.harness.vec.v2x.VecGeometryNode2D;
+import com.foursoft.harness.vec.v2x.VecGeometryNode3D;
+import com.foursoft.harness.vec.v2x.VecGeometrySegment2D;
+import com.foursoft.harness.vec.v2x.VecGeometrySegment3D;
+import com.foursoft.harness.vec.v2x.VecOccurrenceOrUsage;
+import com.foursoft.harness.vec.v2x.VecPartOccurrence;
+import com.foursoft.harness.vec.v2x.VecSpecification;
+import com.foursoft.harness.vec.v2x.traversal.SpecificationOwners;
+import com.foursoft.harness.vec.v2x.traversal.Specifications;
 
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
-import java.util.stream.Stream;
 
 /**
  * Navigation methods for the {@link VecSpecification}.
+ *
+ * @deprecated These navigations start at a specification and at the element holding it, and are therefore
+ * spread over the catalogs of those types: {@link Specifications} and {@link SpecificationOwners}.
  */
+@Deprecated(forRemoval = true)
 public final class SpecificationNavs {
 
     private SpecificationNavs() {
         // hide default constructor
     }
 
+    /**
+     * @deprecated Use {@link Specifications#toParentDocumentNumber()} instead.
+     */
+    @Deprecated(forRemoval = true)
     @RequiresBackReferences
     public static Function<VecSpecification, String> parentDocumentNumber() {
-        return spec -> parentDocumentVersion().apply(spec).getDocumentNumber();
+        return Specifications.toParentDocumentNumber()::orElseNull;
     }
 
+    /**
+     * @deprecated Use {@link Specifications#toParentDocumentVersion()} instead.
+     */
+    @Deprecated(forRemoval = true)
     @RequiresBackReferences
     public static Function<VecSpecification, VecDocumentVersion> parentDocumentVersion() {
-        return specification -> {
-            final VecSheetOrChapter sheetOrChapter = specification.getParentSheetOrChapter();
-            final VecDocumentVersion documentVersion = specification.getParentDocumentVersion();
-            if (documentVersion != null) {
-                return documentVersion;
-            } else {
-                return sheetOrChapter.getParentDocumentVersion();
-            }
-        };
+        return Specifications.toParentDocumentVersion()::orElseNull;
     }
 
+    /**
+     * @deprecated Use {@link SpecificationOwners#toOccurrenceOrUsages()} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<HasSpecifications<VecSpecification>, List<VecOccurrenceOrUsage>> allOccurrenceOrUsages() {
-        return specifications -> Stream.concat(
-                        components().apply(specifications).stream(),
-                        specifications.getSpecificationsWithType(VecPartUsageSpecification.class)
-                                .stream()
-                                .map(VecPartUsageSpecification::getPartUsages)
-                                .flatMap(Collection::stream))
-                .toList();
+        return SpecificationOwners.toOccurrenceOrUsages()::listFrom;
     }
 
     /**
@@ -79,14 +88,11 @@ public final class SpecificationNavs {
      * their {@link VecCompositionSpecification#getComponents() components}.
      *
      * @return A possibly-empty list of Components.
+     * @deprecated Use {@link SpecificationOwners#toComponents()} instead.
      */
+    @Deprecated(forRemoval = true)
     public static Function<HasSpecifications<VecSpecification>, List<VecPartOccurrence>> components() {
-        return specifications -> specifications
-                .getSpecificationsWithType(VecCompositionSpecification.class)
-                .stream()
-                .map(VecCompositionSpecification::getComponents)
-                .flatMap(Collection::stream)
-                .toList();
+        return SpecificationOwners.toComponents()::listFrom;
     }
 
     /**
@@ -95,37 +101,47 @@ public final class SpecificationNavs {
      *
      * @param compositionSpecificationId Id the {@link VecCompositionSpecification} has to have.
      * @return A possibly-empty list of Components.
+     * @deprecated Use {@link SpecificationOwners#componentsBy(String)} instead.
      */
+    @Deprecated(forRemoval = true)
     public static Function<HasSpecifications<VecSpecification>, List<VecPartOccurrence>> componentsBy(
             final String compositionSpecificationId) {
-        return specifications -> specifications
-                .getSpecificationWith(VecCompositionSpecification.class, compositionSpecificationId)
-                .map(VecCompositionSpecification::getComponents)
-                .orElseGet(Collections::emptyList);
+        return SpecificationOwners.componentsBy(
+                compositionSpecificationId)::listFrom;
     }
 
+    /**
+     * @deprecated Use {@link Specifications#geometrySegment2dBy(String)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecBuildingBlockSpecification2D, VecGeometrySegment2D> geometrySegment2dBy(
             final String segmentId) {
-        return specification -> findElementById(specification.getGeometrySegments(), segmentId);
+        return Specifications.geometrySegment2dBy(segmentId)::orElseNull;
     }
 
+    /**
+     * @deprecated Use {@link Specifications#geometrySegment3dBy(String)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecBuildingBlockSpecification3D, VecGeometrySegment3D> geometrySegment3dBy(
             final String segmentId) {
-        return specification -> findElementById(specification.getGeometrySegments(), segmentId);
+        return Specifications.geometrySegment3dBy(segmentId)::orElseNull;
     }
 
+    /**
+     * @deprecated Use {@link Specifications#geometryNode2dBy(String)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecBuildingBlockSpecification2D, VecGeometryNode2D> geometryNode2dBy(final String nodeId) {
-        return specification -> findElementById(specification.getGeometryNodes(), nodeId);
+        return Specifications.geometryNode2dBy(nodeId)::orElseNull;
     }
 
+    /**
+     * @deprecated Use {@link Specifications#geometryNode3dBy(String)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecBuildingBlockSpecification3D, VecGeometryNode3D> geometryNode3dBy(final String nodeId) {
-        return specification -> findElementById(specification.getGeometryNodes(), nodeId);
-    }
-
-    private static <T extends HasIdentification> T findElementById(final List<T> elements, final String id) {
-        return elements.stream()
-                .filter(element -> element.getIdentification().equals(id))
-                .collect(StreamUtils.findOneOrNone()).orElse(null);
+        return Specifications.geometryNode3dBy(nodeId)::orElseNull;
     }
 
 }

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/navigations/SpecificationNavs.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/navigations/SpecificationNavs.java
@@ -35,7 +35,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/navigations/VecNavs.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/navigations/VecNavs.java
@@ -2,7 +2,7 @@
  * ========================LICENSE_START=================================
  * VEC 2.X
  * %%
- * Copyright (C) 2020 - 2023 4Soft GmbH
+ * Copyright (C) 2020 - 2026 4Soft GmbH
  * %%
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -10,10 +10,10 @@
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * 
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -28,33 +28,41 @@ package com.foursoft.harness.vec.v2x.navigations;
 import com.foursoft.harness.vec.common.annotations.RequiresBackReferences;
 import com.foursoft.harness.vec.v2x.VecDocumentVersion;
 import com.foursoft.harness.vec.v2x.VecExtendableElement;
-import com.foursoft.harness.vec.v2x.VecOccurrenceOrUsage;
 import com.foursoft.harness.vec.v2x.VecRole;
+import com.foursoft.harness.vec.v2x.traversal.ExtendableElements;
+import com.foursoft.harness.vec.v2x.traversal.Roles;
 
 import java.util.List;
 import java.util.function.Function;
 
 /**
  * Navigation methods which don't fit into a special category.
+ *
+ * @deprecated These navigations start at two different source types and are therefore spread over the
+ * catalogs of those types: {@link ExtendableElements} and {@link Roles}.
  */
+@Deprecated(forRemoval = true)
 public final class VecNavs {
 
     private VecNavs() {
         // hide default constructor
     }
 
+    /**
+     * @deprecated Use {@link ExtendableElements#toExternalDocumentNumbers()} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static Function<VecExtendableElement, List<String>> externalDocumentNumbers() {
-        return element -> element.getReferencedExternalDocuments().stream()
-                .map(VecDocumentVersion::getDocumentNumber)
-                .toList();
+        return ExtendableElements.toExternalDocumentNumbers()::listFrom;
     }
 
+    /**
+     * @deprecated Use {@link Roles#toParentDocumentVersion()} instead.
+     */
+    @Deprecated(forRemoval = true)
     @RequiresBackReferences
     public static Function<VecRole, VecDocumentVersion> parentDocumentVersion() {
-        return role -> {
-            final VecOccurrenceOrUsage parentOccurrenceOrUsage = role.getParentOccurrenceOrUsage();
-            return PartOccurrenceOrUsageNavs.parentDocumentVersion().apply(parentOccurrenceOrUsage);
-        };
+        return Roles.toParentDocumentVersion()::orElseNull;
     }
 
 }

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/ConfigurableElements.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/ConfigurableElements.java
@@ -1,0 +1,76 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v2x.traversal;
+
+import com.foursoft.harness.vec.common.traversal.Navigations;
+import com.foursoft.harness.vec.common.traversal.SingleNavigation;
+import com.foursoft.harness.vec.v2x.VecConfigurableElement;
+import com.foursoft.harness.vec.v2x.VecVariantConfiguration;
+
+/**
+ * Navigations starting at a {@link VecConfigurableElement}, that is at any element whose presence can be
+ * configured.
+ */
+public final class ConfigurableElements {
+
+    private ConfigurableElements() {
+        // hide default constructor
+    }
+
+    /**
+     * Navigates to the configuration of a configurable element.
+     * <p>
+     * VEC 2.X deprecates the association this follows without offering a replacement for it, so this
+     * navigation is deprecated for removal in the model's sense, not in this API's.
+     *
+     * @return A navigation to the variant configuration of an element.
+     */
+    @SuppressWarnings({"deprecation", "removal"})
+    public static SingleNavigation<VecConfigurableElement, VecVariantConfiguration> toVariantConfiguration() {
+        return Navigations.nullable(VecConfigurableElement::getConfigInfo);
+    }
+
+    /**
+     * Navigates to the logistic control string of a configurable element.
+     *
+     * @return A navigation to the logistic control string of an element.
+     */
+    public static SingleNavigation<VecConfigurableElement, String> toLogisticControlString() {
+        return toVariantConfiguration()
+                .then(Navigations.nullable(VecVariantConfiguration::getLogisticControlString));
+    }
+
+    /**
+     * Navigates to the logistic control expression of a configurable element.
+     *
+     * @return A navigation to the logistic control expression of an element.
+     */
+    public static SingleNavigation<VecConfigurableElement, String> toLogisticControlExpression() {
+        return toVariantConfiguration()
+                .then(Navigations.nullable(VecVariantConfiguration::getLogisticControlExpression));
+    }
+
+}

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/Contents.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/Contents.java
@@ -1,0 +1,73 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v2x.traversal;
+
+import com.foursoft.harness.vec.common.traversal.MultiNavigation;
+import com.foursoft.harness.vec.common.traversal.Navigations;
+import com.foursoft.harness.vec.common.traversal.SingleNavigation;
+import com.foursoft.harness.vec.v2x.VecContent;
+import com.foursoft.harness.vec.v2x.VecDocumentVersion;
+
+/**
+ * Navigations starting at the {@link VecContent}, the root of a VEC model.
+ * <p>
+ * To reach the specifications of all document versions, continue this navigation at the call site, for example
+ * <pre>
+ * {@code
+ * Contents.toDocumentVersions()
+ *         .then(SpecificationOwners.toSpecifications())
+ *         .ofType(VecPlacementSpecification.class);
+ * }
+ * </pre>
+ */
+public final class Contents {
+
+    private Contents() {
+        // hide default constructor
+    }
+
+    /**
+     * Navigates to the document versions of a content.
+     *
+     * @return A navigation to the document versions of a content.
+     */
+    public static MultiNavigation<VecContent, VecDocumentVersion> toDocumentVersions() {
+        return Navigations.collection(VecContent::getDocumentVersions);
+    }
+
+    /**
+     * Navigates to the document version with the given document number.
+     *
+     * @param documentNumber Document number of the document version to navigate to.
+     * @return A navigation to the identified document version.
+     */
+    public static SingleNavigation<VecContent, VecDocumentVersion> documentVersionBy(final String documentNumber) {
+        return toDocumentVersions()
+                .filter(documentVersion -> documentNumber.equals(documentVersion.getDocumentNumber()))
+                .atMostOne();
+    }
+
+}

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/CustomProperties.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/CustomProperties.java
@@ -1,0 +1,183 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v2x.traversal;
+
+import com.foursoft.harness.vec.common.HasCustomProperties;
+import com.foursoft.harness.vec.common.traversal.MultiNavigation;
+import com.foursoft.harness.vec.common.traversal.Navigations;
+import com.foursoft.harness.vec.common.traversal.SingleNavigation;
+import com.foursoft.harness.vec.v2x.VecBooleanValueProperty;
+import com.foursoft.harness.vec.v2x.VecComplexProperty;
+import com.foursoft.harness.vec.v2x.VecCustomProperty;
+import com.foursoft.harness.vec.v2x.VecDoubleValueProperty;
+import com.foursoft.harness.vec.v2x.VecIntegerValueProperty;
+import com.foursoft.harness.vec.v2x.VecLanguageCode;
+import com.foursoft.harness.vec.v2x.VecLocalizedStringProperty;
+import com.foursoft.harness.vec.v2x.VecSimpleValueProperty;
+import com.foursoft.harness.vec.v2x.VecValueRange;
+import com.foursoft.harness.vec.v2x.VecValueRangeProperty;
+
+import java.math.BigInteger;
+import java.util.function.Predicate;
+
+/**
+ * Navigations starting at a {@link HasCustomProperties} holding {@link VecCustomProperty}s.
+ * <p>
+ * The value navigations are named after the value they lead to, since the property type given as their
+ * argument is what picks it. To reach the properties themselves, start at {@link #toCustomProperties()} and
+ * narrow it at the call site, for example
+ * <pre>
+ * {@code
+ * CustomProperties.toCustomProperties().ofType(VecSimpleValueProperty.class);
+ * }
+ * </pre>
+ */
+public final class CustomProperties {
+
+    private CustomProperties() {
+        // hide default constructor
+    }
+
+    /**
+     * Navigates to the custom properties of an element.
+     *
+     * @return A navigation to the custom properties of an element.
+     */
+    public static MultiNavigation<HasCustomProperties<VecCustomProperty>, VecCustomProperty> toCustomProperties() {
+        return Navigations.collection(HasCustomProperties::getCustomProperties);
+    }
+
+    /**
+     * Navigates to the string value of the {@link VecSimpleValueProperty} with the given property type.
+     *
+     * @param propertyType Type of the property to navigate to.
+     * @return A navigation to the string value of the given property.
+     */
+    public static SingleNavigation<HasCustomProperties<VecCustomProperty>, String> stringValueOf(
+            final String propertyType) {
+        return propertiesOf(propertyType, VecSimpleValueProperty.class).atMostOne()
+                .then(Navigations.nullable(VecSimpleValueProperty::getValue));
+    }
+
+    /**
+     * Navigates to the string values of all {@link VecSimpleValueProperty}s with the given property type.
+     *
+     * @param propertyType Type of the properties to navigate to.
+     * @return A navigation to the string values of the given properties.
+     */
+    public static MultiNavigation<HasCustomProperties<VecCustomProperty>, String> stringValuesOf(
+            final String propertyType) {
+        return propertiesOf(propertyType, VecSimpleValueProperty.class)
+                .then(Navigations.nullable(VecSimpleValueProperty::getValue));
+    }
+
+    /**
+     * Navigates to the integer value of the {@link VecIntegerValueProperty} with the given property type.
+     *
+     * @param propertyType Type of the property to navigate to.
+     * @return A navigation to the integer value of the given property.
+     */
+    public static SingleNavigation<HasCustomProperties<VecCustomProperty>, BigInteger> integerValueOf(
+            final String propertyType) {
+        return propertiesOf(propertyType, VecIntegerValueProperty.class).atMostOne()
+                .then(Navigations.nullable(VecIntegerValueProperty::getValue));
+    }
+
+    /**
+     * Navigates to the double value of the {@link VecDoubleValueProperty} with the given property type.
+     *
+     * @param propertyType Type of the property to navigate to.
+     * @return A navigation to the double value of the given property.
+     */
+    public static SingleNavigation<HasCustomProperties<VecCustomProperty>, Double> doubleValueOf(
+            final String propertyType) {
+        return propertiesOf(propertyType, VecDoubleValueProperty.class).atMostOne()
+                .then(Navigations.nullable(VecDoubleValueProperty::getValue));
+    }
+
+    /**
+     * Navigates to the boolean value of the {@link VecBooleanValueProperty} with the given property type.
+     *
+     * @param propertyType Type of the property to navigate to.
+     * @return A navigation to the boolean value of the given property.
+     */
+    public static SingleNavigation<HasCustomProperties<VecCustomProperty>, Boolean> booleanValueOf(
+            final String propertyType) {
+        return propertiesOf(propertyType, VecBooleanValueProperty.class).atMostOne()
+                .then(Navigations.nullable(VecBooleanValueProperty::isValue));
+    }
+
+    /**
+     * Navigates to the {@link VecValueRange} of the {@link VecValueRangeProperty} with the given property type.
+     *
+     * @param propertyType Type of the property to navigate to.
+     * @return A navigation to the value range of the given property.
+     */
+    public static SingleNavigation<HasCustomProperties<VecCustomProperty>, VecValueRange> valueRangeOf(
+            final String propertyType) {
+        return propertiesOf(propertyType, VecValueRangeProperty.class).atMostOne()
+                .then(Navigations.nullable(VecValueRangeProperty::getValue));
+    }
+
+    /**
+     * Navigates to the custom properties nested in the {@link VecComplexProperty} with the given property type.
+     *
+     * @param propertyType Type of the complex property to navigate into.
+     * @return A navigation to the custom properties of the given complex property.
+     */
+    public static MultiNavigation<HasCustomProperties<VecCustomProperty>, VecCustomProperty> nestedPropertiesOf(
+            final String propertyType) {
+        return propertiesOf(propertyType, VecComplexProperty.class).atMostOne()
+                .then(Navigations.collection(VecComplexProperty::getCustomProperties));
+    }
+
+    /**
+     * Navigates to the value of the {@link VecLocalizedStringProperty} with the given property type, if that
+     * value is in the given language.
+     *
+     * @param propertyType Type of the property to navigate to.
+     * @param languageCode Language the value has to be in.
+     * @return A navigation to the localized value of the given property.
+     * @see LocalizedStringProperties#valueIn(VecLanguageCode)
+     */
+    public static SingleNavigation<HasCustomProperties<VecCustomProperty>, String> localizedValueOf(
+            final String propertyType, final VecLanguageCode languageCode) {
+        return propertiesOf(propertyType, VecLocalizedStringProperty.class).atMostOne()
+                .then(LocalizedStringProperties.valueIn(languageCode));
+    }
+
+    private static <T extends VecCustomProperty> MultiNavigation<HasCustomProperties<VecCustomProperty>, T> propertiesOf(
+            final String propertyType, final Class<T> type) {
+        return toCustomProperties()
+                .ofType(type)
+                .filter(ofPropertyType(propertyType));
+    }
+
+    private static Predicate<VecCustomProperty> ofPropertyType(final String propertyType) {
+        return customProperty -> propertyType.equals(customProperty.getPropertyType());
+    }
+
+}

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/Descriptions.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/Descriptions.java
@@ -26,24 +26,33 @@
 package com.foursoft.harness.vec.v2x.traversal;
 
 import com.foursoft.harness.vec.common.HasDescription;
+import com.foursoft.harness.vec.common.traversal.MultiNavigation;
 import com.foursoft.harness.vec.common.traversal.Navigations;
 import com.foursoft.harness.vec.common.traversal.SingleNavigation;
 import com.foursoft.harness.vec.v2x.VecAbstractLocalizedString;
 import com.foursoft.harness.vec.v2x.VecLanguageCode;
 import com.foursoft.harness.vec.v2x.VecLocalizedTypedString;
 
-import java.util.List;
-
 /**
  * Navigations starting at a {@link HasDescription} holding {@link VecAbstractLocalizedString}s.
  * <p>
- * Each of these navigations picks a value out of the element's description list; use
- * {@link LocalizedStrings} to navigate from such a list directly.
+ * Which of several descriptions applies is decided by a reduction from {@link LocalizedStrings}, not by the
+ * navigation itself.
  */
 public final class Descriptions {
 
     private Descriptions() {
         // hide default constructor
+    }
+
+    /**
+     * Navigates to the localized strings describing an element.
+     *
+     * @return A navigation to the descriptions of an element.
+     */
+    public static MultiNavigation<HasDescription<? extends VecAbstractLocalizedString>,
+            VecAbstractLocalizedString> descriptions() {
+        return Navigations.collection(HasDescription::getDescriptions);
     }
 
     /**
@@ -71,11 +80,11 @@ public final class Descriptions {
      *
      * @param languageCode Language of the description to navigate to.
      * @return A navigation to the description in the given language.
-     * @see LocalizedStrings#stringIn(VecLanguageCode)
+     * @see LocalizedStrings#valueIn(VecLanguageCode)
      */
     public static SingleNavigation<HasDescription<? extends VecAbstractLocalizedString>, String> descriptionIn(
             final VecLanguageCode languageCode) {
-        return descriptions().then(LocalizedStrings.stringIn(languageCode));
+        return descriptions().collect(LocalizedStrings.valueIn(languageCode));
     }
 
     /**
@@ -108,23 +117,11 @@ public final class Descriptions {
      * @param descriptionType Type of the localized string to navigate to.
      * @param languageCode    Language of the localized string to navigate to.
      * @return A navigation to the value of the given type and language.
-     * @see LocalizedStrings#typedStringBy(String, VecLanguageCode)
+     * @see LocalizedStrings#typedValueBy(String, VecLanguageCode)
      */
     public static SingleNavigation<HasDescription<? extends VecAbstractLocalizedString>, String> typedStringBy(
             final String descriptionType, final VecLanguageCode languageCode) {
-        return descriptions().then(LocalizedStrings.typedStringBy(descriptionType, languageCode));
-    }
-
-    /**
-     * Navigates to the description list itself, as the step the {@link LocalizedStrings} navigations
-     * continue from.
-     * <p>
-     * Deliberately not public: a navigation to a list <em>as a value</em> would be easy to mistake for a
-     * {@link com.foursoft.harness.vec.common.traversal.MultiNavigation} to the single strings.
-     */
-    private static SingleNavigation<HasDescription<? extends VecAbstractLocalizedString>,
-            List<? extends VecAbstractLocalizedString>> descriptions() {
-        return Navigations.nullable(HasDescription::getDescriptions);
+        return descriptions().collect(LocalizedStrings.typedValueBy(descriptionType, languageCode));
     }
 
 }

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/Descriptions.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/Descriptions.java
@@ -27,19 +27,15 @@ package com.foursoft.harness.vec.v2x.traversal;
 
 import com.foursoft.harness.vec.common.HasDescription;
 import com.foursoft.harness.vec.common.traversal.SingleNavigation;
-import com.foursoft.harness.vec.common.util.StreamUtils;
-import com.foursoft.harness.vec.common.util.StringUtils;
 import com.foursoft.harness.vec.v2x.VecAbstractLocalizedString;
 import com.foursoft.harness.vec.v2x.VecLanguageCode;
 import com.foursoft.harness.vec.v2x.VecLocalizedTypedString;
-import com.foursoft.harness.vec.v2x.predicates.VecPredicates;
-
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
 
 /**
- * Navigations to the descriptions of a {@link HasDescription} holding {@link VecAbstractLocalizedString}s.
+ * Navigations starting at a {@link HasDescription} holding {@link VecAbstractLocalizedString}s.
+ * <p>
+ * Each of these navigations picks a value out of the element's description list; use
+ * {@link LocalizedStrings} to navigate from such a list directly.
  */
 public final class Descriptions {
 
@@ -72,67 +68,12 @@ public final class Descriptions {
      *
      * @param languageCode Language of the description to navigate to.
      * @return A navigation to the description in the given language.
-     * @see #stringIn(VecLanguageCode)
+     * @see LocalizedStrings#stringIn(VecLanguageCode)
      */
     public static SingleNavigation<HasDescription<? extends VecAbstractLocalizedString>, String> descriptionIn(
             final VecLanguageCode languageCode) {
-        return hasDescription -> stringIn(languageCode).from(hasDescription.getDescriptions());
-    }
-
-    /**
-     * Navigates to the german value of a list of localized strings.
-     *
-     * @return A navigation to the german value.
-     * @see #stringIn(VecLanguageCode)
-     */
-    public static SingleNavigation<List<? extends VecAbstractLocalizedString>, String> germanString() {
-        return stringIn(VecLanguageCode.DE);
-    }
-
-    /**
-     * Navigates to the english value of a list of localized strings.
-     *
-     * @return A navigation to the english value.
-     * @see #stringIn(VecLanguageCode)
-     */
-    public static SingleNavigation<List<? extends VecAbstractLocalizedString>, String> englishString() {
-        return stringIn(VecLanguageCode.EN);
-    }
-
-    /**
-     * Navigates to the value of a list of localized strings in the given language.
-     * <p>
-     * A single {@link VecLocalizedTypedString} with a type is not considered a description and therefore leads
-     * to no value. A single untyped string is used regardless of its language, as there is nothing to choose
-     * from. Otherwise the typed strings are ignored and the value of the given language is used.
-     *
-     * @param languageCode Language of the value to navigate to.
-     * @return A navigation to the value in the given language.
-     */
-    public static SingleNavigation<List<? extends VecAbstractLocalizedString>, String> stringIn(
-            final VecLanguageCode languageCode) {
-        return localizedStrings -> {
-            if (localizedStrings.isEmpty()) {
-                return Optional.empty();
-            }
-            if (localizedStrings.size() == 1) {
-                final VecAbstractLocalizedString localizedString = localizedStrings.get(0);
-                if (localizedString instanceof final VecLocalizedTypedString typedString
-                        && StringUtils.isNotEmpty(typedString.getType())) {
-                    return Optional.empty();
-                }
-                return Optional.ofNullable(localizedString)
-                        .map(VecAbstractLocalizedString::getValue);
-            }
-
-            return localizedStrings.stream()
-                    .filter(Objects::nonNull)
-                    .filter(localizedString -> !(localizedString instanceof VecLocalizedTypedString))
-                    .filter(VecPredicates.languageCode(languageCode))
-                    .map(VecAbstractLocalizedString::getValue)
-                    .filter(Objects::nonNull)
-                    .collect(StreamUtils.findOneOrNone());
-        };
+        return hasDescription -> LocalizedStrings.stringIn(languageCode)
+                .from(hasDescription.getDescriptions());
     }
 
     /**
@@ -165,16 +106,12 @@ public final class Descriptions {
      * @param descriptionType Type of the localized string to navigate to.
      * @param languageCode    Language of the localized string to navigate to.
      * @return A navigation to the value of the given type and language.
+     * @see LocalizedStrings#typedStringBy(String, VecLanguageCode)
      */
     public static SingleNavigation<HasDescription<? extends VecAbstractLocalizedString>, String> typedStringBy(
             final String descriptionType, final VecLanguageCode languageCode) {
-        return hasDescription -> hasDescription.getDescriptions().stream()
-                .filter(VecPredicates.languageCode(languageCode))
-                .flatMap(StreamUtils.ofClass(VecLocalizedTypedString.class))
-                .filter(typedString -> descriptionType.equals(typedString.getType()))
-                .collect(StreamUtils.findOneOrNone())
-                .map(VecLocalizedTypedString::getValue)
-                .filter(StringUtils::isNotEmpty);
+        return hasDescription -> LocalizedStrings.typedStringBy(descriptionType, languageCode)
+                .from(hasDescription.getDescriptions());
     }
 
 }

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/Descriptions.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/Descriptions.java
@@ -26,10 +26,13 @@
 package com.foursoft.harness.vec.v2x.traversal;
 
 import com.foursoft.harness.vec.common.HasDescription;
+import com.foursoft.harness.vec.common.traversal.Navigations;
 import com.foursoft.harness.vec.common.traversal.SingleNavigation;
 import com.foursoft.harness.vec.v2x.VecAbstractLocalizedString;
 import com.foursoft.harness.vec.v2x.VecLanguageCode;
 import com.foursoft.harness.vec.v2x.VecLocalizedTypedString;
+
+import java.util.List;
 
 /**
  * Navigations starting at a {@link HasDescription} holding {@link VecAbstractLocalizedString}s.
@@ -72,8 +75,7 @@ public final class Descriptions {
      */
     public static SingleNavigation<HasDescription<? extends VecAbstractLocalizedString>, String> descriptionIn(
             final VecLanguageCode languageCode) {
-        return hasDescription -> LocalizedStrings.stringIn(languageCode)
-                .from(hasDescription.getDescriptions());
+        return descriptions().then(LocalizedStrings.stringIn(languageCode));
     }
 
     /**
@@ -110,8 +112,19 @@ public final class Descriptions {
      */
     public static SingleNavigation<HasDescription<? extends VecAbstractLocalizedString>, String> typedStringBy(
             final String descriptionType, final VecLanguageCode languageCode) {
-        return hasDescription -> LocalizedStrings.typedStringBy(descriptionType, languageCode)
-                .from(hasDescription.getDescriptions());
+        return descriptions().then(LocalizedStrings.typedStringBy(descriptionType, languageCode));
+    }
+
+    /**
+     * Navigates to the description list itself, as the step the {@link LocalizedStrings} navigations
+     * continue from.
+     * <p>
+     * Deliberately not public: a navigation to a list <em>as a value</em> would be easy to mistake for a
+     * {@link com.foursoft.harness.vec.common.traversal.MultiNavigation} to the single strings.
+     */
+    private static SingleNavigation<HasDescription<? extends VecAbstractLocalizedString>,
+            List<? extends VecAbstractLocalizedString>> descriptions() {
+        return Navigations.nullable(HasDescription::getDescriptions);
     }
 
 }

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/Descriptions.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/Descriptions.java
@@ -51,7 +51,7 @@ public final class Descriptions {
      * @return A navigation to the descriptions of an element.
      */
     public static MultiNavigation<HasDescription<? extends VecAbstractLocalizedString>,
-            VecAbstractLocalizedString> descriptions() {
+            VecAbstractLocalizedString> toDescriptions() {
         return Navigations.collection(HasDescription::getDescriptions);
     }
 
@@ -84,7 +84,7 @@ public final class Descriptions {
      */
     public static SingleNavigation<HasDescription<? extends VecAbstractLocalizedString>, String> descriptionIn(
             final VecLanguageCode languageCode) {
-        return descriptions().collect(LocalizedStrings.valueIn(languageCode));
+        return toDescriptions().collect(LocalizedStrings.valueIn(languageCode));
     }
 
     /**
@@ -121,7 +121,7 @@ public final class Descriptions {
      */
     public static SingleNavigation<HasDescription<? extends VecAbstractLocalizedString>, String> typedStringBy(
             final String descriptionType, final VecLanguageCode languageCode) {
-        return descriptions().collect(LocalizedStrings.typedValueBy(descriptionType, languageCode));
+        return toDescriptions().collect(LocalizedStrings.typedValueBy(descriptionType, languageCode));
     }
 
 }

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/Descriptions.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/Descriptions.java
@@ -1,0 +1,180 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v2x.traversal;
+
+import com.foursoft.harness.vec.common.HasDescription;
+import com.foursoft.harness.vec.common.traversal.SingleNavigation;
+import com.foursoft.harness.vec.common.util.StreamUtils;
+import com.foursoft.harness.vec.common.util.StringUtils;
+import com.foursoft.harness.vec.v2x.VecAbstractLocalizedString;
+import com.foursoft.harness.vec.v2x.VecLanguageCode;
+import com.foursoft.harness.vec.v2x.VecLocalizedTypedString;
+import com.foursoft.harness.vec.v2x.predicates.VecPredicates;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Navigations to the descriptions of a {@link HasDescription} holding {@link VecAbstractLocalizedString}s.
+ */
+public final class Descriptions {
+
+    private Descriptions() {
+        // hide default constructor
+    }
+
+    /**
+     * Navigates to the german description of an element.
+     *
+     * @return A navigation to the german description.
+     * @see #descriptionIn(VecLanguageCode)
+     */
+    public static SingleNavigation<HasDescription<? extends VecAbstractLocalizedString>, String> germanDescription() {
+        return descriptionIn(VecLanguageCode.DE);
+    }
+
+    /**
+     * Navigates to the english description of an element.
+     *
+     * @return A navigation to the english description.
+     * @see #descriptionIn(VecLanguageCode)
+     */
+    public static SingleNavigation<HasDescription<? extends VecAbstractLocalizedString>, String> englishDescription() {
+        return descriptionIn(VecLanguageCode.EN);
+    }
+
+    /**
+     * Navigates to the description of an element in the given language.
+     *
+     * @param languageCode Language of the description to navigate to.
+     * @return A navigation to the description in the given language.
+     * @see #stringIn(VecLanguageCode)
+     */
+    public static SingleNavigation<HasDescription<? extends VecAbstractLocalizedString>, String> descriptionIn(
+            final VecLanguageCode languageCode) {
+        return hasDescription -> stringIn(languageCode).from(hasDescription.getDescriptions());
+    }
+
+    /**
+     * Navigates to the german value of a list of localized strings.
+     *
+     * @return A navigation to the german value.
+     * @see #stringIn(VecLanguageCode)
+     */
+    public static SingleNavigation<List<? extends VecAbstractLocalizedString>, String> germanString() {
+        return stringIn(VecLanguageCode.DE);
+    }
+
+    /**
+     * Navigates to the english value of a list of localized strings.
+     *
+     * @return A navigation to the english value.
+     * @see #stringIn(VecLanguageCode)
+     */
+    public static SingleNavigation<List<? extends VecAbstractLocalizedString>, String> englishString() {
+        return stringIn(VecLanguageCode.EN);
+    }
+
+    /**
+     * Navigates to the value of a list of localized strings in the given language.
+     * <p>
+     * A single {@link VecLocalizedTypedString} with a type is not considered a description and therefore leads
+     * to no value. A single untyped string is used regardless of its language, as there is nothing to choose
+     * from. Otherwise the typed strings are ignored and the value of the given language is used.
+     *
+     * @param languageCode Language of the value to navigate to.
+     * @return A navigation to the value in the given language.
+     */
+    public static SingleNavigation<List<? extends VecAbstractLocalizedString>, String> stringIn(
+            final VecLanguageCode languageCode) {
+        return localizedStrings -> {
+            if (localizedStrings.isEmpty()) {
+                return Optional.empty();
+            }
+            if (localizedStrings.size() == 1) {
+                final VecAbstractLocalizedString localizedString = localizedStrings.get(0);
+                if (localizedString instanceof final VecLocalizedTypedString typedString
+                        && StringUtils.isNotEmpty(typedString.getType())) {
+                    return Optional.empty();
+                }
+                return Optional.ofNullable(localizedString)
+                        .map(VecAbstractLocalizedString::getValue);
+            }
+
+            return localizedStrings.stream()
+                    .filter(Objects::nonNull)
+                    .filter(localizedString -> !(localizedString instanceof VecLocalizedTypedString))
+                    .filter(VecPredicates.languageCode(languageCode))
+                    .map(VecAbstractLocalizedString::getValue)
+                    .filter(Objects::nonNull)
+                    .collect(StreamUtils.findOneOrNone());
+        };
+    }
+
+    /**
+     * Navigates to the german {@link VecLocalizedTypedString} of the given type.
+     *
+     * @param descriptionType Type of the localized string to navigate to.
+     * @return A navigation to the german value of the given type.
+     * @see #typedStringBy(String, VecLanguageCode)
+     */
+    public static SingleNavigation<HasDescription<? extends VecAbstractLocalizedString>, String> germanTypedStringBy(
+            final String descriptionType) {
+        return typedStringBy(descriptionType, VecLanguageCode.DE);
+    }
+
+    /**
+     * Navigates to the english {@link VecLocalizedTypedString} of the given type.
+     *
+     * @param descriptionType Type of the localized string to navigate to.
+     * @return A navigation to the english value of the given type.
+     * @see #typedStringBy(String, VecLanguageCode)
+     */
+    public static SingleNavigation<HasDescription<? extends VecAbstractLocalizedString>, String> englishTypedStringBy(
+            final String descriptionType) {
+        return typedStringBy(descriptionType, VecLanguageCode.EN);
+    }
+
+    /**
+     * Navigates to the {@link VecLocalizedTypedString} of the given type in the given language.
+     *
+     * @param descriptionType Type of the localized string to navigate to.
+     * @param languageCode    Language of the localized string to navigate to.
+     * @return A navigation to the value of the given type and language.
+     */
+    public static SingleNavigation<HasDescription<? extends VecAbstractLocalizedString>, String> typedStringBy(
+            final String descriptionType, final VecLanguageCode languageCode) {
+        return hasDescription -> hasDescription.getDescriptions().stream()
+                .filter(VecPredicates.languageCode(languageCode))
+                .flatMap(StreamUtils.ofClass(VecLocalizedTypedString.class))
+                .filter(typedString -> descriptionType.equals(typedString.getType()))
+                .collect(StreamUtils.findOneOrNone())
+                .map(VecLocalizedTypedString::getValue)
+                .filter(StringUtils::isNotEmpty);
+    }
+
+}

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/DocumentVersions.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/DocumentVersions.java
@@ -1,0 +1,435 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v2x.traversal;
+
+import com.foursoft.harness.vec.common.HasIdentification;
+import com.foursoft.harness.vec.common.traversal.MultiNavigation;
+import com.foursoft.harness.vec.common.traversal.SingleNavigation;
+import com.foursoft.harness.vec.v2x.HasOccurrenceOrUsages;
+import com.foursoft.harness.vec.v2x.VecBuildingBlockPositioning2D;
+import com.foursoft.harness.vec.v2x.VecBuildingBlockPositioning3D;
+import com.foursoft.harness.vec.v2x.VecBuildingBlockSpecification2D;
+import com.foursoft.harness.vec.v2x.VecBuildingBlockSpecification3D;
+import com.foursoft.harness.vec.v2x.VecDocumentVersion;
+import com.foursoft.harness.vec.v2x.VecGeometryNode;
+import com.foursoft.harness.vec.v2x.VecGeometryNode2D;
+import com.foursoft.harness.vec.v2x.VecGeometryNode3D;
+import com.foursoft.harness.vec.v2x.VecGeometrySegment2D;
+import com.foursoft.harness.vec.v2x.VecGeometrySegment3D;
+import com.foursoft.harness.vec.v2x.VecHarnessDrawingSpecification2D;
+import com.foursoft.harness.vec.v2x.VecHarnessGeometrySpecification3D;
+import com.foursoft.harness.vec.v2x.VecNodeLocation;
+import com.foursoft.harness.vec.v2x.VecOccurrenceOrUsage;
+import com.foursoft.harness.vec.v2x.VecOccurrenceOrUsageViewItem2D;
+import com.foursoft.harness.vec.v2x.VecOccurrenceOrUsageViewItem3D;
+import com.foursoft.harness.vec.v2x.VecOnPointPlacement;
+import com.foursoft.harness.vec.v2x.VecPlaceableElementRole;
+import com.foursoft.harness.vec.v2x.VecPlacement;
+import com.foursoft.harness.vec.v2x.VecPlacementSpecification;
+import com.foursoft.harness.vec.v2x.VecSpecification;
+import com.foursoft.harness.vec.v2x.VecTopologyNode;
+import com.foursoft.harness.vec.v2x.VecTopologySegment;
+
+import java.util.Objects;
+import java.util.function.Predicate;
+
+/**
+ * Navigations starting at a {@link VecDocumentVersion}.
+ * <p>
+ * A document version reaches most of its content through its {@link VecSpecification}s, so the steps here are
+ * composed of {@link SpecificationOwners#toSpecifications()} and the matching step of {@link Specifications}.
+ * The navigations taking an argument select a single element among those, which is why they keep a noun
+ * phrase as their name.
+ */
+public final class DocumentVersions {
+
+    private DocumentVersions() {
+        // hide default constructor
+    }
+
+    /**
+     * Navigates to the 2D building blocks of a document version.
+     *
+     * @return A navigation to the 2D building block specifications of a document version.
+     */
+    public static MultiNavigation<VecDocumentVersion, VecBuildingBlockSpecification2D>
+    toBuildingBlockSpecifications2D() {
+        return SpecificationOwners.<VecDocumentVersion>toSpecifications()
+                .ofType(VecBuildingBlockSpecification2D.class);
+    }
+
+    /**
+     * Navigates to the 3D building blocks of a document version.
+     *
+     * @return A navigation to the 3D building block specifications of a document version.
+     */
+    public static MultiNavigation<VecDocumentVersion, VecBuildingBlockSpecification3D>
+    toBuildingBlockSpecifications3D() {
+        return SpecificationOwners.<VecDocumentVersion>toSpecifications()
+                .ofType(VecBuildingBlockSpecification3D.class);
+    }
+
+    /**
+     * Navigates to the 2D geometry nodes of all building blocks of a document version.
+     *
+     * @return A navigation to the 2D geometry nodes of a document version.
+     */
+    public static MultiNavigation<VecDocumentVersion, VecGeometryNode2D> toGeometryNodes2D() {
+        return toBuildingBlockSpecifications2D().then(Specifications.toGeometryNodes2D());
+    }
+
+    /**
+     * Navigates to the 3D geometry nodes of all building blocks of a document version.
+     *
+     * @return A navigation to the 3D geometry nodes of a document version.
+     */
+    public static MultiNavigation<VecDocumentVersion, VecGeometryNode3D> toGeometryNodes3D() {
+        return toBuildingBlockSpecifications3D().then(Specifications.toGeometryNodes3D());
+    }
+
+    /**
+     * Navigates to the 2D geometry segments of all building blocks of a document version.
+     *
+     * @return A navigation to the 2D geometry segments of a document version.
+     */
+    public static MultiNavigation<VecDocumentVersion, VecGeometrySegment2D> toGeometrySegments2D() {
+        return toBuildingBlockSpecifications2D().then(Specifications.toGeometrySegments2D());
+    }
+
+    /**
+     * Navigates to the 3D geometry segments of all building blocks of a document version.
+     *
+     * @return A navigation to the 3D geometry segments of a document version.
+     */
+    public static MultiNavigation<VecDocumentVersion, VecGeometrySegment3D> toGeometrySegments3D() {
+        return toBuildingBlockSpecifications3D().then(Specifications.toGeometrySegments3D());
+    }
+
+    /**
+     * Navigates to the 2D view items of all building blocks of a document version.
+     *
+     * @return A navigation to the 2D view items of a document version.
+     */
+    public static MultiNavigation<VecDocumentVersion, VecOccurrenceOrUsageViewItem2D> toViewItems2D() {
+        return toBuildingBlockSpecifications2D().then(Specifications.toViewItems2D());
+    }
+
+    /**
+     * Navigates to the 3D view items of all building blocks of a document version.
+     *
+     * @return A navigation to the 3D view items of a document version.
+     */
+    public static MultiNavigation<VecDocumentVersion, VecOccurrenceOrUsageViewItem3D> toViewItems3D() {
+        return toBuildingBlockSpecifications3D().then(Specifications.toViewItems3D());
+    }
+
+    /**
+     * Navigates to the placements of all {@link VecPlacementSpecification}s of a document version.
+     *
+     * @return A navigation to the placements of a document version.
+     */
+    public static MultiNavigation<VecDocumentVersion, VecPlacement> toPlacements() {
+        return SpecificationOwners.<VecDocumentVersion>toSpecifications()
+                .ofType(VecPlacementSpecification.class)
+                .then(Specifications.toPlacements());
+    }
+
+    /**
+     * Navigates to the {@link VecNodeLocation}s of all on point placements of a document version.
+     *
+     * @return A navigation to the node locations of a document version.
+     */
+    public static MultiNavigation<VecDocumentVersion, VecNodeLocation> toNodeLocations() {
+        return toPlacements()
+                .ofType(VecOnPointPlacement.class)
+                .then(Placements.toLocations())
+                .ofType(VecNodeLocation.class);
+    }
+
+    /**
+     * Navigates to the 2D building block positionings of all
+     * {@link VecHarnessDrawingSpecification2D}s of a document version.
+     *
+     * @return A navigation to the 2D building block positionings of a document version.
+     */
+    public static MultiNavigation<VecDocumentVersion, VecBuildingBlockPositioning2D>
+    toBuildingBlockPositionings2D() {
+        return SpecificationOwners.<VecDocumentVersion>toSpecifications()
+                .ofType(VecHarnessDrawingSpecification2D.class)
+                .then(Specifications.toBuildingBlockPositionings2D());
+    }
+
+    /**
+     * Navigates to the 3D building block positionings of all
+     * {@link VecHarnessGeometrySpecification3D}s of a document version.
+     *
+     * @return A navigation to the 3D building block positionings of a document version.
+     */
+    public static MultiNavigation<VecDocumentVersion, VecBuildingBlockPositioning3D>
+    toBuildingBlockPositionings3D() {
+        return SpecificationOwners.<VecDocumentVersion>toSpecifications()
+                .ofType(VecHarnessGeometrySpecification3D.class)
+                .then(Specifications.toBuildingBlockPositionings3D());
+    }
+
+    /**
+     * Navigates to the 2D building block with the given identification.
+     *
+     * @param specificationId Identification of the building block to navigate to.
+     * @return A navigation to the identified 2D building block specification.
+     */
+    public static SingleNavigation<VecDocumentVersion, VecBuildingBlockSpecification2D>
+    buildingBlockSpecification2dBy(final String specificationId) {
+        return toBuildingBlockSpecifications2D().filter(identifiedBy(specificationId)).atMostOne();
+    }
+
+    /**
+     * Navigates to the 3D building block with the given identification.
+     *
+     * @param specificationId Identification of the building block to navigate to.
+     * @return A navigation to the identified 3D building block specification.
+     */
+    public static SingleNavigation<VecDocumentVersion, VecBuildingBlockSpecification3D>
+    buildingBlockSpecification3dBy(final String specificationId) {
+        return toBuildingBlockSpecifications3D().filter(identifiedBy(specificationId)).atMostOne();
+    }
+
+    /**
+     * Navigates to the 3D geometry nodes representing the given {@link VecTopologyNode}.
+     *
+     * @param topologyNode Topology node the geometry nodes have to reference.
+     * @return A navigation to the 3D geometry nodes of the given topology node.
+     */
+    public static MultiNavigation<VecDocumentVersion, VecGeometryNode3D> geometryNodes3dBy(
+            final VecTopologyNode topologyNode) {
+        return toGeometryNodes3D().filter(referencing(topologyNode));
+    }
+
+    /**
+     * Navigates to the 3D geometry segments representing the given {@link VecTopologySegment}.
+     *
+     * @param topologySegment Topology segment the geometry segments have to reference.
+     * @return A navigation to the 3D geometry segments of the given topology segment.
+     */
+    public static MultiNavigation<VecDocumentVersion, VecGeometrySegment3D> geometrySegments3dBy(
+            final VecTopologySegment topologySegment) {
+        return toGeometrySegments3D()
+                .filter(segment -> Objects.equals(topologySegment, segment.getReferenceSegment()));
+    }
+
+    /**
+     * Navigates to the 2D geometry node representing the topology node of the given {@link VecNodeLocation}.
+     *
+     * @param location Location whose referenced topology node the geometry node has to reference.
+     * @return A navigation to the 2D geometry node of the given location.
+     */
+    public static SingleNavigation<VecDocumentVersion, VecGeometryNode2D> geometryNode2dBy(
+            final VecNodeLocation location) {
+        return toGeometryNodes2D().filter(referencing(location.getReferencedNode())).atMostOne();
+    }
+
+    /**
+     * Navigates to the 3D geometry node representing the topology node of the given {@link VecNodeLocation}.
+     *
+     * @param location Location whose referenced topology node the geometry node has to reference.
+     * @return A navigation to the 3D geometry node of the given location.
+     */
+    public static SingleNavigation<VecDocumentVersion, VecGeometryNode3D> geometryNode3dBy(
+            final VecNodeLocation location) {
+        return toGeometryNodes3D().filter(referencing(location.getReferencedNode())).atMostOne();
+    }
+
+    /**
+     * Navigates to the 3D view items showing the given occurrence or usage.
+     *
+     * @param occurrenceOrUsage Occurrence or usage the view items have to show.
+     * @return A navigation to the 3D view items of the given occurrence or usage.
+     */
+    public static MultiNavigation<VecDocumentVersion, VecOccurrenceOrUsageViewItem3D> viewItems3dBy(
+            final VecOccurrenceOrUsage occurrenceOrUsage) {
+        return toViewItems3D().filter(viewItem -> viewItem.getOccurrenceOrUsage().contains(occurrenceOrUsage));
+    }
+
+    /**
+     * Navigates to the 2D view item showing the occurrence or usage with the given identification.
+     *
+     * @param occurrenceOrUsageId Identification of the occurrence or usage the view item has to show.
+     * @return A navigation to the 2D view item of the identified occurrence or usage.
+     */
+    public static SingleNavigation<VecDocumentVersion, VecOccurrenceOrUsageViewItem2D> viewItem2dBy(
+            final String occurrenceOrUsageId) {
+        return toViewItems2D().filter(showing(occurrenceOrUsageId)).atMostOne();
+    }
+
+    /**
+     * Navigates to the 3D view item showing the occurrence or usage with the given identification.
+     *
+     * @param occurrenceOrUsageId Identification of the occurrence or usage the view item has to show.
+     * @return A navigation to the 3D view item of the identified occurrence or usage.
+     */
+    public static SingleNavigation<VecDocumentVersion, VecOccurrenceOrUsageViewItem3D> viewItem3dBy(
+            final String occurrenceOrUsageId) {
+        return toViewItems3D().filter(showing(occurrenceOrUsageId)).atMostOne();
+    }
+
+    /**
+     * Navigates to the 2D building block positioning referencing the given building block.
+     *
+     * @param buildingBlock Building block the positioning has to reference.
+     * @return A navigation to the positioning of the given 2D building block.
+     */
+    public static SingleNavigation<VecDocumentVersion, VecBuildingBlockPositioning2D> positioning2dWith(
+            final VecBuildingBlockSpecification2D buildingBlock) {
+        return toBuildingBlockPositionings2D()
+                .filter(positioning -> Objects.equals(buildingBlock, positioning.getReferenced2DBuildingBlock()))
+                .atMostOne();
+    }
+
+    /**
+     * Navigates to the 3D building block positioning referencing the given building block.
+     *
+     * @param buildingBlock Building block the positioning has to reference.
+     * @return A navigation to the positioning of the given 3D building block.
+     */
+    public static SingleNavigation<VecDocumentVersion, VecBuildingBlockPositioning3D> positioning3dWith(
+            final VecBuildingBlockSpecification3D buildingBlock) {
+        return toBuildingBlockPositionings3D()
+                .filter(positioning -> Objects.equals(buildingBlock, positioning.getReferenced3DBuildingBlock()))
+                .atMostOne();
+    }
+
+    /**
+     * Navigates to the placements placing the given {@link VecPlaceableElementRole}.
+     *
+     * @param placedElement Role the placements have to place.
+     * @return A navigation to the placements of the given role.
+     */
+    public static MultiNavigation<VecDocumentVersion, VecPlacement> placementsOf(
+            final VecPlaceableElementRole placedElement) {
+        return toPlacements().filter(placing(placedElement));
+    }
+
+    /**
+     * Navigates to the {@link VecNodeLocation}s of the on point placements placing the given
+     * {@link VecPlaceableElementRole}.
+     *
+     * @param placedElement Role the placements have to place.
+     * @return A navigation to the node locations of the given role.
+     */
+    public static MultiNavigation<VecDocumentVersion, VecNodeLocation> nodeLocationsOf(
+            final VecPlaceableElementRole placedElement) {
+        return toPlacements()
+                .ofType(VecOnPointPlacement.class)
+                .filter(placing(placedElement))
+                .then(Placements.toLocations())
+                .ofType(VecNodeLocation.class);
+    }
+
+    /**
+     * Navigates to the {@link VecPlaceableElementRole} of the component with the given identification, taken
+     * from the composition specification with the given identification.
+     *
+     * @param compositionSpecificationId Identification of the composition specification holding the component.
+     * @param occurrenceOrUsageId        Identification of the component.
+     * @return A navigation to the placeable element role of the identified component.
+     */
+    public static SingleNavigation<VecDocumentVersion, VecPlaceableElementRole> placeableElementRoleBy(
+            final String compositionSpecificationId, final String occurrenceOrUsageId) {
+        return SpecificationOwners.<VecDocumentVersion>componentsBy(compositionSpecificationId)
+                .filter(identifiedBy(occurrenceOrUsageId))
+                .then(OccurrenceOrUsages.toRoles())
+                .ofType(VecPlaceableElementRole.class)
+                .atMostOne();
+    }
+
+    /**
+     * Navigates to the placement of the component with the given identification, taken from the composition
+     * specification with the given identification.
+     *
+     * @param compositionSpecificationId Identification of the composition specification holding the component.
+     * @param occurrenceOrUsageId        Identification of the component.
+     * @return A navigation to the placement of the identified component.
+     * @see #placeableElementRoleBy(String, String)
+     */
+    public static SingleNavigation<VecDocumentVersion, VecPlacement> placementBy(
+            final String compositionSpecificationId, final String occurrenceOrUsageId) {
+        final SingleNavigation<VecDocumentVersion, VecPlaceableElementRole> placedElement =
+                placeableElementRoleBy(compositionSpecificationId, occurrenceOrUsageId);
+        return documentVersion -> placedElement.from(documentVersion)
+                .flatMap(role -> placementsOf(role).atMostOne().from(documentVersion));
+    }
+
+    /**
+     * Navigates to the {@link VecTopologyNode} the component with the given identification is placed on.
+     *
+     * @param occurrenceIdentification Identification of the component.
+     * @return A navigation to the topology node of the identified component.
+     */
+    public static SingleNavigation<VecDocumentVersion, VecTopologyNode> topologyNodeBy(
+            final String occurrenceIdentification) {
+        return SpecificationOwners.<VecDocumentVersion>toComponents()
+                .filter(identifiedBy(occurrenceIdentification))
+                .then(OccurrenceOrUsages.toReferencedTopologyNode())
+                .atMostOne();
+    }
+
+    /**
+     * Navigates to the {@link VecTopologyNode} the given component is placed on, by looking up the node
+     * locations of its {@link VecPlaceableElementRole} in the document version.
+     *
+     * @param component Occurrence or usage to find the topology node of.
+     * @return A navigation to the topology node of the given component.
+     */
+    public static SingleNavigation<VecDocumentVersion, VecTopologyNode> topologyNodeOf(
+            final VecOccurrenceOrUsage component) {
+        return documentVersion -> OccurrenceOrUsages.toPlaceableElementRole()
+                .from(component)
+                .flatMap(role -> nodeLocationsOf(role).atMostOne().from(documentVersion))
+                .map(VecNodeLocation::getReferencedNode);
+    }
+
+    private static Predicate<VecGeometryNode> referencing(final VecTopologyNode topologyNode) {
+        return geometryNode -> Objects.equals(topologyNode, geometryNode.getReferenceNode());
+    }
+
+    private static Predicate<VecPlacement> placing(final VecPlaceableElementRole placedElement) {
+        return placement -> placement.getPlacedElement().contains(placedElement);
+    }
+
+    private static Predicate<HasIdentification> identifiedBy(final String identification) {
+        return element -> identification.equals(element.getIdentification());
+    }
+
+    private static Predicate<HasOccurrenceOrUsages> showing(final String occurrenceOrUsageId) {
+        return viewItem -> ViewItems.toOccurrenceOrUsages()
+                .atMostOne()
+                .from(viewItem)
+                .map(VecOccurrenceOrUsage::getIdentification)
+                .filter(occurrenceOrUsageId::equals)
+                .isPresent();
+    }
+
+}

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/ExtendableElements.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/ExtendableElements.java
@@ -1,0 +1,62 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v2x.traversal;
+
+import com.foursoft.harness.vec.common.traversal.MultiNavigation;
+import com.foursoft.harness.vec.common.traversal.Navigations;
+import com.foursoft.harness.vec.v2x.VecDocumentVersion;
+import com.foursoft.harness.vec.v2x.VecExtendableElement;
+
+/**
+ * Navigations starting at a {@link VecExtendableElement}, the common super type of the elements which can
+ * carry custom properties and reference external documents.
+ */
+public final class ExtendableElements {
+
+    private ExtendableElements() {
+        // hide default constructor
+    }
+
+    /**
+     * Navigates to the external documents an element references.
+     *
+     * @return A navigation to the referenced external documents of an element.
+     */
+    public static MultiNavigation<VecExtendableElement, VecDocumentVersion> toReferencedExternalDocuments() {
+        return Navigations.collection(VecExtendableElement::getReferencedExternalDocuments);
+    }
+
+    /**
+     * Navigates to the document numbers of the external documents an element references.
+     *
+     * @return A navigation to the document numbers of the referenced external documents.
+     */
+    public static MultiNavigation<VecExtendableElement, String> toExternalDocumentNumbers() {
+        return toReferencedExternalDocuments()
+                .then(Navigations.nullable(VecDocumentVersion::getDocumentNumber));
+    }
+
+}

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/LocalizedStringProperties.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/LocalizedStringProperties.java
@@ -1,0 +1,60 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v2x.traversal;
+
+import com.foursoft.harness.vec.common.traversal.Navigations;
+import com.foursoft.harness.vec.common.traversal.SingleNavigation;
+import com.foursoft.harness.vec.v2x.VecLanguageCode;
+import com.foursoft.harness.vec.v2x.VecLocalizedString;
+import com.foursoft.harness.vec.v2x.VecLocalizedStringProperty;
+import com.foursoft.harness.vec.v2x.predicates.VecPredicates;
+
+/**
+ * Navigations starting at a {@link VecLocalizedStringProperty}.
+ * <p>
+ * A localized string property holds exactly one {@link VecLocalizedString}, so choosing between several
+ * languages does not arise here; the language is a condition on the one value, not a selection among many.
+ * Reducing several localized strings to one value is what {@link LocalizedStrings} is for.
+ */
+public final class LocalizedStringProperties {
+
+    private LocalizedStringProperties() {
+        // hide default constructor
+    }
+
+    /**
+     * Navigates to the value of a localized string property, if it is in the given language.
+     *
+     * @param languageCode Language the value has to be in.
+     * @return A navigation to the value in the given language.
+     */
+    public static SingleNavigation<VecLocalizedStringProperty, String> valueIn(final VecLanguageCode languageCode) {
+        return Navigations.nullable(VecLocalizedStringProperty::getValue)
+                .filter(VecPredicates.languageCode(languageCode))
+                .then(Navigations.nullable(VecLocalizedString::getValue));
+    }
+
+}

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/LocalizedStrings.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/LocalizedStrings.java
@@ -26,8 +26,6 @@
 package com.foursoft.harness.vec.v2x.traversal;
 
 import com.foursoft.harness.vec.common.traversal.MultiNavigation;
-import com.foursoft.harness.vec.common.traversal.Navigations;
-import com.foursoft.harness.vec.common.traversal.SingleNavigation;
 import com.foursoft.harness.vec.common.util.StreamUtils;
 import com.foursoft.harness.vec.common.util.StringUtils;
 import com.foursoft.harness.vec.v2x.VecAbstractLocalizedString;
@@ -38,11 +36,20 @@ import com.foursoft.harness.vec.v2x.predicates.VecPredicates;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collector;
 
 /**
- * Navigations starting at a list of {@link VecAbstractLocalizedString}s.
+ * Reductions from several {@link VecAbstractLocalizedString}s to the one value that applies.
  * <p>
- * Use {@link Descriptions} to navigate from an element holding such a list.
+ * These are <em>not</em> navigations: choosing the right value needs rules over the localized strings as a
+ * whole, which no sequence of steps expresses. They are therefore used with
+ * {@link MultiNavigation#collect(Collector)} on a navigation leading to the localized strings, such as
+ * {@link Descriptions#descriptions()}:
+ * <pre>
+ * {@code
+ * Descriptions.descriptions().collect(LocalizedStrings.valueIn(VecLanguageCode.DE));
+ * }
+ * </pre>
  */
 public final class LocalizedStrings {
 
@@ -51,38 +58,18 @@ public final class LocalizedStrings {
     }
 
     /**
-     * Navigates to the german value.
-     *
-     * @return A navigation to the german value.
-     * @see #stringIn(VecLanguageCode)
-     */
-    public static SingleNavigation<List<? extends VecAbstractLocalizedString>, String> germanString() {
-        return stringIn(VecLanguageCode.DE);
-    }
-
-    /**
-     * Navigates to the english value.
-     *
-     * @return A navigation to the english value.
-     * @see #stringIn(VecLanguageCode)
-     */
-    public static SingleNavigation<List<? extends VecAbstractLocalizedString>, String> englishString() {
-        return stringIn(VecLanguageCode.EN);
-    }
-
-    /**
-     * Navigates to the value in the given language.
+     * Reduces localized strings to the value in the given language.
      * <p>
-     * A single {@link VecLocalizedTypedString} with a type is not considered a description and therefore leads
-     * to no value. A single untyped string is used regardless of its language, as there is nothing to choose
-     * from. Otherwise the typed strings are ignored and the value of the given language is used.
+     * A single {@link VecLocalizedTypedString} with a type is not considered a description and therefore
+     * yields no value. A single untyped string is used regardless of its language, as there is nothing to
+     * choose from. Otherwise the typed strings are ignored and the value of the given language is used.
      *
-     * @param languageCode Language of the value to navigate to.
-     * @return A navigation to the value in the given language.
+     * @param languageCode Language of the value to reduce to.
+     * @return A reduction to the value in the given language.
      */
-    public static SingleNavigation<List<? extends VecAbstractLocalizedString>, String> stringIn(
+    public static Collector<VecAbstractLocalizedString, ?, Optional<String>> valueIn(
             final VecLanguageCode languageCode) {
-        return localizedStrings -> {
+        return StreamUtils.reducing(localizedStrings -> {
             if (localizedStrings.isEmpty()) {
                 return Optional.empty();
             }
@@ -103,34 +90,33 @@ public final class LocalizedStrings {
                     .map(VecAbstractLocalizedString::getValue)
                     .filter(Objects::nonNull)
                     .collect(StreamUtils.findOneOrNone());
-        };
+        });
     }
 
     /**
-     * Navigates to the value of the {@link VecLocalizedTypedString} with the given type and language.
+     * Reduces localized strings to the value of the {@link VecLocalizedTypedString} with the given type and
+     * language.
      *
-     * @param descriptionType Type of the localized string to navigate to.
-     * @param languageCode    Language of the localized string to navigate to.
-     * @return A navigation to the value of the given type and language.
+     * @param descriptionType Type of the localized string to reduce to.
+     * @param languageCode    Language of the localized string to reduce to.
+     * @return A reduction to the value of the given type and language.
      */
-    public static SingleNavigation<List<? extends VecAbstractLocalizedString>, String> typedStringBy(
+    public static Collector<VecAbstractLocalizedString, ?, Optional<String>> typedValueBy(
             final String descriptionType, final VecLanguageCode languageCode) {
-        return elements()
-                .filter(VecPredicates.languageCode(languageCode))
-                .ofType(VecLocalizedTypedString.class)
-                .filter(typedString -> descriptionType.equals(typedString.getType()))
-                .atMostOne()
-                .then(Navigations.nullable(VecLocalizedTypedString::getValue))
-                .filter(StringUtils::isNotEmpty);
+        return StreamUtils.reducing(localizedStrings -> reduceToTypedValue(
+                localizedStrings, descriptionType, languageCode));
     }
 
-    /**
-     * Navigates from the list to the single localized strings, so that navigations over them can be composed
-     * from the operators. Needed because the source of this catalog is the list itself.
-     */
-    private static MultiNavigation<List<? extends VecAbstractLocalizedString>, VecAbstractLocalizedString>
-    elements() {
-        return Navigations.collection(localizedStrings -> localizedStrings);
+    private static Optional<String> reduceToTypedValue(final List<VecAbstractLocalizedString> localizedStrings,
+                                                       final String descriptionType,
+                                                       final VecLanguageCode languageCode) {
+        return localizedStrings.stream()
+                .filter(VecPredicates.languageCode(languageCode))
+                .flatMap(StreamUtils.ofClass(VecLocalizedTypedString.class))
+                .filter(typedString -> descriptionType.equals(typedString.getType()))
+                .collect(StreamUtils.findOneOrNone())
+                .map(VecLocalizedTypedString::getValue)
+                .filter(StringUtils::isNotEmpty);
     }
 
 }

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/LocalizedStrings.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/LocalizedStrings.java
@@ -1,0 +1,125 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v2x.traversal;
+
+import com.foursoft.harness.vec.common.traversal.SingleNavigation;
+import com.foursoft.harness.vec.common.util.StreamUtils;
+import com.foursoft.harness.vec.common.util.StringUtils;
+import com.foursoft.harness.vec.v2x.VecAbstractLocalizedString;
+import com.foursoft.harness.vec.v2x.VecLanguageCode;
+import com.foursoft.harness.vec.v2x.VecLocalizedTypedString;
+import com.foursoft.harness.vec.v2x.predicates.VecPredicates;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Navigations starting at a list of {@link VecAbstractLocalizedString}s.
+ * <p>
+ * Use {@link Descriptions} to navigate from an element holding such a list.
+ */
+public final class LocalizedStrings {
+
+    private LocalizedStrings() {
+        // hide default constructor
+    }
+
+    /**
+     * Navigates to the german value.
+     *
+     * @return A navigation to the german value.
+     * @see #stringIn(VecLanguageCode)
+     */
+    public static SingleNavigation<List<? extends VecAbstractLocalizedString>, String> germanString() {
+        return stringIn(VecLanguageCode.DE);
+    }
+
+    /**
+     * Navigates to the english value.
+     *
+     * @return A navigation to the english value.
+     * @see #stringIn(VecLanguageCode)
+     */
+    public static SingleNavigation<List<? extends VecAbstractLocalizedString>, String> englishString() {
+        return stringIn(VecLanguageCode.EN);
+    }
+
+    /**
+     * Navigates to the value in the given language.
+     * <p>
+     * A single {@link VecLocalizedTypedString} with a type is not considered a description and therefore leads
+     * to no value. A single untyped string is used regardless of its language, as there is nothing to choose
+     * from. Otherwise the typed strings are ignored and the value of the given language is used.
+     *
+     * @param languageCode Language of the value to navigate to.
+     * @return A navigation to the value in the given language.
+     */
+    public static SingleNavigation<List<? extends VecAbstractLocalizedString>, String> stringIn(
+            final VecLanguageCode languageCode) {
+        return localizedStrings -> {
+            if (localizedStrings.isEmpty()) {
+                return Optional.empty();
+            }
+            if (localizedStrings.size() == 1) {
+                final VecAbstractLocalizedString localizedString = localizedStrings.get(0);
+                if (localizedString instanceof final VecLocalizedTypedString typedString
+                        && StringUtils.isNotEmpty(typedString.getType())) {
+                    return Optional.empty();
+                }
+                return Optional.ofNullable(localizedString)
+                        .map(VecAbstractLocalizedString::getValue);
+            }
+
+            return localizedStrings.stream()
+                    .filter(Objects::nonNull)
+                    .filter(localizedString -> !(localizedString instanceof VecLocalizedTypedString))
+                    .filter(VecPredicates.languageCode(languageCode))
+                    .map(VecAbstractLocalizedString::getValue)
+                    .filter(Objects::nonNull)
+                    .collect(StreamUtils.findOneOrNone());
+        };
+    }
+
+    /**
+     * Navigates to the value of the {@link VecLocalizedTypedString} with the given type and language.
+     *
+     * @param descriptionType Type of the localized string to navigate to.
+     * @param languageCode    Language of the localized string to navigate to.
+     * @return A navigation to the value of the given type and language.
+     */
+    public static SingleNavigation<List<? extends VecAbstractLocalizedString>, String> typedStringBy(
+            final String descriptionType, final VecLanguageCode languageCode) {
+        return localizedStrings -> localizedStrings.stream()
+                .filter(VecPredicates.languageCode(languageCode))
+                .flatMap(StreamUtils.ofClass(VecLocalizedTypedString.class))
+                .filter(typedString -> descriptionType.equals(typedString.getType()))
+                .collect(StreamUtils.findOneOrNone())
+                .map(VecLocalizedTypedString::getValue)
+                .filter(StringUtils::isNotEmpty);
+    }
+
+}

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/LocalizedStrings.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/LocalizedStrings.java
@@ -44,10 +44,10 @@ import java.util.stream.Collector;
  * These are <em>not</em> navigations: choosing the right value needs rules over the localized strings as a
  * whole, which no sequence of steps expresses. They are therefore used with
  * {@link MultiNavigation#collect(Collector)} on a navigation leading to the localized strings, such as
- * {@link Descriptions#descriptions()}:
+ * {@link Descriptions#toDescriptions()}:
  * <pre>
  * {@code
- * Descriptions.descriptions().collect(LocalizedStrings.valueIn(VecLanguageCode.DE));
+ * Descriptions.toDescriptions().collect(LocalizedStrings.valueIn(VecLanguageCode.DE));
  * }
  * </pre>
  */

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/LocalizedStrings.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/LocalizedStrings.java
@@ -25,6 +25,8 @@
  */
 package com.foursoft.harness.vec.v2x.traversal;
 
+import com.foursoft.harness.vec.common.traversal.MultiNavigation;
+import com.foursoft.harness.vec.common.traversal.Navigations;
 import com.foursoft.harness.vec.common.traversal.SingleNavigation;
 import com.foursoft.harness.vec.common.util.StreamUtils;
 import com.foursoft.harness.vec.common.util.StringUtils;
@@ -113,13 +115,22 @@ public final class LocalizedStrings {
      */
     public static SingleNavigation<List<? extends VecAbstractLocalizedString>, String> typedStringBy(
             final String descriptionType, final VecLanguageCode languageCode) {
-        return localizedStrings -> localizedStrings.stream()
+        return elements()
                 .filter(VecPredicates.languageCode(languageCode))
-                .flatMap(StreamUtils.ofClass(VecLocalizedTypedString.class))
+                .ofType(VecLocalizedTypedString.class)
                 .filter(typedString -> descriptionType.equals(typedString.getType()))
-                .collect(StreamUtils.findOneOrNone())
-                .map(VecLocalizedTypedString::getValue)
+                .atMostOne()
+                .then(Navigations.nullable(VecLocalizedTypedString::getValue))
                 .filter(StringUtils::isNotEmpty);
+    }
+
+    /**
+     * Navigates from the list to the single localized strings, so that navigations over them can be composed
+     * from the operators. Needed because the source of this catalog is the list itself.
+     */
+    private static MultiNavigation<List<? extends VecAbstractLocalizedString>, VecAbstractLocalizedString>
+    elements() {
+        return Navigations.collection(localizedStrings -> localizedStrings);
     }
 
 }

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/OccurrenceOrUsages.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/OccurrenceOrUsages.java
@@ -1,0 +1,247 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v2x.traversal;
+
+import com.foursoft.harness.vec.common.annotations.RequiresBackReferences;
+import com.foursoft.harness.vec.common.exception.VecException;
+import com.foursoft.harness.vec.common.traversal.MultiNavigation;
+import com.foursoft.harness.vec.common.traversal.Navigations;
+import com.foursoft.harness.vec.common.traversal.SingleNavigation;
+import com.foursoft.harness.vec.common.util.StringUtils;
+import com.foursoft.harness.vec.v2x.VecCompositionSpecification;
+import com.foursoft.harness.vec.v2x.VecDocumentVersion;
+import com.foursoft.harness.vec.v2x.VecLocation;
+import com.foursoft.harness.vec.v2x.VecModuleFamily;
+import com.foursoft.harness.vec.v2x.VecOccurrenceOrUsage;
+import com.foursoft.harness.vec.v2x.VecPartOccurrence;
+import com.foursoft.harness.vec.v2x.VecPartOrUsageRelatedSpecification;
+import com.foursoft.harness.vec.v2x.VecPartUsage;
+import com.foursoft.harness.vec.v2x.VecPartUsageSpecification;
+import com.foursoft.harness.vec.v2x.VecPartVersion;
+import com.foursoft.harness.vec.v2x.VecPartWithSubComponentsRole;
+import com.foursoft.harness.vec.v2x.VecPlaceableElementRole;
+import com.foursoft.harness.vec.v2x.VecPrimaryPartType;
+import com.foursoft.harness.vec.v2x.VecRole;
+import com.foursoft.harness.vec.v2x.VecTopologyNode;
+import com.foursoft.harness.vec.v2x.visitor.ReferencedNodeLocationVisitor;
+
+import java.util.Optional;
+
+/**
+ * Navigations starting at a {@link VecOccurrenceOrUsage}, including its {@link VecPartOccurrence} and
+ * {@link VecPartUsage} sub types.
+ * <p>
+ * Where both sub types lead to the same target, the navigation starts at the family and resolves the sub type
+ * internally, so the source never shows up in the method name. Navigations which only a
+ * {@link VecPartOccurrence} has, such as {@link #toPart()}, start there.
+ */
+public final class OccurrenceOrUsages {
+
+    private OccurrenceOrUsages() {
+        // hide default constructor
+    }
+
+    /**
+     * Navigates to the roles of an occurrence or usage.
+     *
+     * @return A navigation to the roles of an occurrence or usage.
+     */
+    public static MultiNavigation<VecOccurrenceOrUsage, VecRole> toRoles() {
+        return Navigations.collection(VecOccurrenceOrUsage::getRoles);
+    }
+
+    /**
+     * Navigates to the {@link VecPlaceableElementRole} of an occurrence or usage.
+     * <p>
+     * An occurrence or usage is expected to have at most one such role. If there are several ones, the first
+     * is chosen, see {@link MultiNavigation#atMostOne()}.
+     *
+     * @return A navigation to the placeable element role of an occurrence or usage.
+     */
+    public static SingleNavigation<VecOccurrenceOrUsage, VecPlaceableElementRole> toPlaceableElementRole() {
+        return toRoles()
+                .ofType(VecPlaceableElementRole.class)
+                .atMostOne();
+    }
+
+    /**
+     * Navigates to the {@link VecDocumentVersion} an occurrence or usage belongs to, through the
+     * {@link VecCompositionSpecification} of an occurrence and the {@link VecPartUsageSpecification} of a
+     * usage.
+     *
+     * @return A navigation to the parent document version of an occurrence or usage.
+     */
+    @RequiresBackReferences
+    public static SingleNavigation<VecOccurrenceOrUsage, VecDocumentVersion> toParentDocumentVersion() {
+        return occurrenceOrUsage -> switch (occurrenceOrUsage) {
+            case final VecPartOccurrence occurrence -> Navigations
+                    .nullable(VecPartOccurrence::getParentCompositionSpecification)
+                    .then(Specifications.toParentDocumentVersion())
+                    .from(occurrence);
+            case final VecPartUsage usage -> Navigations
+                    .nullable(VecPartUsage::getParentPartUsageSpecification)
+                    .then(Specifications.toParentDocumentVersion())
+                    .from(usage);
+            default -> throw unhandledSubType(occurrenceOrUsage);
+        };
+    }
+
+    /**
+     * Navigates to the document number of the {@link VecDocumentVersion} an occurrence or usage belongs to.
+     *
+     * @return A navigation to the parent document number of an occurrence or usage.
+     * @see #toParentDocumentVersion()
+     */
+    @RequiresBackReferences
+    public static SingleNavigation<VecOccurrenceOrUsage, String> toParentDocumentNumber() {
+        return toParentDocumentVersion().then(Navigations.nullable(VecDocumentVersion::getDocumentNumber));
+    }
+
+    /**
+     * Navigates to the {@link VecPrimaryPartType} of an occurrence or usage.
+     * <p>
+     * A usage states its type itself. An occurrence takes it from its {@link VecPartVersion}, falling back to
+     * the part usage it realizes and finally to {@link VecPrimaryPartType#OTHER} if it has no part.
+     *
+     * @return A navigation to the primary part type of an occurrence or usage.
+     */
+    public static SingleNavigation<VecOccurrenceOrUsage, VecPrimaryPartType> toPrimaryPartType() {
+        return occurrenceOrUsage -> switch (occurrenceOrUsage) {
+            case final VecPartOccurrence occurrence -> occurrence.getPart() != null
+                    ? Optional.ofNullable(occurrence.getPart().getPrimaryPartType())
+                    : Optional.of(toRealizedPartUsages()
+                                          .then(Navigations.nullable(VecPartUsage::getPrimaryPartUsageType))
+                                          .atMostOne()
+                                          .orElse(occurrence, VecPrimaryPartType.OTHER));
+            case final VecPartUsage usage -> Optional.ofNullable(usage.getPrimaryPartUsageType());
+            default -> throw unhandledSubType(occurrenceOrUsage);
+        };
+    }
+
+    /**
+     * Navigates to the {@link VecPartOrUsageRelatedSpecification}s of an occurrence or usage, through the
+     * {@link VecPartVersion} of an occurrence.
+     *
+     * @return A navigation to the part or usage related specifications of an occurrence or usage.
+     */
+    @RequiresBackReferences
+    public static MultiNavigation<VecOccurrenceOrUsage, VecPartOrUsageRelatedSpecification>
+    toPartOrUsageRelatedSpecifications() {
+        return occurrenceOrUsage -> switch (occurrenceOrUsage) {
+            case final VecPartOccurrence occurrence -> toPart()
+                    .then(Navigations.collection(VecPartVersion::getRefPartOrUsageRelatedSpecification))
+                    .from(occurrence);
+            case final VecPartUsage usage -> Navigations
+                    .collection(VecPartUsage::getPartOrUsageRelatedSpecification)
+                    .from(usage);
+            default -> throw unhandledSubType(occurrenceOrUsage);
+        };
+    }
+
+    /**
+     * Navigates to the {@link VecTopologyNode} an occurrence or usage is placed on, by resolving the
+     * locations of its on point placements with the {@link ReferencedNodeLocationVisitor}.
+     *
+     * @return A navigation to the referenced topology node of an occurrence or usage.
+     */
+    public static SingleNavigation<VecOccurrenceOrUsage, VecTopologyNode> toReferencedTopologyNode() {
+        final ReferencedNodeLocationVisitor visitor = new ReferencedNodeLocationVisitor();
+        return toRoles()
+                .ofType(VecPlaceableElementRole.class)
+                .then(PlaceableElementRoles.toOnPointPlacements())
+                .then(Placements.toLocations())
+                .then(Navigations.<VecLocation, VecTopologyNode>nullable(location -> location.accept(visitor)))
+                .atMostOne();
+    }
+
+    /**
+     * Navigates to the {@link VecPartVersion} an occurrence is an occurrence of.
+     *
+     * @return A navigation to the part of an occurrence.
+     */
+    public static SingleNavigation<VecPartOccurrence, VecPartVersion> toPart() {
+        return Navigations.nullable(VecPartOccurrence::getPart);
+    }
+
+    /**
+     * Navigates to the part number of the {@link VecPartVersion} of an occurrence, with multiple whitespaces
+     * collapsed into one.
+     *
+     * @return A navigation to the part number of an occurrence.
+     */
+    public static SingleNavigation<VecPartOccurrence, String> toPartNumber() {
+        return toPart()
+                .then(Navigations.nullable(VecPartVersion::getPartNumber))
+                .then(Navigations.nullable(StringUtils::collapseMultipleWhitespaces));
+    }
+
+    /**
+     * Navigates to the part version of the {@link VecPartVersion} of an occurrence, with multiple whitespaces
+     * collapsed into one.
+     *
+     * @return A navigation to the part version of an occurrence.
+     */
+    public static SingleNavigation<VecPartOccurrence, String> toPartVersion() {
+        return toPart()
+                .then(Navigations.nullable(VecPartVersion::getPartVersion))
+                .then(Navigations.nullable(StringUtils::collapseMultipleWhitespaces));
+    }
+
+    /**
+     * Navigates to the part usages an occurrence realizes.
+     *
+     * @return A navigation to the realized part usages of an occurrence.
+     */
+    public static MultiNavigation<VecPartOccurrence, VecPartUsage> toRealizedPartUsages() {
+        return Navigations.collection(VecPartOccurrence::getRealizedPartUsage);
+    }
+
+    /**
+     * Navigates to the {@link VecModuleFamily} of an occurrence which is a module.
+     * <p>
+     * Only an occurrence of a {@link VecPrimaryPartType#PART_STRUCTURE} is a module, so any other occurrence
+     * leads nowhere. Note that an assembly is a part structure as well.
+     *
+     * @return A navigation to the module family of an occurrence.
+     */
+    public static SingleNavigation<VecPartOccurrence, VecModuleFamily> toModuleFamily() {
+        final SingleNavigation<VecOccurrenceOrUsage, VecModuleFamily> moduleFamily = toRoles()
+                .ofType(VecPartWithSubComponentsRole.class)
+                .then(Navigations.collection(VecPartWithSubComponentsRole::getRefModuleFamily))
+                .atMostOne();
+        return occurrence -> toPart()
+                .then(Navigations.nullable(VecPartVersion::getPrimaryPartType))
+                .from(occurrence)
+                .filter(VecPrimaryPartType.PART_STRUCTURE::equals)
+                .flatMap(partType -> moduleFamily.from(occurrence));
+    }
+
+    private static VecException unhandledSubType(final VecOccurrenceOrUsage occurrenceOrUsage) {
+        return new VecException("Unhandled sub type of VecOccurrenceOrUsage: "
+                                        + occurrenceOrUsage.getClass().getName());
+    }
+
+}

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/PlaceableElementRoles.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/PlaceableElementRoles.java
@@ -46,7 +46,7 @@ public final class PlaceableElementRoles {
      *
      * @return A navigation to the placements of a role.
      */
-    public static MultiNavigation<VecPlaceableElementRole, VecPlacement> placements() {
+    public static MultiNavigation<VecPlaceableElementRole, VecPlacement> toPlacements() {
         return Navigations.collection(VecPlaceableElementRole::getRefPlacement);
     }
 
@@ -55,8 +55,8 @@ public final class PlaceableElementRoles {
      *
      * @return A navigation to the on point placements of a role.
      */
-    public static MultiNavigation<VecPlaceableElementRole, VecOnPointPlacement> onPointPlacements() {
-        return placements().ofType(VecOnPointPlacement.class);
+    public static MultiNavigation<VecPlaceableElementRole, VecOnPointPlacement> toOnPointPlacements() {
+        return toPlacements().ofType(VecOnPointPlacement.class);
     }
 
     /**
@@ -64,8 +64,8 @@ public final class PlaceableElementRoles {
      *
      * @return A navigation to the on way placements of a role.
      */
-    public static MultiNavigation<VecPlaceableElementRole, VecOnWayPlacement> onWayPlacements() {
-        return placements().ofType(VecOnWayPlacement.class);
+    public static MultiNavigation<VecPlaceableElementRole, VecOnWayPlacement> toOnWayPlacements() {
+        return toPlacements().ofType(VecOnWayPlacement.class);
     }
 
 }

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/PlaceableElementRoles.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/PlaceableElementRoles.java
@@ -26,52 +26,46 @@
 package com.foursoft.harness.vec.v2x.traversal;
 
 import com.foursoft.harness.vec.common.traversal.MultiNavigation;
-import com.foursoft.harness.vec.v2x.VecLocation;
+import com.foursoft.harness.vec.common.traversal.Navigations;
 import com.foursoft.harness.vec.v2x.VecOnPointPlacement;
 import com.foursoft.harness.vec.v2x.VecOnWayPlacement;
+import com.foursoft.harness.vec.v2x.VecPlaceableElementRole;
 import com.foursoft.harness.vec.v2x.VecPlacement;
 
-import java.util.Objects;
-import java.util.stream.Stream;
-
 /**
- * Navigations starting at a {@link VecPlacement}.
+ * Navigations starting at a {@link VecPlaceableElementRole}.
  */
-public final class Placements {
+public final class PlaceableElementRoles {
 
-    private Placements() {
+    private PlaceableElementRoles() {
         // hide default constructor
     }
 
     /**
-     * Navigates to the locations of a placement, regardless of how the placement expresses them: a
-     * {@link VecOnPointPlacement} holds them in a list, a {@link VecOnWayPlacement} as its start and end
-     * location. Unset locations are skipped.
+     * Navigates to all placements of a role.
      *
-     * @return A navigation to the locations of a placement.
+     * @return A navigation to the placements of a role.
      */
-    public static MultiNavigation<VecPlacement, VecLocation> locations() {
-        return placement -> switch (placement) {
-            case final VecOnPointPlacement onPointPlacement -> onPointPlacement.getLocations().stream()
-                    .filter(Objects::nonNull);
-            case final VecOnWayPlacement onWayPlacement -> Stream
-                    .of(onWayPlacement.getStartLocation(), onWayPlacement.getEndLocation())
-                    .filter(Objects::nonNull);
-            default -> Stream.empty();
-        };
+    public static MultiNavigation<VecPlaceableElementRole, VecPlacement> placements() {
+        return Navigations.collection(VecPlaceableElementRole::getRefPlacement);
     }
 
     /**
-     * Navigates to the locations of a placement which have the given type.
+     * Navigates to the {@link VecOnPointPlacement}s of a role.
      *
-     * @param locationType Type the locations have to have.
-     * @param <T>          Type to narrow the navigation to.
-     * @return A navigation to the locations of the given type.
-     * @see #locations()
+     * @return A navigation to the on point placements of a role.
      */
-    public static <T extends VecLocation> MultiNavigation<VecPlacement, T> locationsWith(
-            final Class<T> locationType) {
-        return locations().ofType(locationType);
+    public static MultiNavigation<VecPlaceableElementRole, VecOnPointPlacement> onPointPlacements() {
+        return placements().ofType(VecOnPointPlacement.class);
+    }
+
+    /**
+     * Navigates to the {@link VecOnWayPlacement}s of a role.
+     *
+     * @return A navigation to the on way placements of a role.
+     */
+    public static MultiNavigation<VecPlaceableElementRole, VecOnWayPlacement> onWayPlacements() {
+        return placements().ofType(VecOnWayPlacement.class);
     }
 
 }

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/Placements.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/Placements.java
@@ -36,6 +36,9 @@ import java.util.stream.Stream;
 
 /**
  * Navigations starting at a {@link VecPlacement}.
+ * <p>
+ * To restrict the result to a certain kind of location, narrow the navigation at the call site with
+ * {@code Placements.locations().ofType(VecNodeLocation.class)}.
  */
 public final class Placements {
 
@@ -59,19 +62,6 @@ public final class Placements {
                     .filter(Objects::nonNull);
             default -> Stream.empty();
         };
-    }
-
-    /**
-     * Navigates to the locations of a placement which have the given type.
-     *
-     * @param locationType Type the locations have to have.
-     * @param <T>          Type to narrow the navigation to.
-     * @return A navigation to the locations of the given type.
-     * @see #locations()
-     */
-    public static <T extends VecLocation> MultiNavigation<VecPlacement, T> locationsWith(
-            final Class<T> locationType) {
-        return locations().ofType(locationType);
     }
 
 }

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/Placements.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/Placements.java
@@ -1,0 +1,151 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v2x.traversal;
+
+import com.foursoft.harness.vec.common.traversal.MultiNavigation;
+import com.foursoft.harness.vec.common.traversal.Navigations;
+import com.foursoft.harness.vec.common.traversal.SingleNavigation;
+import com.foursoft.harness.vec.common.util.StreamUtils;
+import com.foursoft.harness.vec.v2x.HasOccurrenceOrUsages;
+import com.foursoft.harness.vec.v2x.VecLocation;
+import com.foursoft.harness.vec.v2x.VecOnPointPlacement;
+import com.foursoft.harness.vec.v2x.VecOnWayPlacement;
+import com.foursoft.harness.vec.v2x.VecOccurrenceOrUsageViewItem2D;
+import com.foursoft.harness.vec.v2x.VecOccurrenceOrUsageViewItem3D;
+import com.foursoft.harness.vec.v2x.VecPartOccurrence;
+import com.foursoft.harness.vec.v2x.VecPlaceableElementRole;
+import com.foursoft.harness.vec.v2x.VecPlacement;
+
+import java.util.Objects;
+import java.util.stream.Stream;
+
+/**
+ * Navigations to {@link VecPlacement}s and the {@link VecLocation}s they refer to.
+ */
+public final class Placements {
+
+    private Placements() {
+        // hide default constructor
+    }
+
+    /**
+     * Navigates to all placements of a {@link VecPlaceableElementRole}.
+     *
+     * @return A navigation to the placements of a role.
+     */
+    public static MultiNavigation<VecPlaceableElementRole, VecPlacement> placements() {
+        return Navigations.collection(VecPlaceableElementRole::getRefPlacement);
+    }
+
+    /**
+     * Navigates to the {@link VecOnPointPlacement}s of a {@link VecPlaceableElementRole}.
+     *
+     * @return A navigation to the on point placements of a role.
+     */
+    public static MultiNavigation<VecPlaceableElementRole, VecOnPointPlacement> onPointPlacement() {
+        return placements().ofType(VecOnPointPlacement.class);
+    }
+
+    /**
+     * Navigates to the {@link VecOnWayPlacement}s of a {@link VecPlaceableElementRole}.
+     *
+     * @return A navigation to the on way placements of a role.
+     */
+    public static MultiNavigation<VecPlaceableElementRole, VecOnWayPlacement> onWayPlacement() {
+        return placements().ofType(VecOnWayPlacement.class);
+    }
+
+    /**
+     * Navigates to the locations of a {@link VecOnPointPlacement}.
+     *
+     * @return A navigation to the locations of an on point placement.
+     */
+    public static MultiNavigation<VecOnPointPlacement, VecLocation> onPointLocations() {
+        return Navigations.collection(VecOnPointPlacement::getLocations);
+    }
+
+    /**
+     * Navigates to the start and end location of a {@link VecOnWayPlacement}.
+     *
+     * @return A navigation to the locations of an on way placement.
+     */
+    public static MultiNavigation<VecOnWayPlacement, VecLocation> onWayLocations() {
+        return placement -> Stream.of(placement.getStartLocation(), placement.getEndLocation())
+                .filter(Objects::nonNull);
+    }
+
+    /**
+     * Navigates to the start and end location of a {@link VecOnWayPlacement} which have the given type.
+     *
+     * @param locationType Type the locations have to have.
+     * @param <T>          Type to narrow the navigation to.
+     * @return A navigation to the locations of the given type.
+     */
+    public static <T extends VecLocation> MultiNavigation<VecOnWayPlacement, T> onWayLocationsWith(
+            final Class<T> locationType) {
+        return onWayLocations().ofType(locationType);
+    }
+
+    /**
+     * Navigates to the {@link VecPlaceableElementRole} of a {@link VecOccurrenceOrUsageViewItem3D} or
+     * {@link VecOccurrenceOrUsageViewItem2D}.
+     * <p>
+     * A view item is expected to reference at most one placeable element role. If there are several ones, the
+     * first is chosen, see {@link StreamUtils#findOneOrNone()}.
+     *
+     * @return A navigation to the placeable element role of a view item.
+     */
+    public static SingleNavigation<HasOccurrenceOrUsages, VecPlaceableElementRole> placeableElementRole() {
+        return viewItem -> viewItem.getOccurrenceOrUsage().stream()
+                .flatMap(StreamUtils.ofClass(VecPartOccurrence.class))
+                .flatMap(StreamUtils.toStream(
+                        occurrence -> occurrence.getRolesWithType(VecPlaceableElementRole.class)))
+                .collect(StreamUtils.findOneOrNone());
+    }
+
+    /**
+     * Navigates to the locations of a {@link VecOccurrenceOrUsageViewItem3D} or
+     * {@link VecOccurrenceOrUsageViewItem2D}, using the given navigation to get from the placeable element
+     * role of the view item to its locations.
+     * <p>
+     * Both kinds of placement can be used, as the way from the role to the locations is passed in:
+     * <pre>
+     * {@code
+     * Placements.locationsOf(Placements.onPointPlacement().thenEach(Placements.onPointLocations()));
+     * Placements.locationsOf(Placements.onWayPlacement().thenEach(Placements.onWayLocations()));
+     * }
+     * </pre>
+     *
+     * @param locations Navigation from the placeable element role to its locations.
+     * @return A navigation to the locations of a view item.
+     * @see #placeableElementRole()
+     */
+    public static MultiNavigation<HasOccurrenceOrUsages, VecLocation> locationsOf(
+            final MultiNavigation<VecPlaceableElementRole, VecLocation> locations) {
+        return placeableElementRole().thenEach(locations);
+    }
+
+}

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/Placements.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/Placements.java
@@ -38,7 +38,7 @@ import java.util.stream.Stream;
  * Navigations starting at a {@link VecPlacement}.
  * <p>
  * To restrict the result to a certain kind of location, narrow the navigation at the call site with
- * {@code Placements.locations().ofType(VecNodeLocation.class)}.
+ * {@code Placements.toLocations().ofType(VecNodeLocation.class)}.
  */
 public final class Placements {
 
@@ -53,7 +53,7 @@ public final class Placements {
      *
      * @return A navigation to the locations of a placement.
      */
-    public static MultiNavigation<VecPlacement, VecLocation> locations() {
+    public static MultiNavigation<VecPlacement, VecLocation> toLocations() {
         return placement -> switch (placement) {
             case final VecOnPointPlacement onPointPlacement -> onPointPlacement.getLocations().stream()
                     .filter(Objects::nonNull);

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/Roles.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/Roles.java
@@ -1,0 +1,65 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v2x.traversal;
+
+import com.foursoft.harness.vec.common.annotations.RequiresBackReferences;
+import com.foursoft.harness.vec.common.traversal.Navigations;
+import com.foursoft.harness.vec.common.traversal.SingleNavigation;
+import com.foursoft.harness.vec.v2x.VecDocumentVersion;
+import com.foursoft.harness.vec.v2x.VecOccurrenceOrUsage;
+import com.foursoft.harness.vec.v2x.VecRole;
+
+/**
+ * Navigations starting at a {@link VecRole}.
+ */
+public final class Roles {
+
+    private Roles() {
+        // hide default constructor
+    }
+
+    /**
+     * Navigates to the {@link VecOccurrenceOrUsage} a role belongs to.
+     *
+     * @return A navigation to the occurrence or usage of a role.
+     */
+    @RequiresBackReferences
+    public static SingleNavigation<VecRole, VecOccurrenceOrUsage> toParentOccurrenceOrUsage() {
+        return Navigations.nullable(VecRole::getParentOccurrenceOrUsage);
+    }
+
+    /**
+     * Navigates to the {@link VecDocumentVersion} the occurrence or usage of a role belongs to.
+     *
+     * @return A navigation to the parent document version of a role.
+     * @see OccurrenceOrUsages#toParentDocumentVersion()
+     */
+    @RequiresBackReferences
+    public static SingleNavigation<VecRole, VecDocumentVersion> toParentDocumentVersion() {
+        return toParentOccurrenceOrUsage().then(OccurrenceOrUsages.toParentDocumentVersion());
+    }
+
+}

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/SpecificationOwners.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/SpecificationOwners.java
@@ -1,0 +1,130 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v2x.traversal;
+
+import com.foursoft.harness.vec.common.HasSpecifications;
+import com.foursoft.harness.vec.common.traversal.MultiNavigation;
+import com.foursoft.harness.vec.common.traversal.Navigations;
+import com.foursoft.harness.vec.v2x.VecCompositionSpecification;
+import com.foursoft.harness.vec.v2x.VecDocumentVersion;
+import com.foursoft.harness.vec.v2x.VecOccurrenceOrUsage;
+import com.foursoft.harness.vec.v2x.VecPartOccurrence;
+import com.foursoft.harness.vec.v2x.VecPartUsage;
+import com.foursoft.harness.vec.v2x.VecPartUsageSpecification;
+import com.foursoft.harness.vec.v2x.VecSheetOrChapter;
+import com.foursoft.harness.vec.v2x.VecSpecification;
+
+import java.util.stream.Stream;
+
+/**
+ * Navigations starting at a {@link HasSpecifications} holding {@link VecSpecification}s, that is at a
+ * {@link VecDocumentVersion} or a {@link VecSheetOrChapter}.
+ * <p>
+ * The catalog is not named {@code Specifications}, which is the catalog of the specifications themselves;
+ * these navigations start at the element <em>holding</em> them. They are generic in their source, so a chain
+ * starting at one of the holders keeps that holder as its source type:
+ * <pre>
+ * {@code
+ * MultiNavigation<VecDocumentVersion, VecPlacementSpecification> placementSpecifications =
+ *     SpecificationOwners.<VecDocumentVersion>toSpecifications().ofType(VecPlacementSpecification.class);
+ * }
+ * </pre>
+ *
+ * @see Specifications
+ */
+public final class SpecificationOwners {
+
+    private SpecificationOwners() {
+        // hide default constructor
+    }
+
+    /**
+     * Navigates to the specifications of their holder.
+     *
+     * @param <S> Type of the specification holder to navigate from.
+     * @return A navigation to the specifications of a holder.
+     */
+    public static <S extends HasSpecifications<VecSpecification>> MultiNavigation<S, VecSpecification>
+    toSpecifications() {
+        return Navigations.collection(HasSpecifications::getSpecifications);
+    }
+
+    /**
+     * Navigates to the components of all {@link VecCompositionSpecification}s of a specification holder.
+     *
+     * @param <S> Type of the specification holder to navigate from.
+     * @return A navigation to the components of a holder.
+     */
+    public static <S extends HasSpecifications<VecSpecification>> MultiNavigation<S, VecPartOccurrence>
+    toComponents() {
+        return SpecificationOwners.<S>toSpecifications()
+                .ofType(VecCompositionSpecification.class)
+                .then(Specifications.toComponents());
+    }
+
+    /**
+     * Navigates to the part usages of all {@link VecPartUsageSpecification}s of a specification holder.
+     *
+     * @param <S> Type of the specification holder to navigate from.
+     * @return A navigation to the part usages of a holder.
+     */
+    public static <S extends HasSpecifications<VecSpecification>> MultiNavigation<S, VecPartUsage> toPartUsages() {
+        return SpecificationOwners.<S>toSpecifications()
+                .ofType(VecPartUsageSpecification.class)
+                .then(Specifications.toPartUsages());
+    }
+
+    /**
+     * Navigates to all occurrences and usages of a specification holder, that is to its
+     * {@linkplain #toComponents() components} followed by its {@linkplain #toPartUsages() part usages}.
+     *
+     * @param <S> Type of the specification holder to navigate from.
+     * @return A navigation to the occurrences and usages of a holder.
+     */
+    public static <S extends HasSpecifications<VecSpecification>> MultiNavigation<S, VecOccurrenceOrUsage>
+    toOccurrenceOrUsages() {
+        final MultiNavigation<S, VecPartOccurrence> components = toComponents();
+        final MultiNavigation<S, VecPartUsage> partUsages = toPartUsages();
+        return source -> Stream.concat(components.from(source), partUsages.from(source));
+    }
+
+    /**
+     * Navigates to the components of the {@link VecCompositionSpecification} with the given identification.
+     *
+     * @param compositionSpecificationId Identification of the composition specification to navigate into.
+     * @param <S>                        Type of the specification holder to navigate from.
+     * @return A navigation to the components of the identified composition specification.
+     */
+    public static <S extends HasSpecifications<VecSpecification>> MultiNavigation<S, VecPartOccurrence> componentsBy(
+            final String compositionSpecificationId) {
+        return SpecificationOwners.<S>toSpecifications()
+                .ofType(VecCompositionSpecification.class)
+                .filter(specification -> specification.getIdentification().equals(compositionSpecificationId))
+                .atMostOne()
+                .then(Specifications.toComponents());
+    }
+
+}

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/Specifications.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/Specifications.java
@@ -1,0 +1,246 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v2x.traversal;
+
+import com.foursoft.harness.vec.common.HasIdentification;
+import com.foursoft.harness.vec.common.annotations.RequiresBackReferences;
+import com.foursoft.harness.vec.common.traversal.MultiNavigation;
+import com.foursoft.harness.vec.common.traversal.Navigations;
+import com.foursoft.harness.vec.common.traversal.SingleNavigation;
+import com.foursoft.harness.vec.v2x.VecBuildingBlockPositioning2D;
+import com.foursoft.harness.vec.v2x.VecBuildingBlockPositioning3D;
+import com.foursoft.harness.vec.v2x.VecBuildingBlockSpecification2D;
+import com.foursoft.harness.vec.v2x.VecBuildingBlockSpecification3D;
+import com.foursoft.harness.vec.v2x.VecCompositionSpecification;
+import com.foursoft.harness.vec.v2x.VecDocumentVersion;
+import com.foursoft.harness.vec.v2x.VecGeometryNode2D;
+import com.foursoft.harness.vec.v2x.VecGeometryNode3D;
+import com.foursoft.harness.vec.v2x.VecGeometrySegment2D;
+import com.foursoft.harness.vec.v2x.VecGeometrySegment3D;
+import com.foursoft.harness.vec.v2x.VecHarnessDrawingSpecification2D;
+import com.foursoft.harness.vec.v2x.VecHarnessGeometrySpecification3D;
+import com.foursoft.harness.vec.v2x.VecOccurrenceOrUsageViewItem2D;
+import com.foursoft.harness.vec.v2x.VecOccurrenceOrUsageViewItem3D;
+import com.foursoft.harness.vec.v2x.VecPartOccurrence;
+import com.foursoft.harness.vec.v2x.VecPartUsage;
+import com.foursoft.harness.vec.v2x.VecPartUsageSpecification;
+import com.foursoft.harness.vec.v2x.VecPlacement;
+import com.foursoft.harness.vec.v2x.VecPlacementSpecification;
+import com.foursoft.harness.vec.v2x.VecSheetOrChapter;
+import com.foursoft.harness.vec.v2x.VecSpecification;
+
+import java.util.Optional;
+import java.util.function.Predicate;
+
+/**
+ * Navigations starting at a {@link VecSpecification} or one of its sub types.
+ * <p>
+ * The steps of the sub types name the elements they lead to, which is what the {@code 2D} and {@code 3D} in
+ * their names refer to. Where a document version rather than a single specification is at hand,
+ * {@link DocumentVersions} offers the same targets from there.
+ */
+public final class Specifications {
+
+    private Specifications() {
+        // hide default constructor
+    }
+
+    /**
+     * Navigates to the {@link VecDocumentVersion} a specification belongs to, whether it is held by the
+     * document version directly or by one of its {@link VecSheetOrChapter}s.
+     *
+     * @return A navigation to the parent document version of a specification.
+     */
+    @RequiresBackReferences
+    public static SingleNavigation<VecSpecification, VecDocumentVersion> toParentDocumentVersion() {
+        return specification -> Optional.ofNullable(specification.getParentDocumentVersion())
+                .or(() -> Optional.ofNullable(specification.getParentSheetOrChapter())
+                        .map(VecSheetOrChapter::getParentDocumentVersion));
+    }
+
+    /**
+     * Navigates to the document number of the {@link VecDocumentVersion} a specification belongs to.
+     *
+     * @return A navigation to the parent document number of a specification.
+     * @see #toParentDocumentVersion()
+     */
+    @RequiresBackReferences
+    public static SingleNavigation<VecSpecification, String> toParentDocumentNumber() {
+        return toParentDocumentVersion().then(Navigations.nullable(VecDocumentVersion::getDocumentNumber));
+    }
+
+    /**
+     * Navigates to the components of a {@link VecCompositionSpecification}.
+     *
+     * @return A navigation to the components of a composition specification.
+     */
+    public static MultiNavigation<VecCompositionSpecification, VecPartOccurrence> toComponents() {
+        return Navigations.collection(VecCompositionSpecification::getComponents);
+    }
+
+    /**
+     * Navigates to the part usages of a {@link VecPartUsageSpecification}.
+     *
+     * @return A navigation to the part usages of a part usage specification.
+     */
+    public static MultiNavigation<VecPartUsageSpecification, VecPartUsage> toPartUsages() {
+        return Navigations.collection(VecPartUsageSpecification::getPartUsages);
+    }
+
+    /**
+     * Navigates to the placements of a {@link VecPlacementSpecification}.
+     *
+     * @return A navigation to the placements of a placement specification.
+     */
+    public static MultiNavigation<VecPlacementSpecification, VecPlacement> toPlacements() {
+        return Navigations.collection(VecPlacementSpecification::getPlacements);
+    }
+
+    /**
+     * Navigates to the geometry nodes of a {@link VecBuildingBlockSpecification2D}.
+     *
+     * @return A navigation to the 2D geometry nodes of a building block.
+     */
+    public static MultiNavigation<VecBuildingBlockSpecification2D, VecGeometryNode2D> toGeometryNodes2D() {
+        return Navigations.collection(VecBuildingBlockSpecification2D::getGeometryNodes);
+    }
+
+    /**
+     * Navigates to the geometry nodes of a {@link VecBuildingBlockSpecification3D}.
+     *
+     * @return A navigation to the 3D geometry nodes of a building block.
+     */
+    public static MultiNavigation<VecBuildingBlockSpecification3D, VecGeometryNode3D> toGeometryNodes3D() {
+        return Navigations.collection(VecBuildingBlockSpecification3D::getGeometryNodes);
+    }
+
+    /**
+     * Navigates to the geometry segments of a {@link VecBuildingBlockSpecification2D}.
+     *
+     * @return A navigation to the 2D geometry segments of a building block.
+     */
+    public static MultiNavigation<VecBuildingBlockSpecification2D, VecGeometrySegment2D> toGeometrySegments2D() {
+        return Navigations.collection(VecBuildingBlockSpecification2D::getGeometrySegments);
+    }
+
+    /**
+     * Navigates to the geometry segments of a {@link VecBuildingBlockSpecification3D}.
+     *
+     * @return A navigation to the 3D geometry segments of a building block.
+     */
+    public static MultiNavigation<VecBuildingBlockSpecification3D, VecGeometrySegment3D> toGeometrySegments3D() {
+        return Navigations.collection(VecBuildingBlockSpecification3D::getGeometrySegments);
+    }
+
+    /**
+     * Navigates to the view items of a {@link VecBuildingBlockSpecification2D}.
+     *
+     * @return A navigation to the 2D view items of a building block.
+     */
+    public static MultiNavigation<VecBuildingBlockSpecification2D, VecOccurrenceOrUsageViewItem2D> toViewItems2D() {
+        return Navigations.collection(VecBuildingBlockSpecification2D::getPlacedElementViewItems);
+    }
+
+    /**
+     * Navigates to the view items of a {@link VecBuildingBlockSpecification3D}.
+     *
+     * @return A navigation to the 3D view items of a building block.
+     */
+    public static MultiNavigation<VecBuildingBlockSpecification3D, VecOccurrenceOrUsageViewItem3D> toViewItems3D() {
+        return Navigations.collection(VecBuildingBlockSpecification3D::getPlacedElementViewItem3Ds);
+    }
+
+    /**
+     * Navigates to the building block positionings of a {@link VecHarnessDrawingSpecification2D}.
+     *
+     * @return A navigation to the 2D building block positionings of a harness drawing.
+     */
+    public static MultiNavigation<VecHarnessDrawingSpecification2D, VecBuildingBlockPositioning2D>
+    toBuildingBlockPositionings2D() {
+        return Navigations.collection(VecHarnessDrawingSpecification2D::getBuildingBlockPositionings);
+    }
+
+    /**
+     * Navigates to the building block positionings of a {@link VecHarnessGeometrySpecification3D}.
+     *
+     * @return A navigation to the 3D building block positionings of a harness geometry.
+     */
+    public static MultiNavigation<VecHarnessGeometrySpecification3D, VecBuildingBlockPositioning3D>
+    toBuildingBlockPositionings3D() {
+        return Navigations.collection(VecHarnessGeometrySpecification3D::getBuildingBlockPositionings);
+    }
+
+    /**
+     * Navigates to the geometry node of a {@link VecBuildingBlockSpecification2D} with the given identification.
+     *
+     * @param nodeId Identification of the geometry node to navigate to.
+     * @return A navigation to the identified 2D geometry node.
+     */
+    public static SingleNavigation<VecBuildingBlockSpecification2D, VecGeometryNode2D> geometryNode2dBy(
+            final String nodeId) {
+        return toGeometryNodes2D().filter(identifiedBy(nodeId)).atMostOne();
+    }
+
+    /**
+     * Navigates to the geometry node of a {@link VecBuildingBlockSpecification3D} with the given identification.
+     *
+     * @param nodeId Identification of the geometry node to navigate to.
+     * @return A navigation to the identified 3D geometry node.
+     */
+    public static SingleNavigation<VecBuildingBlockSpecification3D, VecGeometryNode3D> geometryNode3dBy(
+            final String nodeId) {
+        return toGeometryNodes3D().filter(identifiedBy(nodeId)).atMostOne();
+    }
+
+    /**
+     * Navigates to the geometry segment of a {@link VecBuildingBlockSpecification2D} with the given
+     * identification.
+     *
+     * @param segmentId Identification of the geometry segment to navigate to.
+     * @return A navigation to the identified 2D geometry segment.
+     */
+    public static SingleNavigation<VecBuildingBlockSpecification2D, VecGeometrySegment2D> geometrySegment2dBy(
+            final String segmentId) {
+        return toGeometrySegments2D().filter(identifiedBy(segmentId)).atMostOne();
+    }
+
+    /**
+     * Navigates to the geometry segment of a {@link VecBuildingBlockSpecification3D} with the given
+     * identification.
+     *
+     * @param segmentId Identification of the geometry segment to navigate to.
+     * @return A navigation to the identified 3D geometry segment.
+     */
+    public static SingleNavigation<VecBuildingBlockSpecification3D, VecGeometrySegment3D> geometrySegment3dBy(
+            final String segmentId) {
+        return toGeometrySegments3D().filter(identifiedBy(segmentId)).atMostOne();
+    }
+
+    private static Predicate<HasIdentification> identifiedBy(final String identification) {
+        return element -> element.getIdentification().equals(identification);
+    }
+
+}

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/TopologySegments.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/TopologySegments.java
@@ -1,0 +1,113 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v2x.traversal;
+
+import com.foursoft.harness.vec.common.annotations.RequiresBackReferences;
+import com.foursoft.harness.vec.common.traversal.MultiNavigation;
+import com.foursoft.harness.vec.common.traversal.Navigations;
+import com.foursoft.harness.vec.common.traversal.SingleNavigation;
+import com.foursoft.harness.vec.v2x.VecNumericalValue;
+import com.foursoft.harness.vec.v2x.VecSegmentCrossSectionArea;
+import com.foursoft.harness.vec.v2x.VecSegmentLength;
+import com.foursoft.harness.vec.v2x.VecTopologySegment;
+import com.foursoft.harness.vec.v2x.VecTopologySpecification;
+
+import java.util.Objects;
+
+/**
+ * Navigations starting at a {@link VecTopologySegment}.
+ * <p>
+ * A segment carries its length and cross section area several times over, once per classification, which is
+ * why the navigations to them are named after the value they select rather than after a plain step.
+ */
+public final class TopologySegments {
+
+    private TopologySegments() {
+        // hide default constructor
+    }
+
+    /**
+     * Navigates to the document number of the {@link com.foursoft.harness.vec.v2x.VecDocumentVersion} the
+     * {@link VecTopologySpecification} of a segment belongs to.
+     *
+     * @return A navigation to the parent document number of a segment.
+     */
+    @RequiresBackReferences
+    public static SingleNavigation<VecTopologySegment, String> toParentDocumentNumber() {
+        return Navigations.nullable(VecTopologySegment::getParentTopologySpecification)
+                .then(Specifications.toParentDocumentNumber());
+    }
+
+    /**
+     * Navigates to the length informations of a segment.
+     *
+     * @return A navigation to the length informations of a segment.
+     */
+    public static MultiNavigation<VecTopologySegment, VecSegmentLength> toLengthInformations() {
+        return Navigations.<VecTopologySegment, VecSegmentLength>collection(VecTopologySegment::getLengthInformations)
+                .filter(Objects::nonNull);
+    }
+
+    /**
+     * Navigates to the cross section area informations of a segment.
+     *
+     * @return A navigation to the cross section area informations of a segment.
+     */
+    public static MultiNavigation<VecTopologySegment, VecSegmentCrossSectionArea> toCrossSectionAreaInformations() {
+        return Navigations.<VecTopologySegment, VecSegmentCrossSectionArea>collection(
+                        VecTopologySegment::getCrossSectionAreaInformations)
+                .filter(Objects::nonNull);
+    }
+
+    /**
+     * Navigates to the length of a segment with the given classification.
+     *
+     * @param segmentLengthClassification Classification of the length to navigate to.
+     * @return A navigation to the length value of the given classification.
+     */
+    public static SingleNavigation<VecTopologySegment, Double> lengthBy(final String segmentLengthClassification) {
+        return toLengthInformations()
+                .filter(length -> segmentLengthClassification.equals(length.getClassification()))
+                .atMostOne()
+                .then(Navigations.nullable(VecSegmentLength::getLength))
+                .then(Navigations.nullable(VecNumericalValue::getValueComponent));
+    }
+
+    /**
+     * Navigates to the cross section area of a segment of the given type.
+     *
+     * @param areaType Type of the cross section area to navigate to, which may be {@code null}.
+     * @return A navigation to the cross section area value of the given type.
+     */
+    public static SingleNavigation<VecTopologySegment, Double> crossSectionAreaBy(final String areaType) {
+        return toCrossSectionAreaInformations()
+                .filter(area -> Objects.equals(areaType, area.getCrossSectionAreaType()))
+                .atMostOne()
+                .then(Navigations.nullable(VecSegmentCrossSectionArea::getArea))
+                .then(Navigations.nullable(VecNumericalValue::getValueComponent));
+    }
+
+}

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/ViewItems.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/ViewItems.java
@@ -25,9 +25,11 @@
  */
 package com.foursoft.harness.vec.v2x.traversal;
 
+import com.foursoft.harness.vec.common.traversal.MultiNavigation;
+import com.foursoft.harness.vec.common.traversal.Navigations;
 import com.foursoft.harness.vec.common.traversal.SingleNavigation;
-import com.foursoft.harness.vec.common.util.StreamUtils;
 import com.foursoft.harness.vec.v2x.HasOccurrenceOrUsages;
+import com.foursoft.harness.vec.v2x.VecOccurrenceOrUsage;
 import com.foursoft.harness.vec.v2x.VecOccurrenceOrUsageViewItem2D;
 import com.foursoft.harness.vec.v2x.VecOccurrenceOrUsageViewItem3D;
 import com.foursoft.harness.vec.v2x.VecPartOccurrence;
@@ -53,19 +55,28 @@ public final class ViewItems {
     }
 
     /**
+     * Navigates to the occurrences or usages a view item shows.
+     *
+     * @return A navigation to the occurrences or usages of a view item.
+     */
+    public static MultiNavigation<HasOccurrenceOrUsages, VecOccurrenceOrUsage> occurrenceOrUsages() {
+        return Navigations.collection(HasOccurrenceOrUsages::getOccurrenceOrUsage);
+    }
+
+    /**
      * Navigates to the {@link VecPlaceableElementRole} of a view item.
      * <p>
      * A view item is expected to reference at most one placeable element role. If there are several ones, the
-     * first is chosen, see {@link StreamUtils#findOneOrNone()}.
+     * first is chosen, see {@link MultiNavigation#atMostOne()}.
      *
      * @return A navigation to the placeable element role of a view item.
      */
     public static SingleNavigation<HasOccurrenceOrUsages, VecPlaceableElementRole> placeableElementRole() {
-        return viewItem -> viewItem.getOccurrenceOrUsage().stream()
-                .flatMap(StreamUtils.ofClass(VecPartOccurrence.class))
-                .flatMap(StreamUtils.toStream(
-                        occurrence -> occurrence.getRolesWithType(VecPlaceableElementRole.class)))
-                .collect(StreamUtils.findOneOrNone());
+        return occurrenceOrUsages()
+                .ofType(VecPartOccurrence.class)
+                .then(Navigations.collection(VecOccurrenceOrUsage::getRoles))
+                .ofType(VecPlaceableElementRole.class)
+                .atMostOne();
     }
 
 }

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/ViewItems.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/ViewItems.java
@@ -41,8 +41,8 @@ import com.foursoft.harness.vec.v2x.VecPlaceableElementRole;
  * <pre>
  * {@code
  * ViewItems.placeableElementRole()
- *         .thenEach(PlaceableElementRoles.onWayPlacements())
- *         .thenEach(Placements.locations());
+ *         .then(PlaceableElementRoles.onWayPlacements())
+ *         .then(Placements.locations());
  * }
  * </pre>
  */

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/ViewItems.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/ViewItems.java
@@ -1,0 +1,86 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v2x.traversal;
+
+import com.foursoft.harness.vec.common.traversal.MultiNavigation;
+import com.foursoft.harness.vec.common.traversal.SingleNavigation;
+import com.foursoft.harness.vec.common.util.StreamUtils;
+import com.foursoft.harness.vec.v2x.HasOccurrenceOrUsages;
+import com.foursoft.harness.vec.v2x.VecLocation;
+import com.foursoft.harness.vec.v2x.VecOccurrenceOrUsageViewItem2D;
+import com.foursoft.harness.vec.v2x.VecOccurrenceOrUsageViewItem3D;
+import com.foursoft.harness.vec.v2x.VecPartOccurrence;
+import com.foursoft.harness.vec.v2x.VecPlaceableElementRole;
+
+/**
+ * Navigations starting at a {@link HasOccurrenceOrUsages}, that is a {@link VecOccurrenceOrUsageViewItem2D}
+ * or {@link VecOccurrenceOrUsageViewItem3D}.
+ */
+public final class ViewItems {
+
+    private ViewItems() {
+        // hide default constructor
+    }
+
+    /**
+     * Navigates to the {@link VecPlaceableElementRole} of a view item.
+     * <p>
+     * A view item is expected to reference at most one placeable element role. If there are several ones, the
+     * first is chosen, see {@link StreamUtils#findOneOrNone()}.
+     *
+     * @return A navigation to the placeable element role of a view item.
+     */
+    public static SingleNavigation<HasOccurrenceOrUsages, VecPlaceableElementRole> placeableElementRole() {
+        return viewItem -> viewItem.getOccurrenceOrUsage().stream()
+                .flatMap(StreamUtils.ofClass(VecPartOccurrence.class))
+                .flatMap(StreamUtils.toStream(
+                        occurrence -> occurrence.getRolesWithType(VecPlaceableElementRole.class)))
+                .collect(StreamUtils.findOneOrNone());
+    }
+
+    /**
+     * Navigates to the locations of a view item, using the given navigation to get from its placeable element
+     * role to the locations.
+     * <p>
+     * Since the way from the role to the locations is passed in, every kind of placement can be used:
+     * <pre>
+     * {@code
+     * ViewItems.locations(PlaceableElementRoles.onPointPlacements().thenEach(Placements.locations()));
+     * ViewItems.locations(PlaceableElementRoles.onWayPlacements().thenEach(Placements.locations()));
+     * ViewItems.locations(PlaceableElementRoles.placements().thenEach(Placements.locations()));
+     * }
+     * </pre>
+     *
+     * @param locations Navigation from the placeable element role to its locations.
+     * @return A navigation to the locations of a view item.
+     * @see #placeableElementRole()
+     */
+    public static MultiNavigation<HasOccurrenceOrUsages, VecLocation> locations(
+            final MultiNavigation<VecPlaceableElementRole, VecLocation> locations) {
+        return placeableElementRole().thenEach(locations);
+    }
+
+}

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/ViewItems.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/ViewItems.java
@@ -42,9 +42,9 @@ import com.foursoft.harness.vec.v2x.VecPlaceableElementRole;
  * To reach the locations of a view item, continue this navigation at the call site, for example
  * <pre>
  * {@code
- * ViewItems.placeableElementRole()
- *         .then(PlaceableElementRoles.onWayPlacements())
- *         .then(Placements.locations());
+ * ViewItems.toPlaceableElementRole()
+ *         .then(PlaceableElementRoles.toOnWayPlacements())
+ *         .then(Placements.toLocations());
  * }
  * </pre>
  */
@@ -59,7 +59,7 @@ public final class ViewItems {
      *
      * @return A navigation to the occurrences or usages of a view item.
      */
-    public static MultiNavigation<HasOccurrenceOrUsages, VecOccurrenceOrUsage> occurrenceOrUsages() {
+    public static MultiNavigation<HasOccurrenceOrUsages, VecOccurrenceOrUsage> toOccurrenceOrUsages() {
         return Navigations.collection(HasOccurrenceOrUsages::getOccurrenceOrUsage);
     }
 
@@ -71,8 +71,8 @@ public final class ViewItems {
      *
      * @return A navigation to the placeable element role of a view item.
      */
-    public static SingleNavigation<HasOccurrenceOrUsages, VecPlaceableElementRole> placeableElementRole() {
-        return occurrenceOrUsages()
+    public static SingleNavigation<HasOccurrenceOrUsages, VecPlaceableElementRole> toPlaceableElementRole() {
+        return toOccurrenceOrUsages()
                 .ofType(VecPartOccurrence.class)
                 .then(Navigations.collection(VecOccurrenceOrUsage::getRoles))
                 .ofType(VecPlaceableElementRole.class)

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/ViewItems.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/ViewItems.java
@@ -25,11 +25,9 @@
  */
 package com.foursoft.harness.vec.v2x.traversal;
 
-import com.foursoft.harness.vec.common.traversal.MultiNavigation;
 import com.foursoft.harness.vec.common.traversal.SingleNavigation;
 import com.foursoft.harness.vec.common.util.StreamUtils;
 import com.foursoft.harness.vec.v2x.HasOccurrenceOrUsages;
-import com.foursoft.harness.vec.v2x.VecLocation;
 import com.foursoft.harness.vec.v2x.VecOccurrenceOrUsageViewItem2D;
 import com.foursoft.harness.vec.v2x.VecOccurrenceOrUsageViewItem3D;
 import com.foursoft.harness.vec.v2x.VecPartOccurrence;
@@ -38,6 +36,15 @@ import com.foursoft.harness.vec.v2x.VecPlaceableElementRole;
 /**
  * Navigations starting at a {@link HasOccurrenceOrUsages}, that is a {@link VecOccurrenceOrUsageViewItem2D}
  * or {@link VecOccurrenceOrUsageViewItem3D}.
+ * <p>
+ * To reach the locations of a view item, continue this navigation at the call site, for example
+ * <pre>
+ * {@code
+ * ViewItems.placeableElementRole()
+ *         .thenEach(PlaceableElementRoles.onWayPlacements())
+ *         .thenEach(Placements.locations());
+ * }
+ * </pre>
  */
 public final class ViewItems {
 
@@ -59,28 +66,6 @@ public final class ViewItems {
                 .flatMap(StreamUtils.toStream(
                         occurrence -> occurrence.getRolesWithType(VecPlaceableElementRole.class)))
                 .collect(StreamUtils.findOneOrNone());
-    }
-
-    /**
-     * Navigates to the locations of a view item, using the given navigation to get from its placeable element
-     * role to the locations.
-     * <p>
-     * Since the way from the role to the locations is passed in, every kind of placement can be used:
-     * <pre>
-     * {@code
-     * ViewItems.locations(PlaceableElementRoles.onPointPlacements().thenEach(Placements.locations()));
-     * ViewItems.locations(PlaceableElementRoles.onWayPlacements().thenEach(Placements.locations()));
-     * ViewItems.locations(PlaceableElementRoles.placements().thenEach(Placements.locations()));
-     * }
-     * </pre>
-     *
-     * @param locations Navigation from the placeable element role to its locations.
-     * @return A navigation to the locations of a view item.
-     * @see #placeableElementRole()
-     */
-    public static MultiNavigation<HasOccurrenceOrUsages, VecLocation> locations(
-            final MultiNavigation<VecPlaceableElementRole, VecLocation> locations) {
-        return placeableElementRole().thenEach(locations);
     }
 
 }

--- a/vec/vec-v2x/src/main/java/module-info.java
+++ b/vec/vec-v2x/src/main/java/module-info.java
@@ -35,5 +35,6 @@ open module com.foursoft.harness.vec.v2x {
     exports com.foursoft.harness.vec.v2x.visitor;
     exports com.foursoft.harness.vec.v2x.navigations;
     exports com.foursoft.harness.vec.v2x.predicates;
+    exports com.foursoft.harness.vec.v2x.traversal;
     exports com.foursoft.harness.vec.v2x.validation;
 }

--- a/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/ConfigurableElementsTest.java
+++ b/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/ConfigurableElementsTest.java
@@ -1,0 +1,112 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v2x.traversal;
+
+import com.foursoft.harness.vec.v2x.VecConfigurableElement;
+import com.foursoft.harness.vec.v2x.VecPartOccurrence;
+import com.foursoft.harness.vec.v2x.VecVariantConfiguration;
+import com.foursoft.harness.vec.v2x.navigations.ConfigurableElementNavs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings({"deprecation", "removal"})
+class ConfigurableElementsTest {
+
+    private final VecConfigurableElement unconfigured = new VecPartOccurrence();
+
+    private VecVariantConfiguration configuration;
+    private VecConfigurableElement configured;
+
+    @BeforeEach
+    void setUp() {
+        configuration = new VecVariantConfiguration();
+        configuration.setLogisticControlString("A + B");
+        configuration.setLogisticControlExpression("A OR B");
+
+        final VecPartOccurrence occurrence = new VecPartOccurrence();
+        occurrence.setConfigInfo(configuration);
+        configured = occurrence;
+    }
+
+    @Test
+    void navigatesToTheVariantConfigurationOfAnElement() {
+        assertThat(ConfigurableElements.toVariantConfiguration().from(configured)).contains(configuration);
+    }
+
+    @Test
+    void navigatesToTheLogisticControlStringAndExpression() {
+        assertThat(ConfigurableElements.toLogisticControlString().from(configured)).contains("A + B");
+        assertThat(ConfigurableElements.toLogisticControlExpression().from(configured)).contains("A OR B");
+    }
+
+    @Test
+    void navigatesNowhereForAnUnconfiguredElement() {
+        assertThat(ConfigurableElements.toVariantConfiguration().from(unconfigured)).isEmpty();
+        assertThat(ConfigurableElements.toLogisticControlString().from(unconfigured)).isEmpty();
+        assertThat(ConfigurableElements.toLogisticControlExpression().from(unconfigured)).isEmpty();
+    }
+
+    @Test
+    void navigatesNowhereForAConfigurationWithoutControlInformation() {
+        configuration.setLogisticControlString(null);
+        configuration.setLogisticControlExpression(null);
+
+        assertThat(ConfigurableElements.toLogisticControlString().from(configured)).isEmpty();
+        assertThat(ConfigurableElements.toLogisticControlExpression().from(configured)).isEmpty();
+    }
+
+    /**
+     * Characterisation test for the deprecated {@link ConfigurableElementNavs}, which delegates to
+     * {@link ConfigurableElements}. Can be removed together with {@link ConfigurableElementNavs}.
+     */
+    @Test
+    void deprecatedNavigationsBehaveLikeTheirReplacement() {
+        for (final VecConfigurableElement element : List.of(configured, unconfigured)) {
+            assertThat(ConfigurableElementNavs.variantConfiguration().apply(element))
+                    .isEqualTo(ConfigurableElements.toVariantConfiguration().from(element));
+            assertThat(ConfigurableElementNavs.controlInformation().apply(element))
+                    .isEqualTo(ConfigurableElements.toLogisticControlString().from(element));
+            assertThat(ConfigurableElementNavs.controlExpression().apply(element))
+                    .isEqualTo(ConfigurableElements.toLogisticControlExpression().from(element));
+        }
+    }
+
+    /**
+     * The deprecated navigations accept a {@code null} element, which the replacement does not; a navigation
+     * starts at an element.
+     */
+    @Test
+    void deprecatedNavigationsTolerateANullElement() {
+        assertThat(ConfigurableElementNavs.variantConfiguration().apply(null)).isEmpty();
+        assertThat(ConfigurableElementNavs.controlInformation().apply(null)).isEmpty();
+        assertThat(ConfigurableElementNavs.controlExpression().apply(null)).isEmpty();
+    }
+
+}

--- a/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/ContentsTest.java
+++ b/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/ContentsTest.java
@@ -1,0 +1,99 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v2x.traversal;
+
+import com.foursoft.harness.vec.v2x.VecContent;
+import com.foursoft.harness.vec.v2x.VecDocumentVersion;
+import com.foursoft.harness.vec.v2x.VecPlacementSpecification;
+import com.foursoft.harness.vec.v2x.VecSpecification;
+import com.foursoft.harness.vec.v2x.VecTopologySpecification;
+import com.foursoft.harness.vec.v2x.navigations.ContentNavs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ContentsTest {
+
+    private final VecContent content = new VecContent();
+    private final VecDocumentVersion harness = documentVersion("DOC-1");
+    private final VecDocumentVersion topology = documentVersion("DOC-2");
+
+    private final VecPlacementSpecification placements = new VecPlacementSpecification();
+    private final VecTopologySpecification topologySpecification = new VecTopologySpecification();
+
+    private static VecDocumentVersion documentVersion(final String documentNumber) {
+        final VecDocumentVersion documentVersion = new VecDocumentVersion();
+        documentVersion.setDocumentNumber(documentNumber);
+        return documentVersion;
+    }
+
+    @BeforeEach
+    void setUp() {
+        harness.getSpecifications().add(placements);
+        topology.getSpecifications().add(topologySpecification);
+        content.getDocumentVersions().add(harness);
+        content.getDocumentVersions().add(topology);
+    }
+
+    @Test
+    void navigatesToTheDocumentVersionsOfAContent() {
+        assertThat(Contents.toDocumentVersions().listFrom(content)).containsExactly(harness, topology);
+        assertThat(Contents.toDocumentVersions().listFrom(new VecContent())).isEmpty();
+    }
+
+    @Test
+    void navigatesToTheDocumentVersionWithTheGivenDocumentNumber() {
+        assertThat(Contents.documentVersionBy("DOC-1").from(content)).contains(harness);
+        assertThat(Contents.documentVersionBy("DOC-3").from(content)).isEmpty();
+    }
+
+    @Test
+    void navigatesToTheSpecificationsOfAllDocumentVersions() {
+        assertThat(Contents.toDocumentVersions()
+                           .then(SpecificationOwners.<VecDocumentVersion>toSpecifications())
+                           .listFrom(content))
+                .containsExactly(placements, topologySpecification);
+    }
+
+    /**
+     * Characterisation test for the deprecated {@link ContentNavs}, which delegates to {@link Contents}.
+     * Can be removed together with {@link ContentNavs}.
+     */
+    @Test
+    @SuppressWarnings({"deprecation", "removal"})
+    void deprecatedNavigationsBehaveLikeTheirReplacement() {
+        assertThat(ContentNavs.documentVersionBy("DOC-1").apply(content))
+                .isEqualTo(Contents.documentVersionBy("DOC-1").from(content));
+        assertThat(ContentNavs.documentVersionBy("DOC-3").apply(content))
+                .isEqualTo(Contents.documentVersionBy("DOC-3").from(content));
+        assertThat(ContentNavs.allSpecificationsOf(VecSpecification.class).apply(content))
+                .containsExactly(placements, topologySpecification);
+        assertThat(ContentNavs.allSpecificationsOf(VecPlacementSpecification.class).apply(content))
+                .containsExactly(placements);
+    }
+
+}

--- a/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/CustomPropertiesTest.java
+++ b/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/CustomPropertiesTest.java
@@ -1,0 +1,183 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v2x.traversal;
+
+import com.foursoft.harness.vec.common.HasCustomProperties;
+import com.foursoft.harness.vec.v2x.VecBooleanValueProperty;
+import com.foursoft.harness.vec.v2x.VecComplexProperty;
+import com.foursoft.harness.vec.v2x.VecCustomProperty;
+import com.foursoft.harness.vec.v2x.VecDoubleValueProperty;
+import com.foursoft.harness.vec.v2x.VecIntegerValueProperty;
+import com.foursoft.harness.vec.v2x.VecLanguageCode;
+import com.foursoft.harness.vec.v2x.VecLocalizedString;
+import com.foursoft.harness.vec.v2x.VecLocalizedStringProperty;
+import com.foursoft.harness.vec.v2x.VecPartOccurrence;
+import com.foursoft.harness.vec.v2x.VecSimpleValueProperty;
+import com.foursoft.harness.vec.v2x.VecValueRange;
+import com.foursoft.harness.vec.v2x.VecValueRangeProperty;
+import com.foursoft.harness.vec.v2x.navigations.CustomPropertyNavs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CustomPropertiesTest {
+
+    private static final String COLOUR = "Colour";
+    private static final String COUNT = "Count";
+    private static final String LENGTH = "Length";
+    private static final String RELEASED = "Released";
+    private static final String TOLERANCE = "Tolerance";
+    private static final String DIMENSIONS = "Dimensions";
+    private static final String LABEL = "Label";
+
+    private final VecPartOccurrence element = new VecPartOccurrence();
+
+    private VecValueRange tolerance;
+    private VecCustomProperty nested;
+
+    private static <T extends VecCustomProperty> T property(final T property, final String propertyType) {
+        property.setPropertyType(propertyType);
+        return property;
+    }
+
+    private void add(final VecCustomProperty property) {
+        element.getCustomProperties().add(property);
+    }
+
+    @BeforeEach
+    void setUp() {
+        final VecSimpleValueProperty colour = property(new VecSimpleValueProperty(), COLOUR);
+        colour.setValue("black");
+        final VecSimpleValueProperty secondColour = property(new VecSimpleValueProperty(), COLOUR);
+        secondColour.setValue("white");
+        final VecIntegerValueProperty count = property(new VecIntegerValueProperty(), COUNT);
+        count.setValue(BigInteger.valueOf(3));
+        final VecDoubleValueProperty length = property(new VecDoubleValueProperty(), LENGTH);
+        length.setValue(12.5);
+        final VecBooleanValueProperty released = property(new VecBooleanValueProperty(), RELEASED);
+        released.setValue(true);
+
+        tolerance = new VecValueRange();
+        final VecValueRangeProperty toleranceProperty = property(new VecValueRangeProperty(), TOLERANCE);
+        toleranceProperty.setValue(tolerance);
+
+        nested = property(new VecSimpleValueProperty(), "Width");
+        final VecComplexProperty dimensions = property(new VecComplexProperty(), DIMENSIONS);
+        dimensions.getCustomProperties().add(nested);
+
+        final VecLocalizedString german = new VecLocalizedString();
+        german.setLanguageCode(VecLanguageCode.DE);
+        german.setValue("Kabelbaum");
+        final VecLocalizedStringProperty label = property(new VecLocalizedStringProperty(), LABEL);
+        label.setValue(german);
+
+        add(colour);
+        add(secondColour);
+        add(count);
+        add(length);
+        add(released);
+        add(toleranceProperty);
+        add(dimensions);
+        add(label);
+    }
+
+    @Test
+    void navigatesToTheCustomPropertiesOfAnElement() {
+        assertThat(CustomProperties.toCustomProperties().listFrom(element)).hasSize(8);
+        assertThat(CustomProperties.toCustomProperties().listFrom(new VecPartOccurrence())).isEmpty();
+    }
+
+    @Test
+    void navigatesToTheValueOfTheRequestedProperty() {
+        assertThat(CustomProperties.stringValueOf(COLOUR).from(element)).contains("black");
+        assertThat(CustomProperties.integerValueOf(COUNT).from(element)).contains(BigInteger.valueOf(3));
+        assertThat(CustomProperties.doubleValueOf(LENGTH).from(element)).contains(12.5);
+        assertThat(CustomProperties.booleanValueOf(RELEASED).from(element)).contains(true);
+        assertThat(CustomProperties.valueRangeOf(TOLERANCE).from(element)).contains(tolerance);
+    }
+
+    @Test
+    void navigatesToAllValuesOfTheRequestedProperty() {
+        assertThat(CustomProperties.stringValuesOf(COLOUR).listFrom(element)).containsExactly("black", "white");
+    }
+
+    @Test
+    void navigatesToThePropertiesNestedInTheRequestedComplexProperty() {
+        assertThat(CustomProperties.nestedPropertiesOf(DIMENSIONS).listFrom(element)).containsExactly(nested);
+    }
+
+    @Test
+    void navigatesToTheLocalizedValueOfTheRequestedProperty() {
+        assertThat(CustomProperties.localizedValueOf(LABEL, VecLanguageCode.DE).from(element))
+                .contains("Kabelbaum");
+        assertThat(CustomProperties.localizedValueOf(LABEL, VecLanguageCode.EN).from(element)).isEmpty();
+    }
+
+    @Test
+    void navigatesNowhereForAnUnknownProperty() {
+        assertThat(CustomProperties.stringValueOf("Unknown").from(element)).isEmpty();
+        assertThat(CustomProperties.stringValuesOf("Unknown").listFrom(element)).isEmpty();
+        assertThat(CustomProperties.nestedPropertiesOf("Unknown").listFrom(element)).isEmpty();
+        assertThat(CustomProperties.localizedValueOf("Unknown", VecLanguageCode.DE).from(element)).isEmpty();
+    }
+
+    @Test
+    void navigatesNowhereForAPropertyOfAnotherKind() {
+        assertThat(CustomProperties.integerValueOf(COLOUR).from(element)).isEmpty();
+        assertThat(CustomProperties.stringValueOf(COUNT).from(element)).isEmpty();
+    }
+
+    /**
+     * Characterisation test for the deprecated {@link CustomPropertyNavs}, which delegates to
+     * {@link CustomProperties}. Can be removed together with {@link CustomPropertyNavs}.
+     */
+    @Test
+    @SuppressWarnings({"deprecation", "removal"})
+    void deprecatedNavigationsBehaveLikeTheirReplacement() {
+        final HasCustomProperties<VecCustomProperty> holder = element;
+
+        assertThat(CustomPropertyNavs.customPropertyValueStringOf(COLOUR).apply(holder))
+                .isEqualTo(CustomProperties.stringValueOf(COLOUR).from(element));
+        assertThat(CustomPropertyNavs.customPropertyValueStringsOf(COLOUR).apply(holder))
+                .isEqualTo(CustomProperties.stringValuesOf(COLOUR).listFrom(element));
+        assertThat(CustomPropertyNavs.customPropertyValueIntegerOf(COUNT).apply(holder))
+                .isEqualTo(CustomProperties.integerValueOf(COUNT).from(element));
+        assertThat(CustomPropertyNavs.customPropertyValueDoubleOf(LENGTH).apply(holder))
+                .isEqualTo(CustomProperties.doubleValueOf(LENGTH).from(element));
+        assertThat(CustomPropertyNavs.customPropertyValueBooleanOf(RELEASED).apply(holder))
+                .isEqualTo(CustomProperties.booleanValueOf(RELEASED).from(element));
+        assertThat(CustomPropertyNavs.customPropertyValueRangeOf(TOLERANCE).apply(holder))
+                .isEqualTo(CustomProperties.valueRangeOf(TOLERANCE).from(element));
+        assertThat(CustomPropertyNavs.customPropertyValuesOf(DIMENSIONS).apply(holder))
+                .isEqualTo(CustomProperties.nestedPropertiesOf(DIMENSIONS).listFrom(element));
+        assertThat(CustomPropertyNavs.customPropertyValueLocalizedString(LABEL, VecLanguageCode.DE).apply(holder))
+                .isEqualTo(CustomProperties.localizedValueOf(LABEL, VecLanguageCode.DE).from(element));
+    }
+
+}

--- a/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/DescriptionsTest.java
+++ b/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/DescriptionsTest.java
@@ -50,9 +50,9 @@ class DescriptionsTest {
         final VecAbstractLocalizedString german = localizedString(VecLanguageCode.DE, "Leitung");
         final VecAbstractLocalizedString english = localizedString(VecLanguageCode.EN, "Wire");
 
-        assertThat(Descriptions.descriptions().listFrom(holderOf(german, english)))
+        assertThat(Descriptions.toDescriptions().listFrom(holderOf(german, english)))
                 .containsExactly(german, english);
-        assertThat(Descriptions.descriptions().listFrom(holderOf())).isEmpty();
+        assertThat(Descriptions.toDescriptions().listFrom(holderOf())).isEmpty();
     }
 
     @Test

--- a/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/DescriptionsTest.java
+++ b/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/DescriptionsTest.java
@@ -46,6 +46,16 @@ class DescriptionsTest {
     }
 
     @Test
+    void navigatesToTheDescriptionsOfAnElement() {
+        final VecAbstractLocalizedString german = localizedString(VecLanguageCode.DE, "Leitung");
+        final VecAbstractLocalizedString english = localizedString(VecLanguageCode.EN, "Wire");
+
+        assertThat(Descriptions.descriptions().listFrom(holderOf(german, english)))
+                .containsExactly(german, english);
+        assertThat(Descriptions.descriptions().listFrom(holderOf())).isEmpty();
+    }
+
+    @Test
     void navigatesToTheDescriptionOfTheRequestedLanguage() {
         final HasDescription<VecAbstractLocalizedString> holder = holderOf(
                 localizedString(VecLanguageCode.DE, "Leitung"),

--- a/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/DescriptionsTest.java
+++ b/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/DescriptionsTest.java
@@ -1,0 +1,187 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v2x.traversal;
+
+import com.foursoft.harness.vec.common.HasDescription;
+import com.foursoft.harness.vec.v2x.VecAbstractLocalizedString;
+import com.foursoft.harness.vec.v2x.VecLanguageCode;
+import com.foursoft.harness.vec.v2x.VecLocalizedString;
+import com.foursoft.harness.vec.v2x.VecLocalizedTypedString;
+import com.foursoft.harness.vec.v2x.navigations.DescriptionNavs;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DescriptionsTest {
+
+    private static final String LENGTH_TYPE = "Length";
+
+    private static VecLocalizedString localizedString(final VecLanguageCode languageCode, final String value) {
+        final VecLocalizedString localizedString = new VecLocalizedString();
+        localizedString.setLanguageCode(languageCode);
+        localizedString.setValue(value);
+        return localizedString;
+    }
+
+    private static VecLocalizedTypedString typedString(final VecLanguageCode languageCode, final String type,
+                                                       final String value) {
+        final VecLocalizedTypedString typedString = new VecLocalizedTypedString();
+        typedString.setLanguageCode(languageCode);
+        typedString.setType(type);
+        typedString.setValue(value);
+        return typedString;
+    }
+
+    private static HasDescription<VecAbstractLocalizedString> holderOf(final VecAbstractLocalizedString... strings) {
+        final List<VecAbstractLocalizedString> descriptions = List.of(strings);
+        return () -> descriptions;
+    }
+
+    @Test
+    void navigatesToTheDescriptionOfTheRequestedLanguage() {
+        final HasDescription<VecAbstractLocalizedString> holder = holderOf(
+                localizedString(VecLanguageCode.DE, "Leitung"),
+                localizedString(VecLanguageCode.EN, "Wire"));
+
+        assertThat(Descriptions.germanDescription().from(holder)).contains("Leitung");
+        assertThat(Descriptions.englishDescription().from(holder)).contains("Wire");
+        assertThat(Descriptions.descriptionIn(VecLanguageCode.DE).from(holder)).contains("Leitung");
+    }
+
+    @Test
+    void navigatesToTheOnlyDescriptionRegardlessOfItsLanguage() {
+        final HasDescription<VecAbstractLocalizedString> holder =
+                holderOf(localizedString(VecLanguageCode.EN, "Wire"));
+
+        assertThat(Descriptions.germanDescription().from(holder)).contains("Wire");
+    }
+
+    @Test
+    void navigatesToNoDescriptionForAnEmptyHolder() {
+        assertThat(Descriptions.germanDescription().from(holderOf())).isEmpty();
+    }
+
+    @Test
+    void navigatesToNoDescriptionForASingleTypedString() {
+        final HasDescription<VecAbstractLocalizedString> holder =
+                holderOf(typedString(VecLanguageCode.DE, LENGTH_TYPE, "100"));
+
+        assertThat(Descriptions.germanDescription().from(holder)).isEmpty();
+    }
+
+    @Test
+    void navigatesToASingleTypedStringWithoutAType() {
+        final HasDescription<VecAbstractLocalizedString> holder =
+                holderOf(typedString(VecLanguageCode.DE, null, "Leitung"));
+
+        assertThat(Descriptions.germanDescription().from(holder)).contains("Leitung");
+    }
+
+    @Test
+    void ignoresTypedStringsWhenSeveralDescriptionsArePresent() {
+        final HasDescription<VecAbstractLocalizedString> holder = holderOf(
+                typedString(VecLanguageCode.DE, LENGTH_TYPE, "100"),
+                localizedString(VecLanguageCode.DE, "Leitung"));
+
+        assertThat(Descriptions.germanDescription().from(holder)).contains("Leitung");
+    }
+
+    @Test
+    void navigatesToTheValueOfAListOfLocalizedStrings() {
+        final List<VecAbstractLocalizedString> descriptions = List.of(
+                localizedString(VecLanguageCode.DE, "Leitung"),
+                localizedString(VecLanguageCode.EN, "Wire"));
+
+        assertThat(Descriptions.germanString().from(descriptions)).contains("Leitung");
+        assertThat(Descriptions.englishString().from(descriptions)).contains("Wire");
+        assertThat(Descriptions.stringIn(VecLanguageCode.EN).from(descriptions)).contains("Wire");
+        assertThat(Descriptions.germanString().from(Collections.emptyList())).isEmpty();
+    }
+
+    @Test
+    void navigatesToTheTypedStringOfTheRequestedTypeAndLanguage() {
+        final HasDescription<VecAbstractLocalizedString> holder = holderOf(
+                typedString(VecLanguageCode.DE, LENGTH_TYPE, "100"),
+                typedString(VecLanguageCode.EN, LENGTH_TYPE, "One hundred"),
+                typedString(VecLanguageCode.DE, "Width", "5"));
+
+        assertThat(Descriptions.germanTypedStringBy(LENGTH_TYPE).from(holder)).contains("100");
+        assertThat(Descriptions.englishTypedStringBy(LENGTH_TYPE).from(holder)).contains("One hundred");
+        assertThat(Descriptions.typedStringBy("Width", VecLanguageCode.DE).from(holder)).contains("5");
+        assertThat(Descriptions.typedStringBy("Height", VecLanguageCode.DE).from(holder)).isEmpty();
+    }
+
+    @Test
+    void navigatesToNoTypedStringForAnEmptyValue() {
+        final HasDescription<VecAbstractLocalizedString> holder = holderOf(
+                typedString(VecLanguageCode.DE, LENGTH_TYPE, ""),
+                localizedString(VecLanguageCode.DE, "Leitung"));
+
+        assertThat(Descriptions.germanTypedStringBy(LENGTH_TYPE).from(holder)).isEmpty();
+    }
+
+    /**
+     * Characterisation test for the deprecated {@link DescriptionNavs}, which delegates to
+     * {@link Descriptions}. Can be removed together with {@link DescriptionNavs}.
+     */
+    @Test
+    @SuppressWarnings({"deprecation", "removal"})
+    void deprecatedNavigationsBehaveLikeTheirReplacement() {
+        final List<HasDescription<VecAbstractLocalizedString>> holders = List.of(
+                holderOf(),
+                holderOf(localizedString(VecLanguageCode.EN, "Wire")),
+                holderOf(typedString(VecLanguageCode.DE, LENGTH_TYPE, "100")),
+                holderOf(typedString(VecLanguageCode.DE, null, "Leitung")),
+                holderOf(localizedString(VecLanguageCode.DE, "Leitung"),
+                         localizedString(VecLanguageCode.EN, "Wire"),
+                         typedString(VecLanguageCode.DE, LENGTH_TYPE, "100")));
+
+        for (final HasDescription<VecAbstractLocalizedString> holder : holders) {
+            assertThat(DescriptionNavs.germanDescription().apply(holder))
+                    .isEqualTo(Descriptions.germanDescription().from(holder));
+            assertThat(DescriptionNavs.englishDescription().apply(holder))
+                    .isEqualTo(Descriptions.englishDescription().from(holder));
+            assertThat(DescriptionNavs.descriptionIn(VecLanguageCode.DE).apply(holder))
+                    .isEqualTo(Descriptions.descriptionIn(VecLanguageCode.DE).from(holder));
+            assertThat(DescriptionNavs.germanString().apply(holder.getDescriptions()))
+                    .isEqualTo(Descriptions.germanString().from(holder.getDescriptions()));
+            assertThat(DescriptionNavs.englishString().apply(holder.getDescriptions()))
+                    .isEqualTo(Descriptions.englishString().from(holder.getDescriptions()));
+            assertThat(DescriptionNavs.stringIn(VecLanguageCode.EN).apply(holder.getDescriptions()))
+                    .isEqualTo(Descriptions.stringIn(VecLanguageCode.EN).from(holder.getDescriptions()));
+            assertThat(DescriptionNavs.germanTypedStringBy(LENGTH_TYPE).apply(holder))
+                    .isEqualTo(Descriptions.germanTypedStringBy(LENGTH_TYPE).from(holder));
+            assertThat(DescriptionNavs.englishTypedStringBy(LENGTH_TYPE).apply(holder))
+                    .isEqualTo(Descriptions.englishTypedStringBy(LENGTH_TYPE).from(holder));
+            assertThat(DescriptionNavs.typedStringBy(LENGTH_TYPE, VecLanguageCode.DE).apply(holder))
+                    .isEqualTo(Descriptions.typedStringBy(LENGTH_TYPE, VecLanguageCode.DE).from(holder));
+        }
+    }
+
+}

--- a/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/DescriptionsTest.java
+++ b/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/DescriptionsTest.java
@@ -28,35 +28,17 @@ package com.foursoft.harness.vec.v2x.traversal;
 import com.foursoft.harness.vec.common.HasDescription;
 import com.foursoft.harness.vec.v2x.VecAbstractLocalizedString;
 import com.foursoft.harness.vec.v2x.VecLanguageCode;
-import com.foursoft.harness.vec.v2x.VecLocalizedString;
-import com.foursoft.harness.vec.v2x.VecLocalizedTypedString;
 import com.foursoft.harness.vec.v2x.navigations.DescriptionNavs;
 import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
 import java.util.List;
 
+import static com.foursoft.harness.vec.v2x.traversal.LocalizedStringFixtures.LENGTH_TYPE;
+import static com.foursoft.harness.vec.v2x.traversal.LocalizedStringFixtures.localizedString;
+import static com.foursoft.harness.vec.v2x.traversal.LocalizedStringFixtures.typedString;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class DescriptionsTest {
-
-    private static final String LENGTH_TYPE = "Length";
-
-    private static VecLocalizedString localizedString(final VecLanguageCode languageCode, final String value) {
-        final VecLocalizedString localizedString = new VecLocalizedString();
-        localizedString.setLanguageCode(languageCode);
-        localizedString.setValue(value);
-        return localizedString;
-    }
-
-    private static VecLocalizedTypedString typedString(final VecLanguageCode languageCode, final String type,
-                                                       final String value) {
-        final VecLocalizedTypedString typedString = new VecLocalizedTypedString();
-        typedString.setLanguageCode(languageCode);
-        typedString.setType(type);
-        typedString.setValue(value);
-        return typedString;
-    }
 
     private static HasDescription<VecAbstractLocalizedString> holderOf(final VecAbstractLocalizedString... strings) {
         final List<VecAbstractLocalizedString> descriptions = List.of(strings);
@@ -75,53 +57,14 @@ class DescriptionsTest {
     }
 
     @Test
-    void navigatesToTheOnlyDescriptionRegardlessOfItsLanguage() {
-        final HasDescription<VecAbstractLocalizedString> holder =
-                holderOf(localizedString(VecLanguageCode.EN, "Wire"));
-
-        assertThat(Descriptions.germanDescription().from(holder)).contains("Wire");
-    }
-
-    @Test
     void navigatesToNoDescriptionForAnEmptyHolder() {
         assertThat(Descriptions.germanDescription().from(holderOf())).isEmpty();
     }
 
     @Test
     void navigatesToNoDescriptionForASingleTypedString() {
-        final HasDescription<VecAbstractLocalizedString> holder =
-                holderOf(typedString(VecLanguageCode.DE, LENGTH_TYPE, "100"));
-
-        assertThat(Descriptions.germanDescription().from(holder)).isEmpty();
-    }
-
-    @Test
-    void navigatesToASingleTypedStringWithoutAType() {
-        final HasDescription<VecAbstractLocalizedString> holder =
-                holderOf(typedString(VecLanguageCode.DE, null, "Leitung"));
-
-        assertThat(Descriptions.germanDescription().from(holder)).contains("Leitung");
-    }
-
-    @Test
-    void ignoresTypedStringsWhenSeveralDescriptionsArePresent() {
-        final HasDescription<VecAbstractLocalizedString> holder = holderOf(
-                typedString(VecLanguageCode.DE, LENGTH_TYPE, "100"),
-                localizedString(VecLanguageCode.DE, "Leitung"));
-
-        assertThat(Descriptions.germanDescription().from(holder)).contains("Leitung");
-    }
-
-    @Test
-    void navigatesToTheValueOfAListOfLocalizedStrings() {
-        final List<VecAbstractLocalizedString> descriptions = List.of(
-                localizedString(VecLanguageCode.DE, "Leitung"),
-                localizedString(VecLanguageCode.EN, "Wire"));
-
-        assertThat(Descriptions.germanString().from(descriptions)).contains("Leitung");
-        assertThat(Descriptions.englishString().from(descriptions)).contains("Wire");
-        assertThat(Descriptions.stringIn(VecLanguageCode.EN).from(descriptions)).contains("Wire");
-        assertThat(Descriptions.germanString().from(Collections.emptyList())).isEmpty();
+        assertThat(Descriptions.germanDescription()
+                           .from(holderOf(typedString(VecLanguageCode.DE, LENGTH_TYPE, "100")))).isEmpty();
     }
 
     @Test
@@ -137,15 +80,6 @@ class DescriptionsTest {
         assertThat(Descriptions.typedStringBy("Height", VecLanguageCode.DE).from(holder)).isEmpty();
     }
 
-    @Test
-    void navigatesToNoTypedStringForAnEmptyValue() {
-        final HasDescription<VecAbstractLocalizedString> holder = holderOf(
-                typedString(VecLanguageCode.DE, LENGTH_TYPE, ""),
-                localizedString(VecLanguageCode.DE, "Leitung"));
-
-        assertThat(Descriptions.germanTypedStringBy(LENGTH_TYPE).from(holder)).isEmpty();
-    }
-
     /**
      * Characterisation test for the deprecated {@link DescriptionNavs}, which delegates to
      * {@link Descriptions}. Can be removed together with {@link DescriptionNavs}.
@@ -153,28 +87,15 @@ class DescriptionsTest {
     @Test
     @SuppressWarnings({"deprecation", "removal"})
     void deprecatedNavigationsBehaveLikeTheirReplacement() {
-        final List<HasDescription<VecAbstractLocalizedString>> holders = List.of(
-                holderOf(),
-                holderOf(localizedString(VecLanguageCode.EN, "Wire")),
-                holderOf(typedString(VecLanguageCode.DE, LENGTH_TYPE, "100")),
-                holderOf(typedString(VecLanguageCode.DE, null, "Leitung")),
-                holderOf(localizedString(VecLanguageCode.DE, "Leitung"),
-                         localizedString(VecLanguageCode.EN, "Wire"),
-                         typedString(VecLanguageCode.DE, LENGTH_TYPE, "100")));
+        for (final List<VecAbstractLocalizedString> descriptions : LocalizedStringFixtures.allVariants()) {
+            final HasDescription<VecAbstractLocalizedString> holder = () -> descriptions;
 
-        for (final HasDescription<VecAbstractLocalizedString> holder : holders) {
             assertThat(DescriptionNavs.germanDescription().apply(holder))
                     .isEqualTo(Descriptions.germanDescription().from(holder));
             assertThat(DescriptionNavs.englishDescription().apply(holder))
                     .isEqualTo(Descriptions.englishDescription().from(holder));
             assertThat(DescriptionNavs.descriptionIn(VecLanguageCode.DE).apply(holder))
                     .isEqualTo(Descriptions.descriptionIn(VecLanguageCode.DE).from(holder));
-            assertThat(DescriptionNavs.germanString().apply(holder.getDescriptions()))
-                    .isEqualTo(Descriptions.germanString().from(holder.getDescriptions()));
-            assertThat(DescriptionNavs.englishString().apply(holder.getDescriptions()))
-                    .isEqualTo(Descriptions.englishString().from(holder.getDescriptions()));
-            assertThat(DescriptionNavs.stringIn(VecLanguageCode.EN).apply(holder.getDescriptions()))
-                    .isEqualTo(Descriptions.stringIn(VecLanguageCode.EN).from(holder.getDescriptions()));
             assertThat(DescriptionNavs.germanTypedStringBy(LENGTH_TYPE).apply(holder))
                     .isEqualTo(Descriptions.germanTypedStringBy(LENGTH_TYPE).from(holder));
             assertThat(DescriptionNavs.englishTypedStringBy(LENGTH_TYPE).apply(holder))

--- a/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/DocumentVersionsTest.java
+++ b/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/DocumentVersionsTest.java
@@ -1,0 +1,255 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v2x.traversal;
+
+import com.foursoft.harness.vec.v2x.VecBuildingBlockPositioning2D;
+import com.foursoft.harness.vec.v2x.VecBuildingBlockPositioning3D;
+import com.foursoft.harness.vec.v2x.VecBuildingBlockSpecification2D;
+import com.foursoft.harness.vec.v2x.VecBuildingBlockSpecification3D;
+import com.foursoft.harness.vec.v2x.VecCompositionSpecification;
+import com.foursoft.harness.vec.v2x.VecDocumentVersion;
+import com.foursoft.harness.vec.v2x.VecGeometryNode2D;
+import com.foursoft.harness.vec.v2x.VecGeometryNode3D;
+import com.foursoft.harness.vec.v2x.VecGeometrySegment2D;
+import com.foursoft.harness.vec.v2x.VecGeometrySegment3D;
+import com.foursoft.harness.vec.v2x.VecHarnessDrawingSpecification2D;
+import com.foursoft.harness.vec.v2x.VecHarnessGeometrySpecification3D;
+import com.foursoft.harness.vec.v2x.VecNodeLocation;
+import com.foursoft.harness.vec.v2x.VecOccurrenceOrUsageViewItem2D;
+import com.foursoft.harness.vec.v2x.VecOccurrenceOrUsageViewItem3D;
+import com.foursoft.harness.vec.v2x.VecOnPointPlacement;
+import com.foursoft.harness.vec.v2x.VecPartOccurrence;
+import com.foursoft.harness.vec.v2x.VecPlaceableElementRole;
+import com.foursoft.harness.vec.v2x.VecPlacementSpecification;
+import com.foursoft.harness.vec.v2x.VecTopologyNode;
+import com.foursoft.harness.vec.v2x.VecTopologySegment;
+import com.foursoft.harness.vec.v2x.navigations.DocumentVersionNavs;
+import com.foursoft.harness.vec.v2x.navigations.PartOccurrenceOrUsageNavs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DocumentVersionsTest {
+
+    private static final String COMPOSITION_ID = "COMP-1";
+    private static final String COMPONENT_ID = "OCC-1";
+
+    private final VecDocumentVersion documentVersion = new VecDocumentVersion();
+
+    private final VecBuildingBlockSpecification2D buildingBlock2D = new VecBuildingBlockSpecification2D();
+    private final VecBuildingBlockSpecification3D buildingBlock3D = new VecBuildingBlockSpecification3D();
+    private final VecPlacementSpecification placements = new VecPlacementSpecification();
+    private final VecCompositionSpecification composition = new VecCompositionSpecification();
+    private final VecHarnessDrawingSpecification2D drawing = new VecHarnessDrawingSpecification2D();
+    private final VecHarnessGeometrySpecification3D geometry = new VecHarnessGeometrySpecification3D();
+
+    private final VecTopologyNode topologyNode = new VecTopologyNode();
+    private final VecTopologySegment topologySegment = new VecTopologySegment();
+    private final VecGeometryNode2D node2D = new VecGeometryNode2D();
+    private final VecGeometryNode3D node3D = new VecGeometryNode3D();
+    private final VecGeometrySegment2D segment2D = new VecGeometrySegment2D();
+    private final VecGeometrySegment3D segment3D = new VecGeometrySegment3D();
+    private final VecNodeLocation location = new VecNodeLocation();
+    private final VecOnPointPlacement placement = new VecOnPointPlacement();
+    private final VecPlaceableElementRole placedElement = new VecPlaceableElementRole();
+    private final VecPartOccurrence component = new VecPartOccurrence();
+    private final VecOccurrenceOrUsageViewItem2D viewItem2D = new VecOccurrenceOrUsageViewItem2D();
+    private final VecOccurrenceOrUsageViewItem3D viewItem3D = new VecOccurrenceOrUsageViewItem3D();
+    private final VecBuildingBlockPositioning2D positioning2D = new VecBuildingBlockPositioning2D();
+    private final VecBuildingBlockPositioning3D positioning3D = new VecBuildingBlockPositioning3D();
+
+    @BeforeEach
+    void setUp() {
+        buildingBlock2D.setIdentification("BB-2D");
+        buildingBlock3D.setIdentification("BB-3D");
+        composition.setIdentification(COMPOSITION_ID);
+        component.setIdentification(COMPONENT_ID);
+
+        node2D.setReferenceNode(topologyNode);
+        node3D.setReferenceNode(topologyNode);
+        segment3D.setReferenceSegment(topologySegment);
+        location.setReferencedNode(topologyNode);
+
+        placement.getLocations().add(location);
+        placement.getPlacedElement().add(placedElement);
+        placedElement.getRefPlacement().add(placement);
+        component.getRoles().add(placedElement);
+
+        viewItem2D.getOccurrenceOrUsage().add(component);
+        viewItem3D.getOccurrenceOrUsage().add(component);
+
+        positioning2D.setReferenced2DBuildingBlock(buildingBlock2D);
+        positioning3D.setReferenced3DBuildingBlock(buildingBlock3D);
+
+        buildingBlock2D.getGeometryNodes().add(node2D);
+        buildingBlock2D.getGeometrySegments().add(segment2D);
+        buildingBlock2D.getPlacedElementViewItems().add(viewItem2D);
+        buildingBlock3D.getGeometryNodes().add(node3D);
+        buildingBlock3D.getGeometrySegments().add(segment3D);
+        buildingBlock3D.getPlacedElementViewItem3Ds().add(viewItem3D);
+        placements.getPlacements().add(placement);
+        composition.getComponents().add(component);
+        drawing.getBuildingBlockPositionings().add(positioning2D);
+        geometry.getBuildingBlockPositionings().add(positioning3D);
+
+        documentVersion.getSpecifications().add(buildingBlock2D);
+        documentVersion.getSpecifications().add(buildingBlock3D);
+        documentVersion.getSpecifications().add(placements);
+        documentVersion.getSpecifications().add(composition);
+        documentVersion.getSpecifications().add(drawing);
+        documentVersion.getSpecifications().add(geometry);
+    }
+
+    @Test
+    void navigatesToTheBuildingBlocksOfADocumentVersion() {
+        assertThat(DocumentVersions.toBuildingBlockSpecifications2D().listFrom(documentVersion))
+                .containsExactly(buildingBlock2D);
+        assertThat(DocumentVersions.toBuildingBlockSpecifications3D().listFrom(documentVersion))
+                .containsExactly(buildingBlock3D);
+        assertThat(DocumentVersions.buildingBlockSpecification2dBy("BB-2D").from(documentVersion))
+                .contains(buildingBlock2D);
+        assertThat(DocumentVersions.buildingBlockSpecification3dBy("BB-2D").from(documentVersion)).isEmpty();
+    }
+
+    @Test
+    void navigatesToTheGeometryOfAllBuildingBlocks() {
+        assertThat(DocumentVersions.toGeometryNodes2D().listFrom(documentVersion)).containsExactly(node2D);
+        assertThat(DocumentVersions.toGeometryNodes3D().listFrom(documentVersion)).containsExactly(node3D);
+        assertThat(DocumentVersions.toGeometrySegments3D().listFrom(documentVersion)).containsExactly(segment3D);
+        assertThat(DocumentVersions.toGeometrySegments2D().listFrom(documentVersion)).containsExactly(segment2D);
+    }
+
+    @Test
+    void navigatesToTheGeometryOfTheGivenTopologyElement() {
+        assertThat(DocumentVersions.geometryNodes3dBy(topologyNode).listFrom(documentVersion))
+                .containsExactly(node3D);
+        assertThat(DocumentVersions.geometryNodes3dBy(new VecTopologyNode()).listFrom(documentVersion)).isEmpty();
+        assertThat(DocumentVersions.geometrySegments3dBy(topologySegment).listFrom(documentVersion))
+                .containsExactly(segment3D);
+        assertThat(DocumentVersions.geometryNode2dBy(location).from(documentVersion)).contains(node2D);
+        assertThat(DocumentVersions.geometryNode3dBy(location).from(documentVersion)).contains(node3D);
+    }
+
+    @Test
+    void navigatesToTheViewItemsOfADocumentVersion() {
+        assertThat(DocumentVersions.toViewItems2D().listFrom(documentVersion)).containsExactly(viewItem2D);
+        assertThat(DocumentVersions.toViewItems3D().listFrom(documentVersion)).containsExactly(viewItem3D);
+        assertThat(DocumentVersions.viewItems3dBy(component).listFrom(documentVersion)).containsExactly(viewItem3D);
+        assertThat(DocumentVersions.viewItem2dBy(COMPONENT_ID).from(documentVersion)).contains(viewItem2D);
+        assertThat(DocumentVersions.viewItem3dBy(COMPONENT_ID).from(documentVersion)).contains(viewItem3D);
+        assertThat(DocumentVersions.viewItem2dBy("OCC-2").from(documentVersion)).isEmpty();
+    }
+
+    @Test
+    void navigatesToThePlacementsAndNodeLocationsOfADocumentVersion() {
+        assertThat(DocumentVersions.toPlacements().listFrom(documentVersion)).containsExactly(placement);
+        assertThat(DocumentVersions.toNodeLocations().listFrom(documentVersion)).containsExactly(location);
+        assertThat(DocumentVersions.placementsOf(placedElement).listFrom(documentVersion))
+                .containsExactly(placement);
+        assertThat(DocumentVersions.nodeLocationsOf(placedElement).listFrom(documentVersion))
+                .containsExactly(location);
+        assertThat(DocumentVersions.nodeLocationsOf(new VecPlaceableElementRole()).listFrom(documentVersion))
+                .isEmpty();
+    }
+
+    @Test
+    void navigatesToTheBuildingBlockPositionings() {
+        assertThat(DocumentVersions.toBuildingBlockPositionings2D().listFrom(documentVersion))
+                .containsExactly(positioning2D);
+        assertThat(DocumentVersions.toBuildingBlockPositionings3D().listFrom(documentVersion))
+                .containsExactly(positioning3D);
+        assertThat(DocumentVersions.positioning2dWith(buildingBlock2D).from(documentVersion))
+                .contains(positioning2D);
+        assertThat(DocumentVersions.positioning3dWith(buildingBlock3D).from(documentVersion))
+                .contains(positioning3D);
+        assertThat(DocumentVersions.positioning2dWith(new VecBuildingBlockSpecification2D())
+                           .from(documentVersion)).isEmpty();
+    }
+
+    @Test
+    void navigatesToTheRoleAndPlacementOfTheIdentifiedComponent() {
+        assertThat(DocumentVersions.placeableElementRoleBy(COMPOSITION_ID, COMPONENT_ID).from(documentVersion))
+                .contains(placedElement);
+        assertThat(DocumentVersions.placementBy(COMPOSITION_ID, COMPONENT_ID).from(documentVersion))
+                .contains(placement);
+        assertThat(DocumentVersions.placeableElementRoleBy(COMPOSITION_ID, "OCC-2").from(documentVersion))
+                .isEmpty();
+        assertThat(DocumentVersions.placementBy("COMP-2", COMPONENT_ID).from(documentVersion)).isEmpty();
+    }
+
+    @Test
+    void navigatesToTheTopologyNodeOfAComponent() {
+        assertThat(DocumentVersions.topologyNodeBy(COMPONENT_ID).from(documentVersion)).contains(topologyNode);
+        assertThat(DocumentVersions.topologyNodeBy("OCC-2").from(documentVersion)).isEmpty();
+        assertThat(DocumentVersions.topologyNodeOf(component).from(documentVersion)).contains(topologyNode);
+        assertThat(DocumentVersions.topologyNodeOf(new VecPartOccurrence()).from(documentVersion)).isEmpty();
+    }
+
+    /**
+     * Characterisation test for the deprecated {@link DocumentVersionNavs}, which delegates to
+     * {@link DocumentVersions}. Can be removed together with {@link DocumentVersionNavs}.
+     */
+    @Test
+    @SuppressWarnings({"deprecation", "removal"})
+    void deprecatedNavigationsBehaveLikeTheirReplacement() {
+        assertThat(DocumentVersionNavs.geometryNodes3dBy(topologyNode).apply(documentVersion))
+                .isEqualTo(DocumentVersions.geometryNodes3dBy(topologyNode).listFrom(documentVersion));
+        assertThat(DocumentVersionNavs.geometrySegments3dBy(topologySegment).apply(documentVersion))
+                .isEqualTo(DocumentVersions.geometrySegments3dBy(topologySegment).listFrom(documentVersion));
+        assertThat(DocumentVersionNavs.viewItems3dBy(component).apply(documentVersion))
+                .isEqualTo(DocumentVersions.viewItems3dBy(component).listFrom(documentVersion));
+        assertThat(DocumentVersionNavs.topologyNodeBy(COMPONENT_ID).apply(documentVersion))
+                .isEqualTo(DocumentVersions.topologyNodeBy(COMPONENT_ID).from(documentVersion));
+        assertThat(DocumentVersionNavs.nodeLocationsBy(placedElement).apply(documentVersion))
+                .isEqualTo(DocumentVersions.nodeLocationsOf(placedElement).listFrom(documentVersion));
+        assertThat(DocumentVersionNavs.nodeLocationsBy(null).apply(documentVersion))
+                .isEqualTo(DocumentVersions.toNodeLocations().listFrom(documentVersion));
+        assertThat(DocumentVersionNavs.placeableElementRoleBy(COMPOSITION_ID, COMPONENT_ID).apply(documentVersion))
+                .isEqualTo(placedElement);
+        assertThat(DocumentVersionNavs.placementBy(COMPOSITION_ID, COMPONENT_ID).apply(documentVersion))
+                .isEqualTo(placement);
+        assertThat(DocumentVersionNavs.placeableElementRoleBy(COMPOSITION_ID, "OCC-2").apply(documentVersion))
+                .isNull();
+        assertThat(DocumentVersionNavs.geometryNode2dBy(location).apply(documentVersion)).isEqualTo(node2D);
+        assertThat(DocumentVersionNavs.geometryNode3dBy(location).apply(documentVersion)).isEqualTo(node3D);
+        assertThat(DocumentVersionNavs.viewItem2dBy(COMPONENT_ID).apply(documentVersion))
+                .isEqualTo(DocumentVersions.viewItem2dBy(COMPONENT_ID).from(documentVersion));
+        assertThat(DocumentVersionNavs.viewItem3dBy(COMPONENT_ID).apply(documentVersion))
+                .isEqualTo(DocumentVersions.viewItem3dBy(COMPONENT_ID).from(documentVersion));
+        assertThat(DocumentVersionNavs.buildingBlockSpecification2dBy("BB-2D").apply(documentVersion))
+                .isEqualTo(DocumentVersions.buildingBlockSpecification2dBy("BB-2D").from(documentVersion));
+        assertThat(DocumentVersionNavs.buildingBlockSpecification3dBy("BB-3D").apply(documentVersion))
+                .isEqualTo(DocumentVersions.buildingBlockSpecification3dBy("BB-3D").from(documentVersion));
+        assertThat(DocumentVersionNavs.positioning2dWith(buildingBlock2D).apply(documentVersion))
+                .isEqualTo(DocumentVersions.positioning2dWith(buildingBlock2D).from(documentVersion));
+        assertThat(DocumentVersionNavs.positioning3dWith(buildingBlock3D).apply(documentVersion))
+                .isEqualTo(DocumentVersions.positioning3dWith(buildingBlock3D).from(documentVersion));
+        assertThat(PartOccurrenceOrUsageNavs.findNodeOfComponent().apply(component, documentVersion))
+                .isEqualTo(DocumentVersions.topologyNodeOf(component).from(documentVersion));
+    }
+
+}

--- a/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/ExtendableElementsTest.java
+++ b/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/ExtendableElementsTest.java
@@ -62,12 +62,21 @@ class ExtendableElementsTest {
     /**
      * Characterisation test for the deprecated {@link VecNavs}, which delegates to
      * {@link ExtendableElements}. Can be removed together with {@link VecNavs}.
+     * <p>
+     * The two agree on every model the schema admits, which is what this pins. They deviate on an
+     * unnumbered document: the deprecated navigation maps each referenced document and so yields a
+     * {@code null} element, while the replacement treats a missing number as an absent target and
+     * omits it. Since {@code DocumentNumber} is mandatory, only an incomplete model can tell them
+     * apart, and the fixture below therefore references numbered documents only.
      */
     @Test
     @SuppressWarnings({"deprecation", "removal"})
     void deprecatedNavigationsBehaveLikeTheirReplacement() {
-        assertThat(VecNavs.externalDocumentNumbers().apply(element))
-                .isEqualTo(ExtendableElements.toExternalDocumentNumbers().listFrom(element));
+        final VecExtendableElement numbered = new VecPartOccurrence();
+        numbered.getReferencedExternalDocuments().add(drawing);
+
+        assertThat(VecNavs.externalDocumentNumbers().apply(numbered))
+                .isEqualTo(ExtendableElements.toExternalDocumentNumbers().listFrom(numbered));
     }
 
 }

--- a/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/ExtendableElementsTest.java
+++ b/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/ExtendableElementsTest.java
@@ -1,0 +1,73 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v2x.traversal;
+
+import com.foursoft.harness.vec.v2x.VecDocumentVersion;
+import com.foursoft.harness.vec.v2x.VecExtendableElement;
+import com.foursoft.harness.vec.v2x.VecPartOccurrence;
+import com.foursoft.harness.vec.v2x.navigations.VecNavs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ExtendableElementsTest {
+
+    private final VecExtendableElement element = new VecPartOccurrence();
+    private final VecDocumentVersion drawing = new VecDocumentVersion();
+    private final VecDocumentVersion unnumbered = new VecDocumentVersion();
+
+    @BeforeEach
+    void setUp() {
+        drawing.setDocumentNumber("DRW-1");
+        element.getReferencedExternalDocuments().add(drawing);
+        element.getReferencedExternalDocuments().add(unnumbered);
+    }
+
+    @Test
+    void navigatesToTheReferencedExternalDocumentsOfAnElement() {
+        assertThat(ExtendableElements.toReferencedExternalDocuments().listFrom(element))
+                .containsExactly(drawing, unnumbered);
+        assertThat(ExtendableElements.toReferencedExternalDocuments().listFrom(new VecPartOccurrence())).isEmpty();
+    }
+
+    @Test
+    void navigatesToTheDocumentNumbersOfTheReferencedExternalDocuments() {
+        assertThat(ExtendableElements.toExternalDocumentNumbers().listFrom(element)).containsExactly("DRW-1");
+    }
+
+    /**
+     * Characterisation test for the deprecated {@link VecNavs}, which delegates to
+     * {@link ExtendableElements}. Can be removed together with {@link VecNavs}.
+     */
+    @Test
+    @SuppressWarnings({"deprecation", "removal"})
+    void deprecatedNavigationsBehaveLikeTheirReplacement() {
+        assertThat(VecNavs.externalDocumentNumbers().apply(element))
+                .isEqualTo(ExtendableElements.toExternalDocumentNumbers().listFrom(element));
+    }
+
+}

--- a/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/LocalizedStringFixtures.java
+++ b/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/LocalizedStringFixtures.java
@@ -1,0 +1,80 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v2x.traversal;
+
+import com.foursoft.harness.vec.v2x.VecAbstractLocalizedString;
+import com.foursoft.harness.vec.v2x.VecLanguageCode;
+import com.foursoft.harness.vec.v2x.VecLocalizedString;
+import com.foursoft.harness.vec.v2x.VecLocalizedTypedString;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Localized string fixtures shared by {@link LocalizedStringsTest} and {@link DescriptionsTest}.
+ */
+final class LocalizedStringFixtures {
+
+    static final String LENGTH_TYPE = "Length";
+
+    private LocalizedStringFixtures() {
+        // hide default constructor
+    }
+
+    static VecLocalizedString localizedString(final VecLanguageCode languageCode, final String value) {
+        final VecLocalizedString localizedString = new VecLocalizedString();
+        localizedString.setLanguageCode(languageCode);
+        localizedString.setValue(value);
+        return localizedString;
+    }
+
+    static VecLocalizedTypedString typedString(final VecLanguageCode languageCode, final String type,
+                                               final String value) {
+        final VecLocalizedTypedString typedString = new VecLocalizedTypedString();
+        typedString.setLanguageCode(languageCode);
+        typedString.setType(type);
+        typedString.setValue(value);
+        return typedString;
+    }
+
+    /**
+     * The description list shapes the navigations treat differently, for exhaustive comparisons of the
+     * deprecated navigations against their replacements.
+     */
+    static List<List<VecAbstractLocalizedString>> allVariants() {
+        return List.of(
+                Collections.emptyList(),
+                List.of(localizedString(VecLanguageCode.EN, "Wire")),
+                List.of(typedString(VecLanguageCode.DE, LENGTH_TYPE, "100")),
+                List.of(typedString(VecLanguageCode.DE, null, "Leitung")),
+                List.of(typedString(VecLanguageCode.DE, LENGTH_TYPE, ""),
+                        localizedString(VecLanguageCode.DE, "Leitung")),
+                List.of(localizedString(VecLanguageCode.DE, "Leitung"),
+                        localizedString(VecLanguageCode.EN, "Wire"),
+                        typedString(VecLanguageCode.DE, LENGTH_TYPE, "100")));
+    }
+
+}

--- a/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/LocalizedStringPropertiesTest.java
+++ b/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/LocalizedStringPropertiesTest.java
@@ -1,0 +1,79 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v2x.traversal;
+
+import com.foursoft.harness.vec.v2x.VecLanguageCode;
+import com.foursoft.harness.vec.v2x.VecLocalizedString;
+import com.foursoft.harness.vec.v2x.VecLocalizedStringProperty;
+import com.foursoft.harness.vec.v2x.navigations.CustomPropertyNavs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LocalizedStringPropertiesTest {
+
+    private final VecLocalizedStringProperty property = new VecLocalizedStringProperty();
+
+    @BeforeEach
+    void setUp() {
+        final VecLocalizedString german = new VecLocalizedString();
+        german.setLanguageCode(VecLanguageCode.DE);
+        german.setValue("Kabelbaum");
+        property.setValue(german);
+    }
+
+    @Test
+    void navigatesToTheValueOfTheRequestedLanguage() {
+        assertThat(LocalizedStringProperties.valueIn(VecLanguageCode.DE).from(property)).contains("Kabelbaum");
+    }
+
+    @Test
+    void navigatesNowhereForAnotherLanguage() {
+        assertThat(LocalizedStringProperties.valueIn(VecLanguageCode.EN).from(property)).isEmpty();
+    }
+
+    @Test
+    void navigatesNowhereForAPropertyWithoutValue() {
+        assertThat(LocalizedStringProperties.valueIn(VecLanguageCode.DE).from(new VecLocalizedStringProperty()))
+                .isEmpty();
+    }
+
+    /**
+     * Characterisation test for the deprecated {@link CustomPropertyNavs}, which delegates to
+     * {@link LocalizedStringProperties}. Can be removed together with {@link CustomPropertyNavs}.
+     */
+    @Test
+    @SuppressWarnings({"deprecation", "removal"})
+    void deprecatedNavigationsBehaveLikeTheirReplacement() {
+        assertThat(CustomPropertyNavs.convertLocalizedStringProperty(VecLanguageCode.DE).apply(property))
+                .isEqualTo(LocalizedStringProperties.valueIn(VecLanguageCode.DE).from(property));
+        assertThat(CustomPropertyNavs.convertLocalizedStringProperty(VecLanguageCode.EN).apply(property))
+                .isEqualTo(LocalizedStringProperties.valueIn(VecLanguageCode.EN).from(property));
+        assertThat(CustomPropertyNavs.convertLocalizedStringProperty(VecLanguageCode.DE).apply(null)).isEmpty();
+    }
+
+}

--- a/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/LocalizedStringsTest.java
+++ b/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/LocalizedStringsTest.java
@@ -32,6 +32,8 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collector;
 
 import static com.foursoft.harness.vec.v2x.traversal.LocalizedStringFixtures.LENGTH_TYPE;
 import static com.foursoft.harness.vec.v2x.traversal.LocalizedStringFixtures.localizedString;
@@ -40,38 +42,49 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class LocalizedStringsTest {
 
+    private static Optional<String> reduce(final List<VecAbstractLocalizedString> localizedStrings,
+                                           final Collector<VecAbstractLocalizedString, ?, Optional<String>>
+                                                   reduction) {
+        return localizedStrings.stream().collect(reduction);
+    }
+
     @Test
-    void navigatesToTheValueOfTheRequestedLanguage() {
+    void reducesToTheValueOfTheRequestedLanguage() {
         final List<VecAbstractLocalizedString> localizedStrings = List.of(
                 localizedString(VecLanguageCode.DE, "Leitung"),
                 localizedString(VecLanguageCode.EN, "Wire"));
 
-        assertThat(LocalizedStrings.germanString().from(localizedStrings)).contains("Leitung");
-        assertThat(LocalizedStrings.englishString().from(localizedStrings)).contains("Wire");
-        assertThat(LocalizedStrings.stringIn(VecLanguageCode.EN).from(localizedStrings)).contains("Wire");
+        assertThat(reduce(localizedStrings, LocalizedStrings.valueIn(VecLanguageCode.DE))).contains("Leitung");
+        assertThat(reduce(localizedStrings, LocalizedStrings.valueIn(VecLanguageCode.EN))).contains("Wire");
     }
 
     @Test
-    void navigatesToTheOnlyValueRegardlessOfItsLanguage() {
-        assertThat(LocalizedStrings.germanString().from(List.of(localizedString(VecLanguageCode.EN, "Wire"))))
-                .contains("Wire");
+    void reducesToTheOnlyValueRegardlessOfItsLanguage() {
+        final List<VecAbstractLocalizedString> localizedStrings =
+                List.of(localizedString(VecLanguageCode.EN, "Wire"));
+
+        assertThat(reduce(localizedStrings, LocalizedStrings.valueIn(VecLanguageCode.DE))).contains("Wire");
     }
 
     @Test
-    void navigatesToNoValueForAnEmptyList() {
-        assertThat(LocalizedStrings.germanString().from(Collections.emptyList())).isEmpty();
+    void reducesToNoValueForNoLocalizedString() {
+        assertThat(reduce(Collections.emptyList(), LocalizedStrings.valueIn(VecLanguageCode.DE))).isEmpty();
     }
 
     @Test
-    void navigatesToNoValueForASingleTypedString() {
-        assertThat(LocalizedStrings.germanString()
-                           .from(List.of(typedString(VecLanguageCode.DE, LENGTH_TYPE, "100")))).isEmpty();
+    void reducesToNoValueForASingleTypedString() {
+        final List<VecAbstractLocalizedString> localizedStrings =
+                List.of(typedString(VecLanguageCode.DE, LENGTH_TYPE, "100"));
+
+        assertThat(reduce(localizedStrings, LocalizedStrings.valueIn(VecLanguageCode.DE))).isEmpty();
     }
 
     @Test
-    void navigatesToASingleTypedStringWithoutAType() {
-        assertThat(LocalizedStrings.germanString()
-                           .from(List.of(typedString(VecLanguageCode.DE, null, "Leitung")))).contains("Leitung");
+    void reducesToASingleTypedStringWithoutAType() {
+        final List<VecAbstractLocalizedString> localizedStrings =
+                List.of(typedString(VecLanguageCode.DE, null, "Leitung"));
+
+        assertThat(reduce(localizedStrings, LocalizedStrings.valueIn(VecLanguageCode.DE))).contains("Leitung");
     }
 
     @Test
@@ -80,48 +93,48 @@ class LocalizedStringsTest {
                 typedString(VecLanguageCode.DE, LENGTH_TYPE, "100"),
                 localizedString(VecLanguageCode.DE, "Leitung"));
 
-        assertThat(LocalizedStrings.germanString().from(localizedStrings)).contains("Leitung");
+        assertThat(reduce(localizedStrings, LocalizedStrings.valueIn(VecLanguageCode.DE))).contains("Leitung");
     }
 
     @Test
-    void navigatesToTheTypedStringOfTheRequestedTypeAndLanguage() {
+    void reducesToTheTypedValueOfTheRequestedTypeAndLanguage() {
         final List<VecAbstractLocalizedString> localizedStrings = List.of(
                 typedString(VecLanguageCode.DE, LENGTH_TYPE, "100"),
                 typedString(VecLanguageCode.EN, LENGTH_TYPE, "One hundred"),
                 typedString(VecLanguageCode.DE, "Width", "5"));
 
-        assertThat(LocalizedStrings.typedStringBy(LENGTH_TYPE, VecLanguageCode.DE).from(localizedStrings))
+        assertThat(reduce(localizedStrings, LocalizedStrings.typedValueBy(LENGTH_TYPE, VecLanguageCode.DE)))
                 .contains("100");
-        assertThat(LocalizedStrings.typedStringBy(LENGTH_TYPE, VecLanguageCode.EN).from(localizedStrings))
+        assertThat(reduce(localizedStrings, LocalizedStrings.typedValueBy(LENGTH_TYPE, VecLanguageCode.EN)))
                 .contains("One hundred");
-        assertThat(LocalizedStrings.typedStringBy("Height", VecLanguageCode.DE).from(localizedStrings))
+        assertThat(reduce(localizedStrings, LocalizedStrings.typedValueBy("Height", VecLanguageCode.DE)))
                 .isEmpty();
     }
 
     @Test
-    void navigatesToNoTypedStringForAnEmptyValue() {
+    void reducesToNoTypedValueForAnEmptyValue() {
         final List<VecAbstractLocalizedString> localizedStrings = List.of(
                 typedString(VecLanguageCode.DE, LENGTH_TYPE, ""),
                 localizedString(VecLanguageCode.DE, "Leitung"));
 
-        assertThat(LocalizedStrings.typedStringBy(LENGTH_TYPE, VecLanguageCode.DE).from(localizedStrings))
+        assertThat(reduce(localizedStrings, LocalizedStrings.typedValueBy(LENGTH_TYPE, VecLanguageCode.DE)))
                 .isEmpty();
     }
 
     /**
-     * Characterisation test for the deprecated {@link DescriptionNavs}, whose list based navigations delegate
-     * to {@link LocalizedStrings}. Can be removed together with {@link DescriptionNavs}.
+     * Characterisation test for the list based navigations of the deprecated {@link DescriptionNavs}, which
+     * now apply these reductions. Can be removed together with {@link DescriptionNavs}.
      */
     @Test
     @SuppressWarnings({"deprecation", "removal"})
     void deprecatedNavigationsBehaveLikeTheirReplacement() {
         for (final List<VecAbstractLocalizedString> localizedStrings : LocalizedStringFixtures.allVariants()) {
             assertThat(DescriptionNavs.germanString().apply(localizedStrings))
-                    .isEqualTo(LocalizedStrings.germanString().from(localizedStrings));
+                    .isEqualTo(reduce(localizedStrings, LocalizedStrings.valueIn(VecLanguageCode.DE)));
             assertThat(DescriptionNavs.englishString().apply(localizedStrings))
-                    .isEqualTo(LocalizedStrings.englishString().from(localizedStrings));
+                    .isEqualTo(reduce(localizedStrings, LocalizedStrings.valueIn(VecLanguageCode.EN)));
             assertThat(DescriptionNavs.stringIn(VecLanguageCode.EN).apply(localizedStrings))
-                    .isEqualTo(LocalizedStrings.stringIn(VecLanguageCode.EN).from(localizedStrings));
+                    .isEqualTo(reduce(localizedStrings, LocalizedStrings.valueIn(VecLanguageCode.EN)));
         }
     }
 

--- a/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/LocalizedStringsTest.java
+++ b/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/LocalizedStringsTest.java
@@ -1,0 +1,128 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v2x.traversal;
+
+import com.foursoft.harness.vec.v2x.VecAbstractLocalizedString;
+import com.foursoft.harness.vec.v2x.VecLanguageCode;
+import com.foursoft.harness.vec.v2x.navigations.DescriptionNavs;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static com.foursoft.harness.vec.v2x.traversal.LocalizedStringFixtures.LENGTH_TYPE;
+import static com.foursoft.harness.vec.v2x.traversal.LocalizedStringFixtures.localizedString;
+import static com.foursoft.harness.vec.v2x.traversal.LocalizedStringFixtures.typedString;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LocalizedStringsTest {
+
+    @Test
+    void navigatesToTheValueOfTheRequestedLanguage() {
+        final List<VecAbstractLocalizedString> localizedStrings = List.of(
+                localizedString(VecLanguageCode.DE, "Leitung"),
+                localizedString(VecLanguageCode.EN, "Wire"));
+
+        assertThat(LocalizedStrings.germanString().from(localizedStrings)).contains("Leitung");
+        assertThat(LocalizedStrings.englishString().from(localizedStrings)).contains("Wire");
+        assertThat(LocalizedStrings.stringIn(VecLanguageCode.EN).from(localizedStrings)).contains("Wire");
+    }
+
+    @Test
+    void navigatesToTheOnlyValueRegardlessOfItsLanguage() {
+        assertThat(LocalizedStrings.germanString().from(List.of(localizedString(VecLanguageCode.EN, "Wire"))))
+                .contains("Wire");
+    }
+
+    @Test
+    void navigatesToNoValueForAnEmptyList() {
+        assertThat(LocalizedStrings.germanString().from(Collections.emptyList())).isEmpty();
+    }
+
+    @Test
+    void navigatesToNoValueForASingleTypedString() {
+        assertThat(LocalizedStrings.germanString()
+                           .from(List.of(typedString(VecLanguageCode.DE, LENGTH_TYPE, "100")))).isEmpty();
+    }
+
+    @Test
+    void navigatesToASingleTypedStringWithoutAType() {
+        assertThat(LocalizedStrings.germanString()
+                           .from(List.of(typedString(VecLanguageCode.DE, null, "Leitung")))).contains("Leitung");
+    }
+
+    @Test
+    void ignoresTypedStringsWhenSeveralValuesArePresent() {
+        final List<VecAbstractLocalizedString> localizedStrings = List.of(
+                typedString(VecLanguageCode.DE, LENGTH_TYPE, "100"),
+                localizedString(VecLanguageCode.DE, "Leitung"));
+
+        assertThat(LocalizedStrings.germanString().from(localizedStrings)).contains("Leitung");
+    }
+
+    @Test
+    void navigatesToTheTypedStringOfTheRequestedTypeAndLanguage() {
+        final List<VecAbstractLocalizedString> localizedStrings = List.of(
+                typedString(VecLanguageCode.DE, LENGTH_TYPE, "100"),
+                typedString(VecLanguageCode.EN, LENGTH_TYPE, "One hundred"),
+                typedString(VecLanguageCode.DE, "Width", "5"));
+
+        assertThat(LocalizedStrings.typedStringBy(LENGTH_TYPE, VecLanguageCode.DE).from(localizedStrings))
+                .contains("100");
+        assertThat(LocalizedStrings.typedStringBy(LENGTH_TYPE, VecLanguageCode.EN).from(localizedStrings))
+                .contains("One hundred");
+        assertThat(LocalizedStrings.typedStringBy("Height", VecLanguageCode.DE).from(localizedStrings))
+                .isEmpty();
+    }
+
+    @Test
+    void navigatesToNoTypedStringForAnEmptyValue() {
+        final List<VecAbstractLocalizedString> localizedStrings = List.of(
+                typedString(VecLanguageCode.DE, LENGTH_TYPE, ""),
+                localizedString(VecLanguageCode.DE, "Leitung"));
+
+        assertThat(LocalizedStrings.typedStringBy(LENGTH_TYPE, VecLanguageCode.DE).from(localizedStrings))
+                .isEmpty();
+    }
+
+    /**
+     * Characterisation test for the deprecated {@link DescriptionNavs}, whose list based navigations delegate
+     * to {@link LocalizedStrings}. Can be removed together with {@link DescriptionNavs}.
+     */
+    @Test
+    @SuppressWarnings({"deprecation", "removal"})
+    void deprecatedNavigationsBehaveLikeTheirReplacement() {
+        for (final List<VecAbstractLocalizedString> localizedStrings : LocalizedStringFixtures.allVariants()) {
+            assertThat(DescriptionNavs.germanString().apply(localizedStrings))
+                    .isEqualTo(LocalizedStrings.germanString().from(localizedStrings));
+            assertThat(DescriptionNavs.englishString().apply(localizedStrings))
+                    .isEqualTo(LocalizedStrings.englishString().from(localizedStrings));
+            assertThat(DescriptionNavs.stringIn(VecLanguageCode.EN).apply(localizedStrings))
+                    .isEqualTo(LocalizedStrings.stringIn(VecLanguageCode.EN).from(localizedStrings));
+        }
+    }
+
+}

--- a/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/OccurrenceOrUsagesTest.java
+++ b/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/OccurrenceOrUsagesTest.java
@@ -1,0 +1,213 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v2x.traversal;
+
+import com.foursoft.harness.vec.v2x.VecCompositionSpecification;
+import com.foursoft.harness.vec.v2x.VecDocumentVersion;
+import com.foursoft.harness.vec.v2x.VecModuleFamily;
+import com.foursoft.harness.vec.v2x.VecNodeLocation;
+import com.foursoft.harness.vec.v2x.VecOnPointPlacement;
+import com.foursoft.harness.vec.v2x.VecPartOccurrence;
+import com.foursoft.harness.vec.v2x.VecPartOrUsageRelatedSpecification;
+import com.foursoft.harness.vec.v2x.VecPartUsage;
+import com.foursoft.harness.vec.v2x.VecPartUsageSpecification;
+import com.foursoft.harness.vec.v2x.VecPartVersion;
+import com.foursoft.harness.vec.v2x.VecPartWithSubComponentsRole;
+import com.foursoft.harness.vec.v2x.VecPlaceableElementRole;
+import com.foursoft.harness.vec.v2x.VecPrimaryPartType;
+import com.foursoft.harness.vec.v2x.VecTopologyNode;
+import com.foursoft.harness.vec.v2x.VecWireRole;
+import com.foursoft.harness.vec.v2x.VecWireSpecification;
+import com.foursoft.harness.vec.v2x.navigations.PartOccurrenceOrUsageNavs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OccurrenceOrUsagesTest {
+
+    private final VecDocumentVersion harness = new VecDocumentVersion();
+    private final VecDocumentVersion partMaster = new VecDocumentVersion();
+
+    private final VecPartOccurrence occurrence = new VecPartOccurrence();
+    private final VecPartUsage usage = new VecPartUsage();
+    private final VecPartVersion part = new VecPartVersion();
+    private final VecPlaceableElementRole placeableElementRole = new VecPlaceableElementRole();
+    private final VecWireRole wireRole = new VecWireRole();
+
+    @BeforeEach
+    void setUp() {
+        harness.setDocumentNumber("HARNESS-1");
+        partMaster.setDocumentNumber("PART-MASTER-1");
+
+        part.setPartNumber("  12  34  ");
+        part.setPartVersion("  01 ");
+        part.setPrimaryPartType(VecPrimaryPartType.WIRE);
+        occurrence.setPart(part);
+        occurrence.getRoles().add(wireRole);
+        occurrence.getRoles().add(placeableElementRole);
+
+        final VecCompositionSpecification composition = new VecCompositionSpecification();
+        composition.setParentDocumentVersion(harness);
+        occurrence.setParentCompositionSpecification(composition);
+
+        usage.setPrimaryPartUsageType(VecPrimaryPartType.CONNECTOR_HOUSING);
+        final VecPartUsageSpecification partUsages = new VecPartUsageSpecification();
+        partUsages.setParentDocumentVersion(partMaster);
+        usage.setParentPartUsageSpecification(partUsages);
+    }
+
+    @Test
+    void navigatesToTheRolesOfAnOccurrenceOrUsage() {
+        assertThat(OccurrenceOrUsages.toRoles().listFrom(occurrence))
+                .containsExactly(wireRole, placeableElementRole);
+        assertThat(OccurrenceOrUsages.toRoles().listFrom(usage)).isEmpty();
+    }
+
+    @Test
+    void navigatesToThePlaceableElementRoleOfAnOccurrenceOrUsage() {
+        assertThat(OccurrenceOrUsages.toPlaceableElementRole().from(occurrence)).contains(placeableElementRole);
+        assertThat(OccurrenceOrUsages.toPlaceableElementRole().from(usage)).isEmpty();
+    }
+
+    @Test
+    void navigatesToTheParentDocumentVersionOfAnOccurrenceAndOfAUsage() {
+        assertThat(OccurrenceOrUsages.toParentDocumentVersion().from(occurrence)).contains(harness);
+        assertThat(OccurrenceOrUsages.toParentDocumentVersion().from(usage)).contains(partMaster);
+        assertThat(OccurrenceOrUsages.toParentDocumentNumber().from(occurrence)).contains("HARNESS-1");
+        assertThat(OccurrenceOrUsages.toParentDocumentNumber().from(usage)).contains("PART-MASTER-1");
+    }
+
+    @Test
+    void navigatesToNoParentDocumentVersionForAnUnattachedOccurrence() {
+        assertThat(OccurrenceOrUsages.toParentDocumentVersion().from(new VecPartOccurrence())).isEmpty();
+    }
+
+    @Test
+    void navigatesToThePartOfAnOccurrenceWithItsWhitespacesCollapsed() {
+        assertThat(OccurrenceOrUsages.toPart().from(occurrence)).contains(part);
+        assertThat(OccurrenceOrUsages.toPartNumber().from(occurrence)).contains("12 34");
+        assertThat(OccurrenceOrUsages.toPartVersion().from(occurrence)).contains("01");
+    }
+
+    @Test
+    void navigatesToNoPartForAnOccurrenceWithoutOne() {
+        assertThat(OccurrenceOrUsages.toPart().from(new VecPartOccurrence())).isEmpty();
+        assertThat(OccurrenceOrUsages.toPartNumber().from(new VecPartOccurrence())).isEmpty();
+    }
+
+    @Test
+    void navigatesToThePrimaryPartTypeOfAnOccurrenceAndOfAUsage() {
+        assertThat(OccurrenceOrUsages.toPrimaryPartType().from(occurrence)).contains(VecPrimaryPartType.WIRE);
+        assertThat(OccurrenceOrUsages.toPrimaryPartType().from(usage))
+                .contains(VecPrimaryPartType.CONNECTOR_HOUSING);
+    }
+
+    @Test
+    void navigatesToThePrimaryPartTypeOfTheRealizedUsageForAnOccurrenceWithoutAPart() {
+        final VecPartOccurrence realizing = new VecPartOccurrence();
+        realizing.getRealizedPartUsage().add(usage);
+
+        assertThat(OccurrenceOrUsages.toPrimaryPartType().from(realizing))
+                .contains(VecPrimaryPartType.CONNECTOR_HOUSING);
+        assertThat(OccurrenceOrUsages.toPrimaryPartType().from(new VecPartOccurrence()))
+                .contains(VecPrimaryPartType.OTHER);
+    }
+
+    @Test
+    void navigatesToThePartOrUsageRelatedSpecifications() {
+        final VecPartOrUsageRelatedSpecification specification = new VecWireSpecification();
+        part.getRefPartOrUsageRelatedSpecification().add(specification);
+        usage.getPartOrUsageRelatedSpecification().add(specification);
+
+        assertThat(OccurrenceOrUsages.toPartOrUsageRelatedSpecifications().listFrom(occurrence))
+                .containsExactly(specification);
+        assertThat(OccurrenceOrUsages.toPartOrUsageRelatedSpecifications().listFrom(usage))
+                .containsExactly(specification);
+        assertThat(OccurrenceOrUsages.toPartOrUsageRelatedSpecifications().listFrom(new VecPartOccurrence()))
+                .isEmpty();
+    }
+
+    @Test
+    void navigatesToTheTopologyNodeAnOccurrenceIsPlacedOn() {
+        final VecTopologyNode topologyNode = new VecTopologyNode();
+        final VecNodeLocation location = new VecNodeLocation();
+        location.setReferencedNode(topologyNode);
+        final VecOnPointPlacement placement = new VecOnPointPlacement();
+        placement.getLocations().add(location);
+        placeableElementRole.getRefPlacement().add(placement);
+
+        assertThat(OccurrenceOrUsages.toReferencedTopologyNode().from(occurrence)).contains(topologyNode);
+        assertThat(OccurrenceOrUsages.toReferencedTopologyNode().from(new VecPartOccurrence())).isEmpty();
+    }
+
+    @Test
+    void navigatesToTheModuleFamilyOfAModule() {
+        final VecModuleFamily moduleFamily = new VecModuleFamily();
+        final VecPartWithSubComponentsRole moduleRole = new VecPartWithSubComponentsRole();
+        moduleRole.getRefModuleFamily().add(moduleFamily);
+        occurrence.getRoles().add(moduleRole);
+
+        assertThat(OccurrenceOrUsages.toModuleFamily().from(occurrence)).isEmpty();
+
+        part.setPrimaryPartType(VecPrimaryPartType.PART_STRUCTURE);
+
+        assertThat(OccurrenceOrUsages.toModuleFamily().from(occurrence)).contains(moduleFamily);
+    }
+
+    /**
+     * Characterisation test for the deprecated {@link PartOccurrenceOrUsageNavs}, which delegates to
+     * {@link OccurrenceOrUsages}. Can be removed together with {@link PartOccurrenceOrUsageNavs}.
+     */
+    @Test
+    @SuppressWarnings({"deprecation", "removal"})
+    void deprecatedNavigationsBehaveLikeTheirReplacement() {
+        assertThat(PartOccurrenceOrUsageNavs.parentDocumentVersionOfOccurrence().apply(occurrence))
+                .isEqualTo(harness);
+        assertThat(PartOccurrenceOrUsageNavs.parentDocumentVersionOfUsage().apply(usage)).isEqualTo(partMaster);
+        assertThat(PartOccurrenceOrUsageNavs.parentDocumentVersion().apply(occurrence)).isEqualTo(harness);
+        assertThat(PartOccurrenceOrUsageNavs.parentDocumentNumberOfOccurrence().apply(occurrence))
+                .isEqualTo("HARNESS-1");
+        assertThat(PartOccurrenceOrUsageNavs.parentDocumentNumberOfUsage().apply(usage))
+                .isEqualTo("PART-MASTER-1");
+        assertThat(PartOccurrenceOrUsageNavs.parentDocumentNumber().apply(usage)).isEqualTo("PART-MASTER-1");
+        assertThat(PartOccurrenceOrUsageNavs.partNumber().apply(occurrence))
+                .isEqualTo(OccurrenceOrUsages.toPartNumber().from(occurrence));
+        assertThat(PartOccurrenceOrUsageNavs.partVersion().apply(occurrence))
+                .isEqualTo(OccurrenceOrUsages.toPartVersion().from(occurrence));
+        assertThat(PartOccurrenceOrUsageNavs.primaryPartTypeOfOccurrence().apply(occurrence))
+                .isEqualTo(VecPrimaryPartType.WIRE);
+        assertThat(PartOccurrenceOrUsageNavs.primaryPartType().apply(usage))
+                .isEqualTo(VecPrimaryPartType.CONNECTOR_HOUSING);
+        assertThat(PartOccurrenceOrUsageNavs.moduleFamily().apply(occurrence))
+                .isEqualTo(OccurrenceOrUsages.toModuleFamily().from(occurrence));
+        assertThat(PartOccurrenceOrUsageNavs.topologyNodeByOccurrenceOrUsage().apply(occurrence))
+                .isEqualTo(OccurrenceOrUsages.toReferencedTopologyNode().from(occurrence));
+        assertThat(PartOccurrenceOrUsageNavs.occurrence().apply(occurrence)).contains(occurrence);
+        assertThat(PartOccurrenceOrUsageNavs.usage().apply(usage)).contains(usage);
+    }
+
+}

--- a/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/PlaceableElementRolesTest.java
+++ b/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/PlaceableElementRolesTest.java
@@ -1,0 +1,83 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v2x.traversal;
+
+import com.foursoft.harness.vec.v2x.VecOnPointPlacement;
+import com.foursoft.harness.vec.v2x.VecOnWayPlacement;
+import com.foursoft.harness.vec.v2x.VecPlaceableElementRole;
+import com.foursoft.harness.vec.v2x.navigations.PlacementNavs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PlaceableElementRolesTest {
+
+    private final VecOnPointPlacement onPointPlacement = new VecOnPointPlacement();
+    private final VecOnWayPlacement onWayPlacement = new VecOnWayPlacement();
+
+    private VecPlaceableElementRole role;
+
+    @BeforeEach
+    void setUp() {
+        role = new VecPlaceableElementRole();
+        role.getRefPlacement().add(onPointPlacement);
+        role.getRefPlacement().add(onWayPlacement);
+    }
+
+    @Test
+    void navigatesToAllPlacementsOfARole() {
+        assertThat(PlaceableElementRoles.placements().listFrom(role))
+                .containsExactlyInAnyOrder(onPointPlacement, onWayPlacement);
+    }
+
+    @Test
+    void navigatesToThePlacementsOfTheRequestedKind() {
+        assertThat(PlaceableElementRoles.onPointPlacements().listFrom(role))
+                .containsExactly(onPointPlacement);
+        assertThat(PlaceableElementRoles.onWayPlacements().listFrom(role))
+                .containsExactly(onWayPlacement);
+    }
+
+    @Test
+    void navigatesToNoPlacementForARoleWithoutPlacements() {
+        assertThat(PlaceableElementRoles.placements().listFrom(new VecPlaceableElementRole())).isEmpty();
+    }
+
+    /**
+     * Characterisation test for the deprecated {@link PlacementNavs}, which delegates to
+     * {@link PlaceableElementRoles}. Can be removed together with {@link PlacementNavs}.
+     */
+    @Test
+    @SuppressWarnings({"deprecation", "removal"})
+    void deprecatedNavigationsBehaveLikeTheirReplacement() {
+        assertThat(PlacementNavs.onPointPlacement().apply(role))
+                .containsExactlyElementsOf(PlaceableElementRoles.onPointPlacements().listFrom(role));
+        assertThat(PlacementNavs.onWayPlacement().apply(role))
+                .containsExactlyElementsOf(PlaceableElementRoles.onWayPlacements().listFrom(role));
+    }
+
+}

--- a/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/PlaceableElementRolesTest.java
+++ b/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/PlaceableElementRolesTest.java
@@ -50,21 +50,21 @@ class PlaceableElementRolesTest {
 
     @Test
     void navigatesToAllPlacementsOfARole() {
-        assertThat(PlaceableElementRoles.placements().listFrom(role))
+        assertThat(PlaceableElementRoles.toPlacements().listFrom(role))
                 .containsExactlyInAnyOrder(onPointPlacement, onWayPlacement);
     }
 
     @Test
     void navigatesToThePlacementsOfTheRequestedKind() {
-        assertThat(PlaceableElementRoles.onPointPlacements().listFrom(role))
+        assertThat(PlaceableElementRoles.toOnPointPlacements().listFrom(role))
                 .containsExactly(onPointPlacement);
-        assertThat(PlaceableElementRoles.onWayPlacements().listFrom(role))
+        assertThat(PlaceableElementRoles.toOnWayPlacements().listFrom(role))
                 .containsExactly(onWayPlacement);
     }
 
     @Test
     void navigatesToNoPlacementForARoleWithoutPlacements() {
-        assertThat(PlaceableElementRoles.placements().listFrom(new VecPlaceableElementRole())).isEmpty();
+        assertThat(PlaceableElementRoles.toPlacements().listFrom(new VecPlaceableElementRole())).isEmpty();
     }
 
     /**
@@ -75,9 +75,9 @@ class PlaceableElementRolesTest {
     @SuppressWarnings({"deprecation", "removal"})
     void deprecatedNavigationsBehaveLikeTheirReplacement() {
         assertThat(PlacementNavs.onPointPlacement().apply(role))
-                .containsExactlyElementsOf(PlaceableElementRoles.onPointPlacements().listFrom(role));
+                .containsExactlyElementsOf(PlaceableElementRoles.toOnPointPlacements().listFrom(role));
         assertThat(PlacementNavs.onWayPlacement().apply(role))
-                .containsExactlyElementsOf(PlaceableElementRoles.onWayPlacements().listFrom(role));
+                .containsExactlyElementsOf(PlaceableElementRoles.toOnWayPlacements().listFrom(role));
     }
 
 }

--- a/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/PlacementsTest.java
+++ b/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/PlacementsTest.java
@@ -25,134 +25,69 @@
  */
 package com.foursoft.harness.vec.v2x.traversal;
 
-import com.foursoft.harness.vec.common.traversal.MultiNavigation;
-import com.foursoft.harness.vec.v2x.HasOccurrenceOrUsages;
-import com.foursoft.harness.vec.v2x.VecLocation;
 import com.foursoft.harness.vec.v2x.VecNodeLocation;
-import com.foursoft.harness.vec.v2x.VecOccurrenceOrUsage;
 import com.foursoft.harness.vec.v2x.VecOnPointPlacement;
 import com.foursoft.harness.vec.v2x.VecOnWayPlacement;
-import com.foursoft.harness.vec.v2x.VecPartOccurrence;
-import com.foursoft.harness.vec.v2x.VecPlaceableElementRole;
 import com.foursoft.harness.vec.v2x.VecSegmentLocation;
 import com.foursoft.harness.vec.v2x.navigations.PlacementNavs;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import java.util.Collections;
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class PlacementsTest {
 
-    private VecNodeLocation nodeLocation;
-    private VecSegmentLocation segmentLocation;
-    private VecOnPointPlacement onPointPlacement;
-    private VecOnWayPlacement onWayPlacement;
-    private VecPlaceableElementRole role;
-    private HasOccurrenceOrUsages viewItem;
+    private final VecNodeLocation nodeLocation = new VecNodeLocation();
+    private final VecSegmentLocation segmentLocation = new VecSegmentLocation();
 
-    @BeforeEach
-    void setUp() {
-        nodeLocation = new VecNodeLocation();
-        segmentLocation = new VecSegmentLocation();
-
-        onPointPlacement = new VecOnPointPlacement();
-        onPointPlacement.getLocations().add(nodeLocation);
-
-        onWayPlacement = new VecOnWayPlacement();
-        onWayPlacement.setStartLocation(segmentLocation);
-        onWayPlacement.setEndLocation(nodeLocation);
-
-        role = new VecPlaceableElementRole();
-        role.getRefPlacement().add(onPointPlacement);
-        role.getRefPlacement().add(onWayPlacement);
-
-        final VecPartOccurrence partOccurrence = new VecPartOccurrence();
-        partOccurrence.getRoles().add(role);
-
-        final List<VecOccurrenceOrUsage> occurrences = List.of(partOccurrence);
-        viewItem = () -> occurrences;
+    private VecOnPointPlacement onPointPlacement(final VecNodeLocation... locations) {
+        final VecOnPointPlacement placement = new VecOnPointPlacement();
+        for (final VecNodeLocation location : locations) {
+            placement.getLocations().add(location);
+        }
+        return placement;
     }
 
-    @Test
-    void navigatesToAllPlacementsOfARole() {
-        assertThat(Placements.placements().listFrom(role))
-                .containsExactlyInAnyOrder(onPointPlacement, onWayPlacement);
-    }
-
-    @Test
-    void navigatesToThePlacementsOfTheRequestedKind() {
-        assertThat(Placements.onPointPlacement().listFrom(role)).containsExactly(onPointPlacement);
-        assertThat(Placements.onWayPlacement().listFrom(role)).containsExactly(onWayPlacement);
+    private VecOnWayPlacement onWayPlacement() {
+        final VecOnWayPlacement placement = new VecOnWayPlacement();
+        placement.setStartLocation(segmentLocation);
+        placement.setEndLocation(nodeLocation);
+        return placement;
     }
 
     @Test
     void navigatesToTheLocationsOfAnOnPointPlacement() {
-        assertThat(Placements.onPointLocations().listFrom(onPointPlacement)).containsExactly(nodeLocation);
+        assertThat(Placements.locations().listFrom(onPointPlacement(nodeLocation)))
+                .containsExactly(nodeLocation);
     }
 
     @Test
     void navigatesToTheStartAndEndLocationOfAnOnWayPlacement() {
-        assertThat(Placements.onWayLocations().listFrom(onWayPlacement))
+        assertThat(Placements.locations().listFrom(onWayPlacement()))
                 .containsExactly(segmentLocation, nodeLocation);
+    }
+
+    @Test
+    void navigatesToNoLocationForAPlacementWithoutLocations() {
+        assertThat(Placements.locations().listFrom(onPointPlacement())).isEmpty();
+        assertThat(Placements.locations().listFrom(new VecOnWayPlacement())).isEmpty();
     }
 
     @Test
     void skipsAnUnsetStartOrEndLocation() {
-        onWayPlacement.setStartLocation(null);
+        final VecOnWayPlacement placement = onWayPlacement();
+        placement.setStartLocation(null);
 
-        assertThat(Placements.onWayLocations().listFrom(onWayPlacement)).containsExactly(nodeLocation);
+        assertThat(Placements.locations().listFrom(placement)).containsExactly(nodeLocation);
     }
 
     @Test
-    void navigatesToTheOnWayLocationsOfTheRequestedType() {
-        assertThat(Placements.onWayLocationsWith(VecNodeLocation.class).listFrom(onWayPlacement))
+    void navigatesToTheLocationsOfTheRequestedType() {
+        final VecOnWayPlacement placement = onWayPlacement();
+
+        assertThat(Placements.locationsWith(VecNodeLocation.class).listFrom(placement))
                 .containsExactly(nodeLocation);
-        assertThat(Placements.onWayLocationsWith(VecSegmentLocation.class).listFrom(onWayPlacement))
+        assertThat(Placements.locationsWith(VecSegmentLocation.class).listFrom(placement))
                 .containsExactly(segmentLocation);
-    }
-
-    @Test
-    void navigatesToThePlaceableElementRoleOfAViewItem() {
-        assertThat(Placements.placeableElementRole().from(viewItem)).contains(role);
-    }
-
-    @Test
-    void navigatesToNoPlaceableElementRoleForAnEmptyViewItem() {
-        assertThat(Placements.placeableElementRole().from(Collections::emptyList)).isEmpty();
-    }
-
-    @Test
-    void navigatesToTheOnPointLocationsOfAViewItem() {
-        final MultiNavigation<VecPlaceableElementRole, VecLocation> locations =
-                Placements.onPointPlacement().thenEach(Placements.onPointLocations());
-
-        assertThat(Placements.locationsOf(locations).listFrom(viewItem)).containsExactly(nodeLocation);
-    }
-
-    /**
-     * The way from the role to the locations is a parameter of
-     * {@link Placements#locationsOf(MultiNavigation)}, so on way placements can be used as well. The
-     * deprecated {@link PlacementNavs#locationsOf(java.util.function.Function)} documented this, but its
-     * parameter type only allowed on point placements.
-     */
-    @Test
-    void navigatesToTheOnWayLocationsOfAViewItem() {
-        final MultiNavigation<VecPlaceableElementRole, VecLocation> locations =
-                Placements.onWayPlacement().thenEach(Placements.onWayLocations());
-
-        assertThat(Placements.locationsOf(locations).listFrom(viewItem))
-                .containsExactly(segmentLocation, nodeLocation);
-    }
-
-    @Test
-    void navigatesToNoLocationForAnEmptyViewItem() {
-        final MultiNavigation<VecPlaceableElementRole, VecLocation> locations =
-                Placements.onPointPlacement().thenEach(Placements.onPointLocations());
-
-        assertThat(Placements.locationsOf(locations).listFrom(Collections::emptyList)).isEmpty();
     }
 
     /**
@@ -162,20 +97,12 @@ class PlacementsTest {
     @Test
     @SuppressWarnings({"deprecation", "removal"})
     void deprecatedNavigationsBehaveLikeTheirReplacement() {
-        assertThat(PlacementNavs.onPointPlacement().apply(role))
-                .containsExactlyElementsOf(Placements.onPointPlacement().listFrom(role));
-        assertThat(PlacementNavs.onWayPlacement().apply(role))
-                .containsExactlyElementsOf(Placements.onWayPlacement().listFrom(role));
+        final VecOnWayPlacement placement = onWayPlacement();
 
-        assertThat(PlacementNavs.locationsOf(PlacementNavs.onPointPlacement()).apply(viewItem))
-                .isEqualTo(Placements.locationsOf(
-                                Placements.onPointPlacement().thenEach(Placements.onPointLocations()))
-                                   .listFrom(viewItem));
-        assertThat(PlacementNavs.locationsOf(PlacementNavs.onPointPlacement()).apply(Collections::emptyList))
-                .isEmpty();
-
-        assertThat(PlacementNavs.locationsWith(VecNodeLocation.class).apply(onWayPlacement))
-                .isEqualTo(Placements.onWayLocationsWith(VecNodeLocation.class).listFrom(onWayPlacement));
+        assertThat(PlacementNavs.locationsWith(VecNodeLocation.class).apply(placement))
+                .isEqualTo(Placements.locationsWith(VecNodeLocation.class).listFrom(placement));
+        assertThat(PlacementNavs.locationsWith(VecSegmentLocation.class).apply(placement))
+                .isEqualTo(Placements.locationsWith(VecSegmentLocation.class).listFrom(placement));
     }
 
 }

--- a/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/PlacementsTest.java
+++ b/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/PlacementsTest.java
@@ -84,9 +84,9 @@ class PlacementsTest {
     void navigatesToTheLocationsOfTheRequestedType() {
         final VecOnWayPlacement placement = onWayPlacement();
 
-        assertThat(Placements.locationsWith(VecNodeLocation.class).listFrom(placement))
+        assertThat(Placements.locations().ofType(VecNodeLocation.class).listFrom(placement))
                 .containsExactly(nodeLocation);
-        assertThat(Placements.locationsWith(VecSegmentLocation.class).listFrom(placement))
+        assertThat(Placements.locations().ofType(VecSegmentLocation.class).listFrom(placement))
                 .containsExactly(segmentLocation);
     }
 
@@ -100,9 +100,9 @@ class PlacementsTest {
         final VecOnWayPlacement placement = onWayPlacement();
 
         assertThat(PlacementNavs.locationsWith(VecNodeLocation.class).apply(placement))
-                .isEqualTo(Placements.locationsWith(VecNodeLocation.class).listFrom(placement));
+                .isEqualTo(Placements.locations().ofType(VecNodeLocation.class).listFrom(placement));
         assertThat(PlacementNavs.locationsWith(VecSegmentLocation.class).apply(placement))
-                .isEqualTo(Placements.locationsWith(VecSegmentLocation.class).listFrom(placement));
+                .isEqualTo(Placements.locations().ofType(VecSegmentLocation.class).listFrom(placement));
     }
 
 }

--- a/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/PlacementsTest.java
+++ b/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/PlacementsTest.java
@@ -1,0 +1,181 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v2x.traversal;
+
+import com.foursoft.harness.vec.common.traversal.MultiNavigation;
+import com.foursoft.harness.vec.v2x.HasOccurrenceOrUsages;
+import com.foursoft.harness.vec.v2x.VecLocation;
+import com.foursoft.harness.vec.v2x.VecNodeLocation;
+import com.foursoft.harness.vec.v2x.VecOccurrenceOrUsage;
+import com.foursoft.harness.vec.v2x.VecOnPointPlacement;
+import com.foursoft.harness.vec.v2x.VecOnWayPlacement;
+import com.foursoft.harness.vec.v2x.VecPartOccurrence;
+import com.foursoft.harness.vec.v2x.VecPlaceableElementRole;
+import com.foursoft.harness.vec.v2x.VecSegmentLocation;
+import com.foursoft.harness.vec.v2x.navigations.PlacementNavs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PlacementsTest {
+
+    private VecNodeLocation nodeLocation;
+    private VecSegmentLocation segmentLocation;
+    private VecOnPointPlacement onPointPlacement;
+    private VecOnWayPlacement onWayPlacement;
+    private VecPlaceableElementRole role;
+    private HasOccurrenceOrUsages viewItem;
+
+    @BeforeEach
+    void setUp() {
+        nodeLocation = new VecNodeLocation();
+        segmentLocation = new VecSegmentLocation();
+
+        onPointPlacement = new VecOnPointPlacement();
+        onPointPlacement.getLocations().add(nodeLocation);
+
+        onWayPlacement = new VecOnWayPlacement();
+        onWayPlacement.setStartLocation(segmentLocation);
+        onWayPlacement.setEndLocation(nodeLocation);
+
+        role = new VecPlaceableElementRole();
+        role.getRefPlacement().add(onPointPlacement);
+        role.getRefPlacement().add(onWayPlacement);
+
+        final VecPartOccurrence partOccurrence = new VecPartOccurrence();
+        partOccurrence.getRoles().add(role);
+
+        final List<VecOccurrenceOrUsage> occurrences = List.of(partOccurrence);
+        viewItem = () -> occurrences;
+    }
+
+    @Test
+    void navigatesToAllPlacementsOfARole() {
+        assertThat(Placements.placements().listFrom(role))
+                .containsExactlyInAnyOrder(onPointPlacement, onWayPlacement);
+    }
+
+    @Test
+    void navigatesToThePlacementsOfTheRequestedKind() {
+        assertThat(Placements.onPointPlacement().listFrom(role)).containsExactly(onPointPlacement);
+        assertThat(Placements.onWayPlacement().listFrom(role)).containsExactly(onWayPlacement);
+    }
+
+    @Test
+    void navigatesToTheLocationsOfAnOnPointPlacement() {
+        assertThat(Placements.onPointLocations().listFrom(onPointPlacement)).containsExactly(nodeLocation);
+    }
+
+    @Test
+    void navigatesToTheStartAndEndLocationOfAnOnWayPlacement() {
+        assertThat(Placements.onWayLocations().listFrom(onWayPlacement))
+                .containsExactly(segmentLocation, nodeLocation);
+    }
+
+    @Test
+    void skipsAnUnsetStartOrEndLocation() {
+        onWayPlacement.setStartLocation(null);
+
+        assertThat(Placements.onWayLocations().listFrom(onWayPlacement)).containsExactly(nodeLocation);
+    }
+
+    @Test
+    void navigatesToTheOnWayLocationsOfTheRequestedType() {
+        assertThat(Placements.onWayLocationsWith(VecNodeLocation.class).listFrom(onWayPlacement))
+                .containsExactly(nodeLocation);
+        assertThat(Placements.onWayLocationsWith(VecSegmentLocation.class).listFrom(onWayPlacement))
+                .containsExactly(segmentLocation);
+    }
+
+    @Test
+    void navigatesToThePlaceableElementRoleOfAViewItem() {
+        assertThat(Placements.placeableElementRole().from(viewItem)).contains(role);
+    }
+
+    @Test
+    void navigatesToNoPlaceableElementRoleForAnEmptyViewItem() {
+        assertThat(Placements.placeableElementRole().from(Collections::emptyList)).isEmpty();
+    }
+
+    @Test
+    void navigatesToTheOnPointLocationsOfAViewItem() {
+        final MultiNavigation<VecPlaceableElementRole, VecLocation> locations =
+                Placements.onPointPlacement().thenEach(Placements.onPointLocations());
+
+        assertThat(Placements.locationsOf(locations).listFrom(viewItem)).containsExactly(nodeLocation);
+    }
+
+    /**
+     * The way from the role to the locations is a parameter of
+     * {@link Placements#locationsOf(MultiNavigation)}, so on way placements can be used as well. The
+     * deprecated {@link PlacementNavs#locationsOf(java.util.function.Function)} documented this, but its
+     * parameter type only allowed on point placements.
+     */
+    @Test
+    void navigatesToTheOnWayLocationsOfAViewItem() {
+        final MultiNavigation<VecPlaceableElementRole, VecLocation> locations =
+                Placements.onWayPlacement().thenEach(Placements.onWayLocations());
+
+        assertThat(Placements.locationsOf(locations).listFrom(viewItem))
+                .containsExactly(segmentLocation, nodeLocation);
+    }
+
+    @Test
+    void navigatesToNoLocationForAnEmptyViewItem() {
+        final MultiNavigation<VecPlaceableElementRole, VecLocation> locations =
+                Placements.onPointPlacement().thenEach(Placements.onPointLocations());
+
+        assertThat(Placements.locationsOf(locations).listFrom(Collections::emptyList)).isEmpty();
+    }
+
+    /**
+     * Characterisation test for the deprecated {@link PlacementNavs}, which delegates to {@link Placements}.
+     * Can be removed together with {@link PlacementNavs}.
+     */
+    @Test
+    @SuppressWarnings({"deprecation", "removal"})
+    void deprecatedNavigationsBehaveLikeTheirReplacement() {
+        assertThat(PlacementNavs.onPointPlacement().apply(role))
+                .containsExactlyElementsOf(Placements.onPointPlacement().listFrom(role));
+        assertThat(PlacementNavs.onWayPlacement().apply(role))
+                .containsExactlyElementsOf(Placements.onWayPlacement().listFrom(role));
+
+        assertThat(PlacementNavs.locationsOf(PlacementNavs.onPointPlacement()).apply(viewItem))
+                .isEqualTo(Placements.locationsOf(
+                                Placements.onPointPlacement().thenEach(Placements.onPointLocations()))
+                                   .listFrom(viewItem));
+        assertThat(PlacementNavs.locationsOf(PlacementNavs.onPointPlacement()).apply(Collections::emptyList))
+                .isEmpty();
+
+        assertThat(PlacementNavs.locationsWith(VecNodeLocation.class).apply(onWayPlacement))
+                .isEqualTo(Placements.onWayLocationsWith(VecNodeLocation.class).listFrom(onWayPlacement));
+    }
+
+}

--- a/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/PlacementsTest.java
+++ b/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/PlacementsTest.java
@@ -56,20 +56,20 @@ class PlacementsTest {
 
     @Test
     void navigatesToTheLocationsOfAnOnPointPlacement() {
-        assertThat(Placements.locations().listFrom(onPointPlacement(nodeLocation)))
+        assertThat(Placements.toLocations().listFrom(onPointPlacement(nodeLocation)))
                 .containsExactly(nodeLocation);
     }
 
     @Test
     void navigatesToTheStartAndEndLocationOfAnOnWayPlacement() {
-        assertThat(Placements.locations().listFrom(onWayPlacement()))
+        assertThat(Placements.toLocations().listFrom(onWayPlacement()))
                 .containsExactly(segmentLocation, nodeLocation);
     }
 
     @Test
     void navigatesToNoLocationForAPlacementWithoutLocations() {
-        assertThat(Placements.locations().listFrom(onPointPlacement())).isEmpty();
-        assertThat(Placements.locations().listFrom(new VecOnWayPlacement())).isEmpty();
+        assertThat(Placements.toLocations().listFrom(onPointPlacement())).isEmpty();
+        assertThat(Placements.toLocations().listFrom(new VecOnWayPlacement())).isEmpty();
     }
 
     @Test
@@ -77,16 +77,16 @@ class PlacementsTest {
         final VecOnWayPlacement placement = onWayPlacement();
         placement.setStartLocation(null);
 
-        assertThat(Placements.locations().listFrom(placement)).containsExactly(nodeLocation);
+        assertThat(Placements.toLocations().listFrom(placement)).containsExactly(nodeLocation);
     }
 
     @Test
     void navigatesToTheLocationsOfTheRequestedType() {
         final VecOnWayPlacement placement = onWayPlacement();
 
-        assertThat(Placements.locations().ofType(VecNodeLocation.class).listFrom(placement))
+        assertThat(Placements.toLocations().ofType(VecNodeLocation.class).listFrom(placement))
                 .containsExactly(nodeLocation);
-        assertThat(Placements.locations().ofType(VecSegmentLocation.class).listFrom(placement))
+        assertThat(Placements.toLocations().ofType(VecSegmentLocation.class).listFrom(placement))
                 .containsExactly(segmentLocation);
     }
 
@@ -100,9 +100,9 @@ class PlacementsTest {
         final VecOnWayPlacement placement = onWayPlacement();
 
         assertThat(PlacementNavs.locationsWith(VecNodeLocation.class).apply(placement))
-                .isEqualTo(Placements.locations().ofType(VecNodeLocation.class).listFrom(placement));
+                .isEqualTo(Placements.toLocations().ofType(VecNodeLocation.class).listFrom(placement));
         assertThat(PlacementNavs.locationsWith(VecSegmentLocation.class).apply(placement))
-                .isEqualTo(Placements.locations().ofType(VecSegmentLocation.class).listFrom(placement));
+                .isEqualTo(Placements.toLocations().ofType(VecSegmentLocation.class).listFrom(placement));
     }
 
 }

--- a/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/RolesTest.java
+++ b/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/RolesTest.java
@@ -1,0 +1,80 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v2x.traversal;
+
+import com.foursoft.harness.vec.v2x.VecCompositionSpecification;
+import com.foursoft.harness.vec.v2x.VecDocumentVersion;
+import com.foursoft.harness.vec.v2x.VecPartOccurrence;
+import com.foursoft.harness.vec.v2x.VecPlaceableElementRole;
+import com.foursoft.harness.vec.v2x.VecRole;
+import com.foursoft.harness.vec.v2x.navigations.VecNavs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RolesTest {
+
+    private final VecDocumentVersion documentVersion = new VecDocumentVersion();
+    private final VecPartOccurrence occurrence = new VecPartOccurrence();
+    private final VecRole role = new VecPlaceableElementRole();
+
+    @BeforeEach
+    void setUp() {
+        final VecCompositionSpecification composition = new VecCompositionSpecification();
+        composition.setParentDocumentVersion(documentVersion);
+        occurrence.setParentCompositionSpecification(composition);
+        role.setParentOccurrenceOrUsage(occurrence);
+    }
+
+    @Test
+    void navigatesToTheOccurrenceOrUsageOfARole() {
+        assertThat(Roles.toParentOccurrenceOrUsage().from(role)).contains(occurrence);
+    }
+
+    @Test
+    void navigatesToTheParentDocumentVersionOfARole() {
+        assertThat(Roles.toParentDocumentVersion().from(role)).contains(documentVersion);
+    }
+
+    @Test
+    void navigatesNowhereForAnUnattachedRole() {
+        assertThat(Roles.toParentOccurrenceOrUsage().from(new VecPlaceableElementRole())).isEmpty();
+        assertThat(Roles.toParentDocumentVersion().from(new VecPlaceableElementRole())).isEmpty();
+    }
+
+    /**
+     * Characterisation test for the deprecated {@link VecNavs}, which delegates to {@link Roles}.
+     * Can be removed together with {@link VecNavs}.
+     */
+    @Test
+    @SuppressWarnings({"deprecation", "removal"})
+    void deprecatedNavigationsBehaveLikeTheirReplacement() {
+        assertThat(VecNavs.parentDocumentVersion().apply(role))
+                .isEqualTo(Roles.toParentDocumentVersion().orElseNull(role));
+    }
+
+}

--- a/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/SpecificationOwnersTest.java
+++ b/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/SpecificationOwnersTest.java
@@ -1,0 +1,114 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v2x.traversal;
+
+import com.foursoft.harness.vec.common.HasSpecifications;
+import com.foursoft.harness.vec.v2x.VecCompositionSpecification;
+import com.foursoft.harness.vec.v2x.VecPartOccurrence;
+import com.foursoft.harness.vec.v2x.VecPartUsage;
+import com.foursoft.harness.vec.v2x.VecPartUsageSpecification;
+import com.foursoft.harness.vec.v2x.VecSpecification;
+import com.foursoft.harness.vec.v2x.navigations.SpecificationNavs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SpecificationOwnersTest {
+
+    private final List<VecSpecification> specifications = new ArrayList<>();
+    private final HasSpecifications<VecSpecification> owner = () -> specifications;
+
+    private final VecPartOccurrence firstComponent = new VecPartOccurrence();
+    private final VecPartOccurrence secondComponent = new VecPartOccurrence();
+    private final VecPartUsage partUsage = new VecPartUsage();
+
+    private final VecCompositionSpecification firstComposition = new VecCompositionSpecification();
+    private final VecCompositionSpecification secondComposition = new VecCompositionSpecification();
+    private final VecPartUsageSpecification partUsages = new VecPartUsageSpecification();
+
+    @BeforeEach
+    void setUp() {
+        firstComposition.setIdentification("COMP-1");
+        firstComposition.getComponents().add(firstComponent);
+        secondComposition.setIdentification("COMP-2");
+        secondComposition.getComponents().add(secondComponent);
+        partUsages.getPartUsages().add(partUsage);
+
+        specifications.add(firstComposition);
+        specifications.add(secondComposition);
+        specifications.add(partUsages);
+    }
+
+    @Test
+    void navigatesToTheSpecificationsOfTheirHolder() {
+        assertThat(SpecificationOwners.toSpecifications().listFrom(owner))
+                .containsExactly(firstComposition, secondComposition, partUsages);
+        assertThat(SpecificationOwners.toSpecifications().listFrom(List::of)).isEmpty();
+    }
+
+    @Test
+    void navigatesToTheComponentsOfAllCompositionSpecifications() {
+        assertThat(SpecificationOwners.toComponents().listFrom(owner))
+                .containsExactly(firstComponent, secondComponent);
+    }
+
+    @Test
+    void navigatesToThePartUsagesOfAllPartUsageSpecifications() {
+        assertThat(SpecificationOwners.toPartUsages().listFrom(owner)).containsExactly(partUsage);
+    }
+
+    @Test
+    void navigatesToTheComponentsFollowedByThePartUsages() {
+        assertThat(SpecificationOwners.toOccurrenceOrUsages().listFrom(owner))
+                .containsExactly(firstComponent, secondComponent, partUsage);
+    }
+
+    @Test
+    void navigatesToTheComponentsOfTheIdentifiedCompositionSpecification() {
+        assertThat(SpecificationOwners.componentsBy("COMP-2").listFrom(owner)).containsExactly(secondComponent);
+        assertThat(SpecificationOwners.componentsBy("COMP-3").listFrom(owner)).isEmpty();
+    }
+
+    /**
+     * Characterisation test for the deprecated {@link SpecificationNavs}, which delegates to
+     * {@link SpecificationOwners}. Can be removed together with {@link SpecificationNavs}.
+     */
+    @Test
+    @SuppressWarnings({"deprecation", "removal"})
+    void deprecatedNavigationsBehaveLikeTheirReplacement() {
+        assertThat(SpecificationNavs.components().apply(owner))
+                .isEqualTo(SpecificationOwners.toComponents().listFrom(owner));
+        assertThat(SpecificationNavs.componentsBy("COMP-2").apply(owner))
+                .isEqualTo(SpecificationOwners.componentsBy("COMP-2").listFrom(owner));
+        assertThat(SpecificationNavs.allOccurrenceOrUsages().apply(owner))
+                .isEqualTo(SpecificationOwners.toOccurrenceOrUsages().listFrom(owner));
+    }
+
+}

--- a/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/SpecificationsTest.java
+++ b/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/SpecificationsTest.java
@@ -1,0 +1,155 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v2x.traversal;
+
+import com.foursoft.harness.vec.common.HasModifiableIdentification;
+import com.foursoft.harness.vec.v2x.VecBuildingBlockSpecification2D;
+import com.foursoft.harness.vec.v2x.VecBuildingBlockSpecification3D;
+import com.foursoft.harness.vec.v2x.VecCompositionSpecification;
+import com.foursoft.harness.vec.v2x.VecDocumentVersion;
+import com.foursoft.harness.vec.v2x.VecGeometryNode2D;
+import com.foursoft.harness.vec.v2x.VecGeometryNode3D;
+import com.foursoft.harness.vec.v2x.VecGeometrySegment2D;
+import com.foursoft.harness.vec.v2x.VecGeometrySegment3D;
+import com.foursoft.harness.vec.v2x.VecPartOccurrence;
+import com.foursoft.harness.vec.v2x.VecPartUsage;
+import com.foursoft.harness.vec.v2x.VecPartUsageSpecification;
+import com.foursoft.harness.vec.v2x.VecPlacementSpecification;
+import com.foursoft.harness.vec.v2x.VecSheetOrChapter;
+import com.foursoft.harness.vec.v2x.VecSpecification;
+import com.foursoft.harness.vec.v2x.navigations.SpecificationNavs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SpecificationsTest {
+
+    private final VecDocumentVersion documentVersion = new VecDocumentVersion();
+    private final VecBuildingBlockSpecification2D buildingBlock2D = new VecBuildingBlockSpecification2D();
+    private final VecBuildingBlockSpecification3D buildingBlock3D = new VecBuildingBlockSpecification3D();
+
+    private final VecGeometryNode2D node2D = identified(new VecGeometryNode2D(), "N-1");
+    private final VecGeometryNode3D node3D = identified(new VecGeometryNode3D(), "N-1");
+    private final VecGeometrySegment2D segment2D = identified(new VecGeometrySegment2D(), "S-1");
+    private final VecGeometrySegment3D segment3D = identified(new VecGeometrySegment3D(), "S-1");
+
+    private static <T extends HasModifiableIdentification> T identified(
+            final T element, final String identification) {
+        element.setIdentification(identification);
+        return element;
+    }
+
+    @BeforeEach
+    void setUp() {
+        documentVersion.setDocumentNumber("DOC-1");
+        buildingBlock2D.getGeometryNodes().add(node2D);
+        buildingBlock2D.getGeometrySegments().add(segment2D);
+        buildingBlock3D.getGeometryNodes().add(node3D);
+        buildingBlock3D.getGeometrySegments().add(segment3D);
+    }
+
+    @Test
+    void navigatesToTheParentDocumentVersionHeldByTheSpecificationItself() {
+        final VecSpecification specification = new VecPlacementSpecification();
+        specification.setParentDocumentVersion(documentVersion);
+
+        assertThat(Specifications.toParentDocumentVersion().from(specification)).contains(documentVersion);
+        assertThat(Specifications.toParentDocumentNumber().from(specification)).contains("DOC-1");
+    }
+
+    @Test
+    void navigatesToTheParentDocumentVersionThroughTheSheetOrChapter() {
+        final VecSheetOrChapter sheet = new VecSheetOrChapter();
+        sheet.setParentDocumentVersion(documentVersion);
+        final VecSpecification specification = new VecPlacementSpecification();
+        specification.setParentSheetOrChapter(sheet);
+
+        assertThat(Specifications.toParentDocumentVersion().from(specification)).contains(documentVersion);
+    }
+
+    @Test
+    void navigatesToNoParentDocumentVersionForAnUnattachedSpecification() {
+        assertThat(Specifications.toParentDocumentVersion().from(new VecPlacementSpecification())).isEmpty();
+        assertThat(Specifications.toParentDocumentNumber().from(new VecPlacementSpecification())).isEmpty();
+    }
+
+    @Test
+    void navigatesToTheComponentsAndPartUsagesOfASpecification() {
+        final VecPartOccurrence component = new VecPartOccurrence();
+        final VecCompositionSpecification composition = new VecCompositionSpecification();
+        composition.getComponents().add(component);
+
+        final VecPartUsage partUsage = new VecPartUsage();
+        final VecPartUsageSpecification partUsages = new VecPartUsageSpecification();
+        partUsages.getPartUsages().add(partUsage);
+
+        assertThat(Specifications.toComponents().listFrom(composition)).containsExactly(component);
+        assertThat(Specifications.toPartUsages().listFrom(partUsages)).containsExactly(partUsage);
+    }
+
+    @Test
+    void navigatesToTheGeometryOfABuildingBlock() {
+        assertThat(Specifications.toGeometryNodes2D().listFrom(buildingBlock2D)).containsExactly(node2D);
+        assertThat(Specifications.toGeometryNodes3D().listFrom(buildingBlock3D)).containsExactly(node3D);
+        assertThat(Specifications.toGeometrySegments2D().listFrom(buildingBlock2D)).containsExactly(segment2D);
+        assertThat(Specifications.toGeometrySegments3D().listFrom(buildingBlock3D)).containsExactly(segment3D);
+    }
+
+    @Test
+    void navigatesToTheGeometryWithTheGivenIdentification() {
+        assertThat(Specifications.geometryNode2dBy("N-1").from(buildingBlock2D)).contains(node2D);
+        assertThat(Specifications.geometryNode3dBy("N-1").from(buildingBlock3D)).contains(node3D);
+        assertThat(Specifications.geometrySegment2dBy("S-1").from(buildingBlock2D)).contains(segment2D);
+        assertThat(Specifications.geometrySegment3dBy("S-1").from(buildingBlock3D)).contains(segment3D);
+    }
+
+    @Test
+    void navigatesToNoGeometryForAnUnknownIdentification() {
+        assertThat(Specifications.geometryNode2dBy("N-2").from(buildingBlock2D)).isEmpty();
+        assertThat(Specifications.geometrySegment3dBy("S-2").from(buildingBlock3D)).isEmpty();
+    }
+
+    /**
+     * Characterisation test for the deprecated {@link SpecificationNavs}, which delegates to
+     * {@link Specifications}. Can be removed together with {@link SpecificationNavs}.
+     */
+    @Test
+    @SuppressWarnings({"deprecation", "removal"})
+    void deprecatedNavigationsBehaveLikeTheirReplacement() {
+        final VecSpecification specification = new VecPlacementSpecification();
+        specification.setParentDocumentVersion(documentVersion);
+
+        assertThat(SpecificationNavs.parentDocumentVersion().apply(specification)).isEqualTo(documentVersion);
+        assertThat(SpecificationNavs.parentDocumentNumber().apply(specification)).isEqualTo("DOC-1");
+        assertThat(SpecificationNavs.geometryNode2dBy("N-1").apply(buildingBlock2D)).isEqualTo(node2D);
+        assertThat(SpecificationNavs.geometryNode3dBy("N-1").apply(buildingBlock3D)).isEqualTo(node3D);
+        assertThat(SpecificationNavs.geometrySegment2dBy("S-1").apply(buildingBlock2D)).isEqualTo(segment2D);
+        assertThat(SpecificationNavs.geometrySegment3dBy("S-1").apply(buildingBlock3D)).isEqualTo(segment3D);
+        assertThat(SpecificationNavs.geometryNode2dBy("N-2").apply(buildingBlock2D)).isNull();
+    }
+
+}

--- a/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/TopologySegmentsTest.java
+++ b/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/TopologySegmentsTest.java
@@ -1,0 +1,121 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v2x.traversal;
+
+import com.foursoft.harness.vec.v2x.VecDocumentVersion;
+import com.foursoft.harness.vec.v2x.VecNumericalValue;
+import com.foursoft.harness.vec.v2x.VecSegmentCrossSectionArea;
+import com.foursoft.harness.vec.v2x.VecSegmentLength;
+import com.foursoft.harness.vec.v2x.VecTopologySegment;
+import com.foursoft.harness.vec.v2x.VecTopologySpecification;
+import com.foursoft.harness.vec.v2x.navigations.SegmentNavs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TopologySegmentsTest {
+
+    private static final String DESIGNED = "Designed";
+    private static final String RESERVED = "Reserved";
+
+    private final VecTopologySegment segment = new VecTopologySegment();
+    private final VecDocumentVersion documentVersion = new VecDocumentVersion();
+
+    private static VecNumericalValue value(final double valueComponent) {
+        final VecNumericalValue numericalValue = new VecNumericalValue();
+        numericalValue.setValueComponent(valueComponent);
+        return numericalValue;
+    }
+
+    @BeforeEach
+    void setUp() {
+        documentVersion.setDocumentNumber("DOC-1");
+        final VecTopologySpecification topology = new VecTopologySpecification();
+        topology.setParentDocumentVersion(documentVersion);
+        segment.setParentTopologySpecification(topology);
+
+        final VecSegmentLength length = new VecSegmentLength();
+        length.setClassification(DESIGNED);
+        length.setLength(value(1500.0));
+        segment.getLengthInformations().add(length);
+
+        final VecSegmentCrossSectionArea area = new VecSegmentCrossSectionArea();
+        area.setCrossSectionAreaType(RESERVED);
+        area.setArea(value(2.5));
+        segment.getCrossSectionAreaInformations().add(area);
+    }
+
+    @Test
+    void navigatesToTheParentDocumentNumberOfASegment() {
+        assertThat(TopologySegments.toParentDocumentNumber().from(segment)).contains("DOC-1");
+        assertThat(TopologySegments.toParentDocumentNumber().from(new VecTopologySegment())).isEmpty();
+    }
+
+    @Test
+    void navigatesToTheLengthAndCrossSectionAreaInformations() {
+        assertThat(TopologySegments.toLengthInformations().listFrom(segment)).hasSize(1);
+        assertThat(TopologySegments.toCrossSectionAreaInformations().listFrom(segment)).hasSize(1);
+    }
+
+    @Test
+    void navigatesToTheLengthOfTheRequestedClassification() {
+        assertThat(TopologySegments.lengthBy(DESIGNED).from(segment)).contains(1500.0);
+        assertThat(TopologySegments.lengthBy("Adapted").from(segment)).isEmpty();
+    }
+
+    @Test
+    void navigatesToTheCrossSectionAreaOfTheRequestedType() {
+        assertThat(TopologySegments.crossSectionAreaBy(RESERVED).from(segment)).contains(2.5);
+        assertThat(TopologySegments.crossSectionAreaBy("Real").from(segment)).isEmpty();
+    }
+
+    @Test
+    void navigatesToTheCrossSectionAreaWithoutAType() {
+        final VecSegmentCrossSectionArea untyped = new VecSegmentCrossSectionArea();
+        untyped.setArea(value(4.0));
+        final VecTopologySegment untypedSegment = new VecTopologySegment();
+        untypedSegment.getCrossSectionAreaInformations().add(untyped);
+
+        assertThat(TopologySegments.crossSectionAreaBy(null).from(untypedSegment)).contains(4.0);
+    }
+
+    /**
+     * Characterisation test for the deprecated {@link SegmentNavs}, which delegates to
+     * {@link TopologySegments}. Can be removed together with {@link SegmentNavs}.
+     */
+    @Test
+    @SuppressWarnings({"deprecation", "removal"})
+    void deprecatedNavigationsBehaveLikeTheirReplacement() {
+        assertThat(SegmentNavs.parentDocumentNumber().apply(segment))
+                .isEqualTo(TopologySegments.toParentDocumentNumber().orElseNull(segment));
+        assertThat(SegmentNavs.lengthBy(DESIGNED).apply(segment))
+                .isEqualTo(TopologySegments.lengthBy(DESIGNED).from(segment));
+        assertThat(SegmentNavs.crossSectionAreaBy(RESERVED).apply(segment))
+                .isEqualTo(TopologySegments.crossSectionAreaBy(RESERVED).from(segment));
+    }
+
+}

--- a/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/ViewItemsTest.java
+++ b/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/ViewItemsTest.java
@@ -1,0 +1,134 @@
+/*-
+ * ========================LICENSE_START=================================
+ * VEC 2.X
+ * %%
+ * Copyright (C) 2020 - 2026 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.v2x.traversal;
+
+import com.foursoft.harness.vec.common.traversal.MultiNavigation;
+import com.foursoft.harness.vec.v2x.HasOccurrenceOrUsages;
+import com.foursoft.harness.vec.v2x.VecLocation;
+import com.foursoft.harness.vec.v2x.VecNodeLocation;
+import com.foursoft.harness.vec.v2x.VecOccurrenceOrUsage;
+import com.foursoft.harness.vec.v2x.VecOnPointPlacement;
+import com.foursoft.harness.vec.v2x.VecOnWayPlacement;
+import com.foursoft.harness.vec.v2x.VecPartOccurrence;
+import com.foursoft.harness.vec.v2x.VecPlaceableElementRole;
+import com.foursoft.harness.vec.v2x.VecSegmentLocation;
+import com.foursoft.harness.vec.v2x.navigations.PlacementNavs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ViewItemsTest {
+
+    private static final MultiNavigation<VecPlaceableElementRole, VecLocation> ON_POINT_LOCATIONS =
+            PlaceableElementRoles.onPointPlacements().thenEach(Placements.locations());
+    private static final MultiNavigation<VecPlaceableElementRole, VecLocation> ON_WAY_LOCATIONS =
+            PlaceableElementRoles.onWayPlacements().thenEach(Placements.locations());
+
+    private final VecNodeLocation nodeLocation = new VecNodeLocation();
+    private final VecSegmentLocation segmentLocation = new VecSegmentLocation();
+
+    private VecPlaceableElementRole role;
+    private HasOccurrenceOrUsages viewItem;
+
+    @BeforeEach
+    void setUp() {
+        final VecOnPointPlacement onPointPlacement = new VecOnPointPlacement();
+        onPointPlacement.getLocations().add(nodeLocation);
+
+        final VecOnWayPlacement onWayPlacement = new VecOnWayPlacement();
+        onWayPlacement.setStartLocation(segmentLocation);
+        onWayPlacement.setEndLocation(nodeLocation);
+
+        role = new VecPlaceableElementRole();
+        role.getRefPlacement().add(onPointPlacement);
+        role.getRefPlacement().add(onWayPlacement);
+
+        final VecPartOccurrence partOccurrence = new VecPartOccurrence();
+        partOccurrence.getRoles().add(role);
+
+        final List<VecOccurrenceOrUsage> occurrences = List.of(partOccurrence);
+        viewItem = () -> occurrences;
+    }
+
+    @Test
+    void navigatesToThePlaceableElementRoleOfAViewItem() {
+        assertThat(ViewItems.placeableElementRole().from(viewItem)).contains(role);
+    }
+
+    @Test
+    void navigatesToNoPlaceableElementRoleForAnEmptyViewItem() {
+        assertThat(ViewItems.placeableElementRole().from(Collections::emptyList)).isEmpty();
+    }
+
+    @Test
+    void navigatesToTheOnPointLocationsOfAViewItem() {
+        assertThat(ViewItems.locations(ON_POINT_LOCATIONS).listFrom(viewItem)).containsExactly(nodeLocation);
+    }
+
+    /**
+     * The way from the role to the locations is a parameter of
+     * {@link ViewItems#locations(MultiNavigation)}, so on way placements can be used as well. The deprecated
+     * {@link PlacementNavs#locationsOf(java.util.function.Function)} documented this, but its parameter type
+     * only allowed on point placements.
+     */
+    @Test
+    void navigatesToTheOnWayLocationsOfAViewItem() {
+        assertThat(ViewItems.locations(ON_WAY_LOCATIONS).listFrom(viewItem))
+                .containsExactly(segmentLocation, nodeLocation);
+    }
+
+    @Test
+    void navigatesToTheLocationsOfEveryPlacementKindAtOnce() {
+        final MultiNavigation<VecPlaceableElementRole, VecLocation> allLocations =
+                PlaceableElementRoles.placements().thenEach(Placements.locations());
+
+        assertThat(ViewItems.locations(allLocations).listFrom(viewItem))
+                .containsExactlyInAnyOrder(nodeLocation, segmentLocation, nodeLocation);
+    }
+
+    @Test
+    void navigatesToNoLocationForAnEmptyViewItem() {
+        assertThat(ViewItems.locations(ON_POINT_LOCATIONS).listFrom(Collections::emptyList)).isEmpty();
+    }
+
+    /**
+     * Characterisation test for the deprecated {@link PlacementNavs}, which delegates to {@link ViewItems}.
+     * Can be removed together with {@link PlacementNavs}.
+     */
+    @Test
+    @SuppressWarnings({"deprecation", "removal"})
+    void deprecatedNavigationsBehaveLikeTheirReplacement() {
+        assertThat(PlacementNavs.locationsOf(PlacementNavs.onPointPlacement()).apply(viewItem))
+                .isEqualTo(ViewItems.locations(ON_POINT_LOCATIONS).listFrom(viewItem));
+        assertThat(PlacementNavs.locationsOf(PlacementNavs.onPointPlacement()).apply(Collections::emptyList))
+                .isEmpty();
+    }
+
+}

--- a/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/ViewItemsTest.java
+++ b/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/ViewItemsTest.java
@@ -47,13 +47,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ViewItemsTest {
 
     private static final MultiNavigation<HasOccurrenceOrUsages, VecLocation> ON_POINT_LOCATIONS =
-            ViewItems.placeableElementRole()
-                    .then(PlaceableElementRoles.onPointPlacements())
-                    .then(Placements.locations());
+            ViewItems.toPlaceableElementRole()
+                    .then(PlaceableElementRoles.toOnPointPlacements())
+                    .then(Placements.toLocations());
     private static final MultiNavigation<HasOccurrenceOrUsages, VecLocation> ON_WAY_LOCATIONS =
-            ViewItems.placeableElementRole()
-                    .then(PlaceableElementRoles.onWayPlacements())
-                    .then(Placements.locations());
+            ViewItems.toPlaceableElementRole()
+                    .then(PlaceableElementRoles.toOnWayPlacements())
+                    .then(Placements.toLocations());
 
     private final VecNodeLocation nodeLocation = new VecNodeLocation();
     private final VecSegmentLocation segmentLocation = new VecSegmentLocation();
@@ -84,25 +84,25 @@ class ViewItemsTest {
 
     @Test
     void navigatesToTheOccurrencesOrUsagesOfAViewItem() {
-        assertThat(ViewItems.occurrenceOrUsages().listFrom(viewItem)).containsExactly(partOccurrence);
-        assertThat(ViewItems.occurrenceOrUsages().listFrom(Collections::emptyList)).isEmpty();
+        assertThat(ViewItems.toOccurrenceOrUsages().listFrom(viewItem)).containsExactly(partOccurrence);
+        assertThat(ViewItems.toOccurrenceOrUsages().listFrom(Collections::emptyList)).isEmpty();
     }
 
     @Test
     void navigatesToThePlaceableElementRoleOfAViewItem() {
-        assertThat(ViewItems.placeableElementRole().from(viewItem)).contains(role);
+        assertThat(ViewItems.toPlaceableElementRole().from(viewItem)).contains(role);
     }
 
     @Test
     void navigatesToNoPlaceableElementRoleForAnOccurrenceWithoutSuchARole() {
         partOccurrence.getRoles().clear();
 
-        assertThat(ViewItems.placeableElementRole().from(viewItem)).isEmpty();
+        assertThat(ViewItems.toPlaceableElementRole().from(viewItem)).isEmpty();
     }
 
     @Test
     void navigatesToNoPlaceableElementRoleForAnEmptyViewItem() {
-        assertThat(ViewItems.placeableElementRole().from(Collections::emptyList)).isEmpty();
+        assertThat(ViewItems.toPlaceableElementRole().from(Collections::emptyList)).isEmpty();
     }
 
     @Test
@@ -123,9 +123,9 @@ class ViewItemsTest {
     @Test
     void navigatesToTheLocationsOfEveryPlacementKindAtOnce() {
         final MultiNavigation<HasOccurrenceOrUsages, VecLocation> allLocations =
-                ViewItems.placeableElementRole()
-                        .then(PlaceableElementRoles.placements())
-                        .then(Placements.locations());
+                ViewItems.toPlaceableElementRole()
+                        .then(PlaceableElementRoles.toPlacements())
+                        .then(Placements.toLocations());
 
         assertThat(allLocations.listFrom(viewItem))
                 .containsExactlyInAnyOrder(nodeLocation, segmentLocation, nodeLocation);

--- a/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/ViewItemsTest.java
+++ b/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/ViewItemsTest.java
@@ -59,6 +59,7 @@ class ViewItemsTest {
     private final VecSegmentLocation segmentLocation = new VecSegmentLocation();
 
     private VecPlaceableElementRole role;
+    private VecPartOccurrence partOccurrence;
     private HasOccurrenceOrUsages viewItem;
 
     @BeforeEach
@@ -74,7 +75,7 @@ class ViewItemsTest {
         role.getRefPlacement().add(onPointPlacement);
         role.getRefPlacement().add(onWayPlacement);
 
-        final VecPartOccurrence partOccurrence = new VecPartOccurrence();
+        partOccurrence = new VecPartOccurrence();
         partOccurrence.getRoles().add(role);
 
         final List<VecOccurrenceOrUsage> occurrences = List.of(partOccurrence);
@@ -82,8 +83,21 @@ class ViewItemsTest {
     }
 
     @Test
+    void navigatesToTheOccurrencesOrUsagesOfAViewItem() {
+        assertThat(ViewItems.occurrenceOrUsages().listFrom(viewItem)).containsExactly(partOccurrence);
+        assertThat(ViewItems.occurrenceOrUsages().listFrom(Collections::emptyList)).isEmpty();
+    }
+
+    @Test
     void navigatesToThePlaceableElementRoleOfAViewItem() {
         assertThat(ViewItems.placeableElementRole().from(viewItem)).contains(role);
+    }
+
+    @Test
+    void navigatesToNoPlaceableElementRoleForAnOccurrenceWithoutSuchARole() {
+        partOccurrence.getRoles().clear();
+
+        assertThat(ViewItems.placeableElementRole().from(viewItem)).isEmpty();
     }
 
     @Test

--- a/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/ViewItemsTest.java
+++ b/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/ViewItemsTest.java
@@ -48,12 +48,12 @@ class ViewItemsTest {
 
     private static final MultiNavigation<HasOccurrenceOrUsages, VecLocation> ON_POINT_LOCATIONS =
             ViewItems.placeableElementRole()
-                    .thenEach(PlaceableElementRoles.onPointPlacements())
-                    .thenEach(Placements.locations());
+                    .then(PlaceableElementRoles.onPointPlacements())
+                    .then(Placements.locations());
     private static final MultiNavigation<HasOccurrenceOrUsages, VecLocation> ON_WAY_LOCATIONS =
             ViewItems.placeableElementRole()
-                    .thenEach(PlaceableElementRoles.onWayPlacements())
-                    .thenEach(Placements.locations());
+                    .then(PlaceableElementRoles.onWayPlacements())
+                    .then(Placements.locations());
 
     private final VecNodeLocation nodeLocation = new VecNodeLocation();
     private final VecSegmentLocation segmentLocation = new VecSegmentLocation();
@@ -110,8 +110,8 @@ class ViewItemsTest {
     void navigatesToTheLocationsOfEveryPlacementKindAtOnce() {
         final MultiNavigation<HasOccurrenceOrUsages, VecLocation> allLocations =
                 ViewItems.placeableElementRole()
-                        .thenEach(PlaceableElementRoles.placements())
-                        .thenEach(Placements.locations());
+                        .then(PlaceableElementRoles.placements())
+                        .then(Placements.locations());
 
         assertThat(allLocations.listFrom(viewItem))
                 .containsExactlyInAnyOrder(nodeLocation, segmentLocation, nodeLocation);

--- a/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/ViewItemsTest.java
+++ b/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/ViewItemsTest.java
@@ -46,10 +46,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class ViewItemsTest {
 
-    private static final MultiNavigation<VecPlaceableElementRole, VecLocation> ON_POINT_LOCATIONS =
-            PlaceableElementRoles.onPointPlacements().thenEach(Placements.locations());
-    private static final MultiNavigation<VecPlaceableElementRole, VecLocation> ON_WAY_LOCATIONS =
-            PlaceableElementRoles.onWayPlacements().thenEach(Placements.locations());
+    private static final MultiNavigation<HasOccurrenceOrUsages, VecLocation> ON_POINT_LOCATIONS =
+            ViewItems.placeableElementRole()
+                    .thenEach(PlaceableElementRoles.onPointPlacements())
+                    .thenEach(Placements.locations());
+    private static final MultiNavigation<HasOccurrenceOrUsages, VecLocation> ON_WAY_LOCATIONS =
+            ViewItems.placeableElementRole()
+                    .thenEach(PlaceableElementRoles.onWayPlacements())
+                    .thenEach(Placements.locations());
 
     private final VecNodeLocation nodeLocation = new VecNodeLocation();
     private final VecSegmentLocation segmentLocation = new VecSegmentLocation();
@@ -89,33 +93,33 @@ class ViewItemsTest {
 
     @Test
     void navigatesToTheOnPointLocationsOfAViewItem() {
-        assertThat(ViewItems.locations(ON_POINT_LOCATIONS).listFrom(viewItem)).containsExactly(nodeLocation);
+        assertThat(ON_POINT_LOCATIONS.listFrom(viewItem)).containsExactly(nodeLocation);
     }
 
     /**
-     * The way from the role to the locations is a parameter of
-     * {@link ViewItems#locations(MultiNavigation)}, so on way placements can be used as well. The deprecated
-     * {@link PlacementNavs#locationsOf(java.util.function.Function)} documented this, but its parameter type
-     * only allowed on point placements.
+     * Since the way to the locations is composed at the call site, on way placements work just as well. The
+     * deprecated {@link PlacementNavs#locationsOf(java.util.function.Function)} documented this, but its
+     * parameter type only allowed on point placements.
      */
     @Test
     void navigatesToTheOnWayLocationsOfAViewItem() {
-        assertThat(ViewItems.locations(ON_WAY_LOCATIONS).listFrom(viewItem))
-                .containsExactly(segmentLocation, nodeLocation);
+        assertThat(ON_WAY_LOCATIONS.listFrom(viewItem)).containsExactly(segmentLocation, nodeLocation);
     }
 
     @Test
     void navigatesToTheLocationsOfEveryPlacementKindAtOnce() {
-        final MultiNavigation<VecPlaceableElementRole, VecLocation> allLocations =
-                PlaceableElementRoles.placements().thenEach(Placements.locations());
+        final MultiNavigation<HasOccurrenceOrUsages, VecLocation> allLocations =
+                ViewItems.placeableElementRole()
+                        .thenEach(PlaceableElementRoles.placements())
+                        .thenEach(Placements.locations());
 
-        assertThat(ViewItems.locations(allLocations).listFrom(viewItem))
+        assertThat(allLocations.listFrom(viewItem))
                 .containsExactlyInAnyOrder(nodeLocation, segmentLocation, nodeLocation);
     }
 
     @Test
     void navigatesToNoLocationForAnEmptyViewItem() {
-        assertThat(ViewItems.locations(ON_POINT_LOCATIONS).listFrom(Collections::emptyList)).isEmpty();
+        assertThat(ON_POINT_LOCATIONS.listFrom(Collections::emptyList)).isEmpty();
     }
 
     /**
@@ -126,7 +130,7 @@ class ViewItemsTest {
     @SuppressWarnings({"deprecation", "removal"})
     void deprecatedNavigationsBehaveLikeTheirReplacement() {
         assertThat(PlacementNavs.locationsOf(PlacementNavs.onPointPlacement()).apply(viewItem))
-                .isEqualTo(ViewItems.locations(ON_POINT_LOCATIONS).listFrom(viewItem));
+                .isEqualTo(ON_POINT_LOCATIONS.listFrom(viewItem));
         assertThat(PlacementNavs.locationsOf(PlacementNavs.onPointPlacement()).apply(Collections::emptyList))
                 .isEmpty();
     }


### PR DESCRIPTION
## Pull Request

- [X] I have checked for similar PRs.
- [X] I have read the [contributing guidelines](https://github.com/4Soft-de/harness-model/blob/develop/.github/CONTRIBUTING.md).

### Changes

- [X] Code
- [X] Documentation
- [ ] Other: 

### Description

The navigations packages expose every navigation as a raw
java.util.function.Function, so a navigation has no type identity, cannot
be composed beyond Function#andThen and mixes result shapes (T,
Optional<T>, List<T>, Stream<T>).

Introduce a Navigation interface hierarchy in vec-common:

- Navigation<S, T> extends Function<S, T> as base type and escape hatch
- SingleNavigation<S, T> extends Navigation<S, Optional<T>>
- MultiNavigation<S, T> extends Navigation<S, Stream<T>>
- Navigations as factory for adapting plain getters

Both sub types offer then/thenEach/filter/ofType, so navigations compose
in a typed way while staying usable wherever a Function is expected.

Port DescriptionNavs and PlacementNavs to the new concept as
com.foursoft.harness.vec.v2x.traversal.Descriptions and Placements. The
remaining catalogs and vec-v12x follow separately.

Placements.locationsOf now takes a MultiNavigation from the placeable
element role to its locations. PlacementNavs.locationsOf documented
'@see #onWayPlacement()', but its parameter type only accepted on point
placements, so the documented call did not compile. Passing in the way to
the locations fixes this.

DescriptionNavs and PlacementNavs are deprecated for removal and delegate
to their replacements, so there is a single source of truth while both
APIs coexist. Characterisation tests pin old against new behaviour and can
be removed together with the deprecated classes.

Also remove unused Collectors imports from the remaining v2x navigations.