### PR TITLE
feat: prefer the recommended configuration path over the deprecated one

### DIFF
--- a/docs/api-evolution.md
+++ b/docs/api-evolution.md
@@ -49,6 +49,16 @@ The delegation direction is deliberately old → new. Making the deprecated clas
 and the new one a wrapper would keep the old semantics as the source of truth and prevent the new API
 from fixing anything.
 
+### Deprecations in the model are a separate axis
+
+The VEC and KBL standards deprecate parts of their own models, which is unrelated to this repository
+deprecating its API — a generated model class can be deprecated for removal by the standard while the
+hand-written code using it is current. The two are handled in opposite directions. An API deprecation
+delegates old to new, because the caller is the one who migrates. A model deprecation is absorbed by
+preferring the recommended path and falling back to the deprecated one, because the files already
+written cannot be migrated by anyone here. See
+[Deprecated model associations](vec-navigation-api.md#deprecated-model-associations).
+
 ## Key Design Decisions
 
 - **Tests accompany the new API, not the old one.** Because the legacy API is typically untested,

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,8 @@ files cover usage and the code covers the details.
 ## Cross-cutting
 
 - [API Evolution](api-evolution.md) — how public API is replaced without breaking downstream
-  consumers: version-suffixed modules, and the deprecate-and-delegate pattern for superseded concepts.
+  consumers: version-suffixed modules, the deprecate-and-delegate pattern for superseded concepts, and
+  how deprecations in the models themselves differ from it.
 
 ## Module-level documents
 

--- a/docs/vec-navigation-api.md
+++ b/docs/vec-navigation-api.md
@@ -209,6 +209,37 @@ genuine logic and nothing to compose: `Placements.toLocations()` dispatches on t
 the body of a reduction such as `LocalizedStrings.valueIn(…)` weighs the elements against each other.
 Forcing those through the operators would make them longer, not clearer.
 
+### Deprecated model associations
+
+The VEC standard evolves too and deprecates associations of its own. Where it supersedes one path
+through the model with another, the navigation **follows the recommended path and falls back to the
+deprecated one only where the recommended path leads nowhere**. Both generations of files therefore
+navigate through the same catalog method, and no call site has to know which generation it is holding.
+
+`ConfigurableElements.toVariantConfiguration()` is the reference case. VEC 2.X configures an element
+through the `VecConfigurationConstraint`s referencing it and deprecates the element's own `ConfigInfo`
+association for removal, so the navigation goes back to the constraints and forward to their
+configuration first, and only an empty result sends it to the old association. Three properties of that
+shape generalise:
+
+- **The fallback keys on the result, not on a version flag.** Nothing tells a navigation which
+  generation a file was written against, and mixed files exist. An empty result is the only signal
+  available, and it is the right one: it means the recommended path genuinely holds no answer here.
+- **A path against the reference direction needs back references.** The recommended path is usually the
+  reverse of the association the deprecated one followed forwards, so it depends on the `navext`
+  back-reference accessors and carries `@RequiresBackReferences` — along with everything built on it.
+  Read without back references, such a navigation finds nothing and silently takes the fallback:
+  correct, but degraded, which is what the annotation warns about.
+- **The suppression stays in the catalog.** Using a deprecated getter needs
+  `@SuppressWarnings({"deprecation", "removal"})`, and the catalog is where it belongs. It is then the
+  single place in the repository touching the association, and consumers never need the suppression at
+  all.
+
+The direction is the mirror image of the repository's own deprecations, where the old API delegates to
+the new one (see [API Evolution](api-evolution.md)). Here the new path falls back to the old, because
+the deprecation is in the data rather than in this code: a consumer can migrate its calls, but nobody
+can migrate the files that already exist.
+
 ### The legacy API (`navigations`)
 
 The older generation uses catalogs too — final classes named `<Concept>Navs` with static factory
@@ -254,6 +285,11 @@ Consequences:
 - **A distinct package name, not a singular/plural pair.** `traversal` was chosen over
   `navigation` precisely because the old package is called `navigations`; while both exist, a
   singular/plural pair would create permanent import ambiguity.
+- **A deprecated model association is a fallback, not a second navigation.** Offering the recommended
+  and the superseded path as two catalog methods would push the choice, and the knowledge of which VEC
+  generation a file follows, to every call site — which is exactly what a navigation exists to absorb.
+  One method with a fallback keeps the model's deprecation invisible to consumers until the model
+  removes the association, at which point only the fallback is deleted.
 - **Catalogs expose steps, not composed paths.** Composition happens at the call site, so a catalog
   factory never takes a parameter it would only forward to one of the interface's operators. The chained
   form reads in traversal order and needs no API surface; a wrapper method reads inside-out and hides

--- a/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/ConfigurableElements.java
+++ b/vec/vec-v2x/src/main/java/com/foursoft/harness/vec/v2x/traversal/ConfigurableElements.java
@@ -25,10 +25,15 @@
  */
 package com.foursoft.harness.vec.v2x.traversal;
 
+import com.foursoft.harness.vec.common.annotations.RequiresBackReferences;
+import com.foursoft.harness.vec.common.traversal.MultiNavigation;
 import com.foursoft.harness.vec.common.traversal.Navigations;
 import com.foursoft.harness.vec.common.traversal.SingleNavigation;
 import com.foursoft.harness.vec.v2x.VecConfigurableElement;
+import com.foursoft.harness.vec.v2x.VecConfigurationConstraint;
 import com.foursoft.harness.vec.v2x.VecVariantConfiguration;
+
+import java.util.Optional;
 
 /**
  * Navigations starting at a {@link VecConfigurableElement}, that is at any element whose presence can be
@@ -41,23 +46,46 @@ public final class ConfigurableElements {
     }
 
     /**
+     * Navigates to the {@link VecConfigurationConstraint}s constraining a configurable element.
+     * <p>
+     * This is the reverse of {@link VecConfigurationConstraint#getConstrainedElements()} and therefore only
+     * yields elements on a model read with back references.
+     *
+     * @return A navigation to the configuration constraints of an element.
+     */
+    @RequiresBackReferences
+    public static MultiNavigation<VecConfigurableElement, VecConfigurationConstraint> toConfigurationConstraints() {
+        return Navigations.collection(VecConfigurableElement::getRefConfigurationConstraint);
+    }
+
+    /**
      * Navigates to the configuration of a configurable element.
      * <p>
-     * VEC 2.X deprecates the association this follows without offering a replacement for it, so this
-     * navigation is deprecated for removal in the model's sense, not in this API's.
+     * VEC 2.X configures an element through the {@link VecConfigurationConstraint}s pointing at it, so the
+     * navigation takes that way first: back to the constraints and forward to their configuration. Only if
+     * this leads nowhere does it fall back to the element's own {@code ConfigInfo} association, which the
+     * model deprecated for removal. The fallback also covers a model read without back references, where the
+     * recommended way cannot be followed at all.
      *
      * @return A navigation to the variant configuration of an element.
      */
+    @RequiresBackReferences
     @SuppressWarnings({"deprecation", "removal"})
     public static SingleNavigation<VecConfigurableElement, VecVariantConfiguration> toVariantConfiguration() {
-        return Navigations.nullable(VecConfigurableElement::getConfigInfo);
+        return element -> toConfigurationConstraints()
+                .then(Navigations.nullable(VecConfigurationConstraint::getConfigInfo))
+                .atMostOne()
+                .from(element)
+                .or(() -> Optional.ofNullable(element.getConfigInfo()));
     }
 
     /**
      * Navigates to the logistic control string of a configurable element.
      *
      * @return A navigation to the logistic control string of an element.
+     * @see #toVariantConfiguration()
      */
+    @RequiresBackReferences
     public static SingleNavigation<VecConfigurableElement, String> toLogisticControlString() {
         return toVariantConfiguration()
                 .then(Navigations.nullable(VecVariantConfiguration::getLogisticControlString));
@@ -67,7 +95,9 @@ public final class ConfigurableElements {
      * Navigates to the logistic control expression of a configurable element.
      *
      * @return A navigation to the logistic control expression of an element.
+     * @see #toVariantConfiguration()
      */
+    @RequiresBackReferences
     public static SingleNavigation<VecConfigurableElement, String> toLogisticControlExpression() {
         return toVariantConfiguration()
                 .then(Navigations.nullable(VecVariantConfiguration::getLogisticControlExpression));

--- a/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/ConfigurableElementsTest.java
+++ b/vec/vec-v2x/src/test/java/com/foursoft/harness/vec/v2x/traversal/ConfigurableElementsTest.java
@@ -26,6 +26,7 @@
 package com.foursoft.harness.vec.v2x.traversal;
 
 import com.foursoft.harness.vec.v2x.VecConfigurableElement;
+import com.foursoft.harness.vec.v2x.VecConfigurationConstraint;
 import com.foursoft.harness.vec.v2x.VecPartOccurrence;
 import com.foursoft.harness.vec.v2x.VecVariantConfiguration;
 import com.foursoft.harness.vec.v2x.navigations.ConfigurableElementNavs;
@@ -55,9 +56,55 @@ class ConfigurableElementsTest {
         configured = occurrence;
     }
 
+    /**
+     * Back references are set during unmarshalling only, so a test model has to establish them itself.
+     */
+    private static void constrain(final VecConfigurableElement element,
+                                  final VecVariantConfiguration configuration) {
+        final VecConfigurationConstraint constraint = new VecConfigurationConstraint();
+        constraint.setConfigInfo(configuration);
+        constraint.getConstrainedElements().add(element);
+        element.getRefConfigurationConstraint().add(constraint);
+    }
+
     @Test
     void navigatesToTheVariantConfigurationOfAnElement() {
         assertThat(ConfigurableElements.toVariantConfiguration().from(configured)).contains(configuration);
+    }
+
+    @Test
+    void navigatesToTheVariantConfigurationThroughTheConstrainingConstraint() {
+        final VecVariantConfiguration constrained = new VecVariantConfiguration();
+        constrain(unconfigured, constrained);
+
+        assertThat(ConfigurableElements.toVariantConfiguration().from(unconfigured)).contains(constrained);
+    }
+
+    @Test
+    void prefersTheConstraintOverTheDeprecatedConfigInfo() {
+        final VecVariantConfiguration constrained = new VecVariantConfiguration();
+        constrained.setLogisticControlString("C + D");
+        constrain(configured, constrained);
+
+        assertThat(ConfigurableElements.toVariantConfiguration().from(configured)).contains(constrained);
+        assertThat(ConfigurableElements.toLogisticControlString().from(configured)).contains("C + D");
+    }
+
+    @Test
+    void fallsBackToTheDeprecatedConfigInfoForAConstraintWithoutConfiguration() {
+        constrain(configured, null);
+
+        assertThat(ConfigurableElements.toVariantConfiguration().from(configured)).contains(configuration);
+    }
+
+    @Test
+    void navigatesToTheConfigurationConstraintsOfAnElement() {
+        constrain(configured, configuration);
+
+        assertThat(ConfigurableElements.toConfigurationConstraints().listFrom(configured))
+                .singleElement()
+                .satisfies(constraint -> assertThat(constraint.getConstrainedElements()).containsExactly(configured));
+        assertThat(ConfigurableElements.toConfigurationConstraints().listFrom(unconfigured)).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
## Pull Request

- [X] I have checked for similar PRs.
- [X] I have read the [contributing guidelines](https://github.com/4Soft-de/harness-model/blob/develop/.github/CONTRIBUTING.md).

### Changes

- [X] Code
- [X] Documentation
- [ ] Other: 

Closes: \<Put down the issue number if available or remove that line>

### Description

VEC 2.X configures an element through the ConfigurationConstraints referencing it and deprecates the element's own ConfigInfo association for removal. ConfigurableElements.toVariantConfiguration() therefore navigates back to the constraints and forward to their configuration, and falls back to ConfigInfo only where that leads nowhere, so files of both generations navigate through the same catalog method.

The recommended path follows the back reference to the constraints, which puts @RequiresBackReferences on the navigation and on everything built on it; read without back references it finds nothing and silently takes the fallback.

Adds toConfigurationConstraints() as the reverse step in its own right and documents the pattern, which is the mirror image of the old-to-new delegation used for this repository's own deprecations.